### PR TITLE
Enable system jsoncpp

### DIFF
--- a/cmake/Modules/FindJsonCpp.cmake
+++ b/cmake/Modules/FindJsonCpp.cmake
@@ -1,0 +1,68 @@
+# Find jsoncpp
+#
+# Find the jsoncpp includes and library
+#
+# if you nee to add a custom library search path, do it via via CMAKE_PREFIX_PATH
+#
+# This module defines
+#  JSONCPP_INCLUDE_DIRS, where to find header, etc.
+#  JSONCPP_LIBRARIES, the libraries needed to use jsoncpp.
+#  JSONCPP_FOUND, If false, do not try to use jsoncpp.
+#  JSONCPP_INCLUDE_PREFIX, include prefix for jsoncpp
+
+# try to detect using pkg-config, and use as hints later
+find_package(PkgConfig)
+pkg_check_modules(PC_jsoncpp QUIET jsoncpp)
+
+find_path(
+	JSONCPP_INCLUDE_DIR
+	NAMES json/json.h
+	HINTS ${PC_jsoncpp_INCLUDE_DIRS}
+	DOC "jsoncpp include dir"
+)
+
+find_library(
+	JSONCPP_LIBRARY
+	NAMES jsoncpp
+	HINTS ${PC_jsoncpp_LIBRARY_DIR}
+	DOC "jsoncpp library"
+)
+
+set(JSONCPP_INCLUDE_DIRS ${JSONCPP_INCLUDE_DIR})
+set(JSONCPP_LIBRARIES ${JSONCPP_LIBRARY})
+
+# debug library on windows
+# same naming convention as in qt (appending debug library with d)
+# boost is using the same "hack" as us with "optimized" and "debug"
+if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
+	find_library(
+		JSONCPP_LIBRARY_DEBUG
+		NAMES jsoncppd
+		HINTS ${PC_jsoncpp_LIBDIR} ${PC_jsoncpp_LIBRARY_DIRS}
+		DOC "jsoncpp debug library"
+	)
+
+	set(JSONCPP_LIBRARIES optimized ${JSONCPP_LIBRARIES} debug ${JSONCPP_LIBRARY_DEBUG})
+
+endif()
+
+# find JSONCPP_INCLUDE_PREFIX
+find_path(
+	JSONCPP_INCLUDE_PREFIX
+	NAMES json.h
+	PATH_SUFFIXES jsoncpp/json json
+)
+
+if (${JSONCPP_INCLUDE_PREFIX} MATCHES "jsoncpp")
+	set(JSONCPP_INCLUDE_PREFIX "jsoncpp/json")
+else()
+	set(JSONCPP_INCLUDE_PREFIX "json")
+endif()
+
+# handle the QUIETLY and REQUIRED arguments and set JSONCPP_FOUND to TRUE
+# if all listed variables are TRUE, hide their existence from configuration view
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(jsoncpp DEFAULT_MSG
+	JSONCPP_INCLUDE_DIR JSONCPP_LIBRARY)
+mark_as_advanced (JSONCPP_INCLUDE_DIR JSONCPP_LIBRARY)
+

--- a/include/Json.h
+++ b/include/Json.h
@@ -28,6 +28,6 @@
 #ifndef OPENSHOT_JSON_H
 #define OPENSHOT_JSON_H
 
-#include "../thirdparty/jsoncpp/include/json/json.h"
+#include "json/json.h"
 
 #endif

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -24,6 +24,7 @@
 # along with OpenShot Library. If not, see <http://www.gnu.org/licenses/>.
 ################################################################################
 
+OPTION(USE_SYSTEM_JSONCPP "Use system installed JsonCpp" OFF)
 
 ################ WINDOWS ##################
 # Set some compiler options for Windows
@@ -154,7 +155,13 @@ endif(OPENMP_FOUND)
 
 ################### JSONCPP #####################
 # Include jsoncpp headers (needed for JSON parsing)
-include_directories("../thirdparty/jsoncpp/include")
+if (USE_SYSTEM_JSONCPP)
+	find_package(JsonCpp REQUIRED)
+	include_directories(${JSONCPP_INCLUDE_DIRS})
+else()
+	message("Using embedded JsonCpp")
+	include_directories("../thirdparty/jsoncpp/include")
+endif(USE_SYSTEM_JSONCPP)
 
 ###############  PROFILING  #################
 #set(PROFILER "/usr/lib/libprofiler.so.0.3.2")
@@ -200,12 +207,15 @@ SET ( OPENSHOT_SOURCE_FILES
 		
 		# Qt Video Player
 		${QT_PLAYER_FILES}
-		${MOC_FILES}
-		
-		# Third Party JSON Parser
-		../thirdparty/jsoncpp/src/lib_json/json_reader.cpp
-		../thirdparty/jsoncpp/src/lib_json/json_value.cpp
-		../thirdparty/jsoncpp/src/lib_json/json_writer.cpp )
+		${MOC_FILES})
+
+		IF (NOT USE_SYSTEM_JSONCPP)
+			# Third Party JSON Parser
+			SET ( OPENSHOT_SOURCE_FILES ${OPENSHOT_SOURCE_FILES}
+				../thirdparty/jsoncpp/src/lib_json/json_reader.cpp
+				../thirdparty/jsoncpp/src/lib_json/json_value.cpp
+				../thirdparty/jsoncpp/src/lib_json/json_writer.cpp)
+		ENDIF (NOT USE_SYSTEM_JSONCPP)
 
 		# ImageMagic related files
 		IF (ImageMagick_FOUND)
@@ -251,6 +261,7 @@ SET ( REQUIRED_LIBRARIES
 		${LIBOPENSHOT_AUDIO_LIBRARIES}
 		${QT_LIBRARIES}
 		${PROFILER}
+		${JSONCPP_LIBRARY}
 		)
 		
 		IF (OPENMP_FOUND)

--- a/src/KeyFrame.cpp
+++ b/src/KeyFrame.cpp
@@ -367,7 +367,7 @@ void Keyframe::SetJsonValue(Json::Value root) {
 
 	if (!root["Points"].isNull())
 		// loop through points
-		for (long int x = 0; x < root["Points"].size(); x++) {
+		for (unsigned int x = 0; x < root["Points"].size(); x++) {
 			// Get each point
 			Json::Value existing_point = root["Points"][x];
 


### PR DESCRIPTION
This PR resolves #14 by enabling to build libopenshot with system installed libjsoncpp using CMake option `USE_SYSTEM_JSONCPP` (default OFF). If not set, embedded sources of libjsoncpp will be used as before.

 As remarked [here](https://github.com/komackaj/libopenshot/commit/36af4edc23f2adf37e26e54edbb993ff0068dde4#commitcomment-16855054) there is an issue with `jsoncppConfig.cmake` distributed in `libjsoncpp-dev` on Debian, therefore we use custom CMake find module leveraging pkg-config if available and ignore CMake config files for jsoncpp.

It also fixes compilation ambiguity error when using libjsoncpp 0.6.0 and 1.6.5