### PR TITLE
Audio fix 1

### DIFF
--- a/include/FrameMapper.h
+++ b/include/FrameMapper.h
@@ -147,6 +147,7 @@ namespace openshot
 		CacheMemory final_cache; 		// Cache of actual Frame objects
 		bool is_dirty; 			// When this is true, the next call to GetFrame will re-init the mapping
 		AVAudioResampleContext *avr;	// Audio resampling context object
+		long int timeline_frame_offset;	// Timeline frame offset
 
 		// Internal methods used by init
 		void AddField(long int frame);
@@ -174,6 +175,9 @@ namespace openshot
 
 		/// Change frame rate or audio mapping details
 		void ChangeMapping(Fraction target_fps, PulldownType pulldown,  int target_sample_rate, int target_channels, ChannelLayout target_channel_layout);
+
+		// Set offset relative to parent timeline
+		void SetTimelineFrameOffset(long int offset);
 
 		/// Close the openshot::FrameMapper and internal reader
 		void Close();

--- a/src/FFmpegReader.cpp
+++ b/src/FFmpegReader.cpp
@@ -90,28 +90,12 @@ int AudioLocation::is_near(AudioLocation location, int samples_per_frame, int am
 		// This is too far away to be considered
 		return false;
 
-	int sample_diff = abs(location.sample_start - sample_start);
-	if (location.frame == frame && sample_diff >= 0 && sample_diff <= amount)
+	// Note that samples_per_frame can vary slightly frame to frame when the
+	// audio sampling rate is not an integer multiple of the video fps.
+	int diff = samples_per_frame * (location.frame - frame) + location.sample_start - sample_start;
+	if (abs(diff) <= amount)
 		// close
 		return true;
-
-	// new frame is after
-	if (location.frame > frame)
-	{
-		// remaining samples + new samples
-		sample_diff = (samples_per_frame - sample_start) + location.sample_start;
-		if (sample_diff >= 0 && sample_diff <= amount)
-			return true;
-	}
-
-	// new frame is before
-	if (location.frame < frame)
-	{
-		// remaining new samples + old samples
-		sample_diff = (samples_per_frame - location.sample_start) + sample_start;
-		if (sample_diff >= 0 && sample_diff <= amount)
-			return true;
-	}
 
 	// not close
 	return false;

--- a/src/FFmpegReader.cpp
+++ b/src/FFmpegReader.cpp
@@ -1472,17 +1472,8 @@ AudioLocation FFmpegReader::GetAudioPTSLocation(long int pts)
 		int orig_start = location.sample_start;
 
 		// Update sample start, to prevent gaps in audio
-		if (previous_packet_location.sample_start <= samples_per_frame)
-		{
-			location.sample_start = previous_packet_location.sample_start;
-			location.frame = previous_packet_location.frame;
-		}
-		else
-		{
-			// set to next frame (since we exceeded the # of samples on a frame)
-			location.sample_start = 0;
-			location.frame++;
-		}
+		location.sample_start = previous_packet_location.sample_start;
+		location.frame = previous_packet_location.frame;
 
 		// Debug output
 		ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::GetAudioPTSLocation (Audio Gap Detected)", "Source Frame", orig_frame, "Source Audio Sample", orig_start, "Target Frame", location.frame, "Target Audio Sample", location.sample_start, "pts", pts, "", -1);

--- a/src/Timeline.cpp
+++ b/src/Timeline.cpp
@@ -121,6 +121,11 @@ void Timeline::apply_mapper_to_clip(Clip* clip)
 	FrameMapper* clip_mapped_reader = (FrameMapper*) clip_reader;
 	clip_mapped_reader->ChangeMapping(info.fps, PULLDOWN_NONE, info.sample_rate, info.channels, info.channel_layout);
 
+	// Update timeline offset
+	float time_diff = 0 - clip->Position() + clip->Start();
+	int clip_offset = -round(time_diff * info.fps.ToFloat());
+	clip_mapped_reader->SetTimelineFrameOffset(clip_offset);
+
 	// Update clip reader
 	clip->Reader(clip_reader);
 }

--- a/tests/FrameMapper_Tests.cpp
+++ b/tests/FrameMapper_Tests.cpp
@@ -190,7 +190,7 @@ TEST(FrameMapper_resample_audio_48000_to_41000)
 
 	// Check details
 	CHECK_EQUAL(3, map.GetFrame(1)->GetAudioChannelsCount());
-	CHECK_EQUAL(1460, map.GetFrame(1)->GetAudioSamplesCount());
+	CHECK_EQUAL(1470, map.GetFrame(1)->GetAudioSamplesCount());
 	CHECK_EQUAL(1470, map.GetFrame(2)->GetAudioSamplesCount());
 	CHECK_EQUAL(1470, map.GetFrame(50)->GetAudioSamplesCount());
 
@@ -199,7 +199,7 @@ TEST(FrameMapper_resample_audio_48000_to_41000)
 
 	// Check details
 	CHECK_EQUAL(1, map.GetFrame(1)->GetAudioChannelsCount());
-	CHECK_EQUAL(872, map.GetFrame(1)->GetAudioSamplesCount());
+	CHECK_EQUAL(882, map.GetFrame(1)->GetAudioSamplesCount());
 	CHECK_EQUAL(882, map.GetFrame(2)->GetAudioSamplesCount());
 	CHECK_EQUAL(882, map.GetFrame(50)->GetAudioSamplesCount());
 


### PR DESCRIPTION
Summary
Fixes audio sample distribution across different clips so that there are no extra or missing samples on final output frames which result in small audible clicks on output tracks

Details
a) Added a timeline_frame_offset member to FrameMapper which indicates the position of the clip relative to the main output Timeline. This allows the number of audio samples in each requested frame to match exactly what the Timeline needs.
b) Fixed logic in AudioLocation::is_near() to handle a specific case where consecutive frames can have varying audio samples_per_frame (which happens when the audio sample rate is not an integer multiple of the video frame rate), and the sample_start value is at that upper limit of samples_per_frame.
c) Fixed creation of Samples structure in FrameMapper::Init(). Value of end_samples_position was 1 more than it should be.
d) When checking whether source and mapped frames are identical in FrameMapper::GetFrame(), also consider the audio sample mapping structure.
e) When audio resampling is needed to convert sample rates, the first call to avresample_convert needs some extra input samples for the conversion filter so that enough output samples can be generated as required by the the output frame.

@jonoomph