### PR TITLE
Preserve file structure when copying over headers

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -334,8 +334,9 @@ INSTALL(  TARGETS openshot
   LIBRARY DESTINATION ${LIB_INSTALL_DIR}
   COMPONENT library )
 	
-INSTALL(FILES ${headers} 
-	DESTINATION ${CMAKE_INSTALL_PREFIX}/include/libopenshot )
+INSTALL(DIRECTORY ${CMAKE_SOURCE_DIR}/include/
+	DESTINATION ${CMAKE_INSTALL_PREFIX}/include/libopenshot
+	FILES_MATCHING PATTERN "*.h")
 
 
 ############### CPACK PACKAGING ##############


### PR DESCRIPTION
Changes the install command for headers to install the include directory, rather than the header files, thereby persevering the header structure. Currently using most of the headers in the default include install will fail as the relative paths are wrong.