### PR TITLE
Fixes aspect ratio not applied on export (openshot-qt issue #456)

### DIFF
--- a/src/FFmpegWriter.cpp
+++ b/src/FFmpegWriter.cpp
@@ -904,6 +904,10 @@ AVStream* FFmpegWriter::add_video_stream()
 	c->width = info.width;
 	c->height = info.height;
 
+	// Set aspect ratio of stream
+	c->sample_aspect_ratio.num=info.pixel_ratio.num;
+	c->sample_aspect_ratio.den=info.pixel_ratio.den;
+
 	/* time base: this is the fundamental unit of time (in seconds) in terms
 	 of which frame timestamps are represented. for fixed-fps content,
 	 timebase should be 1/framerate and timestamp increments should be


### PR DESCRIPTION
Currently  aspect ratio of videoprofile is passed to FFmpegWriter::SetVideoOptions but not used anyhow in output setup. So, all videoprofiles requering aspect ratios are nonusable. Please review and apply following patch.