### PR TITLE
Ffmpegreader fix 1

### DIFF
--- a/src/FFmpegReader.cpp
+++ b/src/FFmpegReader.cpp
@@ -1495,8 +1495,17 @@ AudioLocation FFmpegReader::GetAudioPTSLocation(long int pts)
 		int orig_start = location.sample_start;
 
 		// Update sample start, to prevent gaps in audio
-		location.sample_start = previous_packet_location.sample_start;
-		location.frame = previous_packet_location.frame;
+		if (previous_packet_location.sample_start <= samples_per_frame)
+		{
+			location.sample_start = previous_packet_location.sample_start;
+			location.frame = previous_packet_location.frame;
+		}
+		else
+		{
+			// set to next frame (since we exceeded the # of samples on a frame)
+			location.sample_start = 0;
+			location.frame++;
+		}
 
 		// Debug output
 		ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::GetAudioPTSLocation (Audio Gap Detected)", "Source Frame", orig_frame, "Source Audio Sample", orig_start, "Target Frame", location.frame, "Target Audio Sample", location.sample_start, "pts", pts, "", -1);

--- a/src/FFmpegReader.cpp
+++ b/src/FFmpegReader.cpp
@@ -90,12 +90,28 @@ int AudioLocation::is_near(AudioLocation location, int samples_per_frame, int am
 		// This is too far away to be considered
 		return false;
 
-	// Note that samples_per_frame can vary slightly frame to frame when the
-	// audio sampling rate is not an integer multiple of the video fps.
-	int diff = samples_per_frame * (location.frame - frame) + location.sample_start - sample_start;
-	if (abs(diff) <= amount)
+	int sample_diff = abs(location.sample_start - sample_start);
+	if (location.frame == frame && sample_diff >= 0 && sample_diff <= amount)
 		// close
 		return true;
+
+	// new frame is after
+	if (location.frame > frame)
+	{
+		// remaining samples + new samples
+		sample_diff = (samples_per_frame - sample_start) + location.sample_start;
+		if (sample_diff >= 0 && sample_diff <= amount)
+			return true;
+	}
+
+	// new frame is before
+	if (location.frame < frame)
+	{
+		// remaining new samples + old samples
+		sample_diff = (samples_per_frame - location.sample_start) + sample_start;
+		if (sample_diff >= 0 && sample_diff <= amount)
+			return true;
+	}
 
 	// not close
 	return false;


### PR DESCRIPTION
Summary
1. Improve stability of FFmpegReader::ReadStream() function that decodes compressed packets
2. Modified behaviour in FFmpegReader::UpdateVideoInfo() function when handling invalid frame rates

Details
1...
a) In the main while loop in ReadStream(), check if the requested_frame is available in the final_cache before decoding any packets. The decoding loop often gets ahead of itself so the requested_frame may already be available. This prevents the working_cache from overflowing and discarding frames that may still be needed for the output.
b) Increased the stuck frame threshold from 40 iterations to 1000. 40 was too low for some of my test material. Normally, frames should not get stuck anyway so although 1000 seems like a big number, it's a recovery event so perhaps better to be too big than too small.
c) Removed end_of_stream condition from 'working frame is final' check since it can cause a premature flush of the working_cache, resulting in blank frames in final_cache.

2...
a) Changed the default video_timebase to 90kHz instead of 24Hz since 90kHz is the most common PTS timebase
b) In the case where the stream's framerate is invalid, disable video for the stream instead of trying to work with an incorrect frame rate which seems to cause the seeking logic to get stuck in loops

@jonoomph 