### PR TITLE
Fix build ImageMagick under Windows

### DIFF
--- a/cmake/Windows/build-imagemagick.sh
+++ b/cmake/Windows/build-imagemagick.sh
@@ -72,7 +72,7 @@ function isLibsInstalled() {
     libs="$@"
     notfound=false
     for l in "${libs}"; do
-        ld -L/usr/local/lib -l"${l}"
+        ld -L/usr/local/lib -l"${l}" 2>/dev/null
         if [[ $? -ne 0 ]]; then
             notfound=true
         fi
@@ -150,8 +150,9 @@ function buildlibxml2() {
     fi
     extractIfNeeded libxml2-*.tar.gz
     cd libxml2-*/win32/
+    ised configure.js 's/dirSep = "\\\\";/dirSep = "\/";/'
     cscript.exe configure.js compiler=mingw prefix=/usr/local
-    ised ../dict.c '/typedef.*uint32_t;$/d'
+    # ised ../dict.c '/typedef.*uint32_t;$/d'
     ised Makefile.mingw 's/cmd.exe \/C "\?if not exist \(.*\) mkdir \1"\?/mkdir -p \1/'
     ised Makefile.mingw 's/cmd.exe \/C "copy\(.*\)"/cp\1/'
     ised Makefile.mingw '/cp/{y/\\/\//;}'
@@ -189,6 +190,57 @@ function buildjpegsrc() {
 
     cd jpeg-*/
     ./configure
+    make
+    make install
+    cd ..
+}
+
+function buildfreetype() {
+    if isLibsInstalled "freetype"; then
+        if ask "Found freetype installed. Do you want to reinstall it?"; then :
+        else
+            return 0
+        fi
+    fi
+    extract freetype*.tar.bz2
+
+    INCLUDE_PATH=/usr/local/include
+	LIBRARY_PATH=/usr/local/lib
+	BINARY_PATH=/usr/local/bin
+    cd freetype-*/
+    ./configure
+	make
+    make install
+    cd ..
+}
+
+function buildlibwmf() {
+    if isLibsInstalled "wmf"; then
+        if ask "Found libwmf installed. Do you want to reinstall it?"; then :
+        else
+            return 0
+        fi
+    fi
+    extract libwmf*.tar.gz
+
+    cd libwmf-*/
+    ./configure CFLAGS="-I/usr/local/include" LDFLAGS="-L/usr/local/lib"
+    make
+    make install
+    cd ..
+}
+
+function buildlibwebp() {
+    if isLibsInstalled "webp"; then
+        if ask "Found libwebp installed. Do you want to reinstall it?"; then :
+        else
+            return 0
+        fi
+    fi
+    extract libwebp*.tar.gz
+
+    cd libwebp-*/
+    ./configure CFLAGS="-I/usr/local/include" LDFLAGS="-L/usr/local/lib"
     make
     make install
     cd ..

--- a/cmake/Windows/urls.txt
+++ b/cmake/Windows/urls.txt
@@ -1,10 +1,10 @@
-ftp://ftp.imagemagick.org/pub/ImageMagick/ImageMagick-6.8.8-5.tar.xz;d727efcba3e45ce6c51cafbfb387a8fd
-ftp://ftp.imagemagick.org/pub/ImageMagick/delegates/libpng-1.6.9.tar.xz;14e037c5c9f1db16844760285ad5c2d6
-ftp://ftp.imagemagick.org/pub/ImageMagick/delegates/libwebp-0.3.1.tar.gz;dc862bb4006d819b7587767a9e83d31f
+ftp://ftp.imagemagick.org/pub/ImageMagick/releases/ImageMagick-6.8.8-10.tar.xz;ab9b397c1d4798a9f6ae6cc94aa292fe
+ftp://ftp.imagemagick.org/pub/ImageMagick/delegates/libpng-1.6.20.tar.xz;3968acb7c66ef81a9dab867f35d0eb4b
+ftp://ftp.imagemagick.org/pub/ImageMagick/delegates/libwebp-0.4.4.tar.gz;b737062cf688e502b940b460ddc3015f
 ftp://ftp.imagemagick.org/pub/ImageMagick/delegates/libwmf-0.2.8.4.tar.gz;d1177739bf1ceb07f57421f0cee191e0
-ftp://ftp.imagemagick.org/pub/ImageMagick/delegates/libxml2-2.9.1.tar.gz;9c0cfef285d5c4a5c80d00904ddab380
+ftp://ftp.imagemagick.org/pub/ImageMagick/delegates/libxml2-2.9.3.tar.gz;daece17e045f1c107610e137ab50c179
 ftp://ftp.imagemagick.org/pub/ImageMagick/delegates/zlib-1.2.8.tar.xz;28f1205d8dd2001f26fec1e8c2cebe37
-ftp://ftp.imagemagick.org/pub/ImageMagick/delegates/freetype-2.5.2.tar.bz2;10e8f4d6a019b124088d18bc26123a25
+ftp://ftp.imagemagick.org/pub/ImageMagick/delegates/freetype-2.6.2.tar.bz2;86109d0c998787d81ac582bad9adf82e
 http://ncu.dl.sourceforge.net/project/mingw/MinGW/Extension/bzip2/bzip2-1.0.6-4/bzip2-1.0.6-4-mingw32-src.tar.lzma;2a25de4331d1e6e1458d8632dff55fad
-ftp://ftp.imagemagick.org/pub/ImageMagick/delegates/libfpx-1.3.1-3.tar.xz;e61be90557b26bf365ad63d3dd3b0877
-ftp://ftp.imagemagick.org/pub/ImageMagick/delegates/jpegsrc.v9.tar.gz;b397211ddfd506b92cd5e02a22ac924d
+ftp://ftp.imagemagick.org/pub/ImageMagick/delegates/libfpx-1.3.1-4.tar.xz;65e2cf8dcf230ad0b90aead35553bbda
+ftp://ftp.imagemagick.org/pub/ImageMagick/delegates/jpegsrc.v9a.tar.gz;3353992aecaee1805ef4109aadd433e7


### PR DESCRIPTION
I'm trying to build OpenShot for Windows following [your manual](https://docs.google.com/document/d/1V6nq-IuS9zxqO1-OSt8iTS_cw_HMCpsUNofHLYtUNjM/pub#h.3w3btur7l3ik).

It seems that https://github.com/OpenShot/libopenshot/tree/master/cmake/Windows contains old references that don't exist anymore.
It seems to me that I've been able to build ImageMagick with the files contained in this pull request.