### PR TITLE
Revert "Check in code to handle missing clock_gettime() on most versions of M…"

### DIFF
--- a/include/ZmqLogger.h
+++ b/include/ZmqLogger.h
@@ -41,12 +41,6 @@
 #include <zmq.hpp>
 #include <unistd.h>
 
-// OS X does not have clock_gettime, use clock_get_time (https://gist.github.com/jbenet/1087739)
-#ifdef __MACH__
-#include <mach/clock.h>
-#include <mach/mach.h>
-#endif
-
 
 using namespace std;
 

--- a/src/ZmqLogger.cpp
+++ b/src/ZmqLogger.cpp
@@ -176,24 +176,6 @@ void ZmqLogger::AppendDebugMethod(string method_name, string arg1_name, float ar
 
 		stringstream message;
 		message << fixed << setprecision(4);
-
-		// Prepend current time (hires) to message
-		struct timespec ts;
-#ifdef __MACH__ // OS X does not have clock_gettime, use clock_get_time (https://gist.github.com/jbenet/1087739)
-		clock_serv_t cclock;
-		mach_timespec_t mts;
-		host_get_clock_service(mach_host_self(), CALENDAR_CLOCK, &cclock);
-		clock_get_time(cclock, &mts);
-		mach_port_deallocate(mach_task_self(), cclock);
-		ts->tv_sec = mts.tv_sec;
-		ts->tv_nsec = mts.tv_nsec;
-#else
-		clock_gettime(CLOCK_REALTIME, &ts);
-#endif
-		char timebuf[80];
-		strftime(timebuf, sizeof timebuf, "%F %T", localtime(&ts.tv_sec));
-		message << timebuf << "." << std::setiosflags(std::ios::right) << std::setw(9) << std::setfill('0') << ts.tv_nsec << "  ";
-
 		message << method_name << " (";
 
 		// Add attributes to method JSON


### PR DESCRIPTION
Reverts OpenShot/libopenshot#86, breaking on mac