### PR TITLE
Fixing audio pops due to resampling

### DIFF
--- a/include/Frame.h
+++ b/include/Frame.h
@@ -129,6 +129,7 @@ namespace openshot
 		int height;
 		int sample_rate;
 		string color;
+		int64_t max_audio_sample; ///< The max audio sample count added to this frame
 
 		/// Constrain a color value from 0 to 255
 		int constrain(int color_value);
@@ -137,6 +138,7 @@ namespace openshot
 		int64_t number;	 ///< This is the frame number (starting at 1)
 		bool has_audio_data; ///< This frame has been loaded with audio data
 		bool has_image_data; ///< This frame has been loaded with pixel data
+
 
 		/// Constructor - blank frame (300x200 blank image, 48kHz audio silence)
 		Frame();

--- a/include/FrameMapper.h
+++ b/include/FrameMapper.h
@@ -147,7 +147,6 @@ namespace openshot
 		CacheMemory final_cache; 		// Cache of actual Frame objects
 		bool is_dirty; 			// When this is true, the next call to GetFrame will re-init the mapping
 		AVAudioResampleContext *avr;	// Audio resampling context object
-		int64_t timeline_frame_offset;	// Timeline frame offset
 
 		// Internal methods used by init
 		void AddField(int64_t frame);
@@ -175,9 +174,6 @@ namespace openshot
 
 		/// Change frame rate or audio mapping details
 		void ChangeMapping(Fraction target_fps, PulldownType pulldown,  int target_sample_rate, int target_channels, ChannelLayout target_channel_layout);
-
-		// Set offset relative to parent timeline
-		void SetTimelineFrameOffset(int64_t offset);
 
 		/// Close the openshot::FrameMapper and internal reader
 		void Close();

--- a/src/FFmpegReader.cpp
+++ b/src/FFmpegReader.cpp
@@ -1300,7 +1300,7 @@ void FFmpegReader::Seek(int64_t requested_frame)
 	seek_count++;
 
 	// If seeking near frame 1, we need to close and re-open the file (this is more reliable than seeking)
-	int buffer_amount = OPEN_MP_NUM_PROCESSORS * 2;
+	int buffer_amount = max(OPEN_MP_NUM_PROCESSORS, 8);
 	if (requested_frame - buffer_amount < 20)
 	{
 		// Close and re-open file (basically seeking to frame 1)
@@ -1751,7 +1751,7 @@ void FFmpegReader::CheckWorkingFrames(bool end_of_stream, int64_t requested_fram
 			// Get check count for this frame
 			checked_frames_size = checked_frames.size();
             if (!checked_count_tripped || f->number >= requested_frame)
-		    checked_count = checked_frames[f->number];
+			    checked_count = checked_frames[f->number];
             else
                 // Force checked count over the limit
                 checked_count = max_checked_count;

--- a/src/Timeline.cpp
+++ b/src/Timeline.cpp
@@ -127,11 +127,6 @@ void Timeline::apply_mapper_to_clip(Clip* clip)
 	FrameMapper* clip_mapped_reader = (FrameMapper*) clip_reader;
 	clip_mapped_reader->ChangeMapping(info.fps, PULLDOWN_NONE, info.sample_rate, info.channels, info.channel_layout);
 
-	// Update timeline offset
-	double time_diff = 0 - clip->Position() + clip->Start();
-	int clip_offset = -round(time_diff * info.fps.ToDouble());
-	clip_mapped_reader->SetTimelineFrameOffset(clip_offset);
-
 	// Update clip reader
 	clip->Reader(clip_reader);
 }


### PR DESCRIPTION
Fixing audio pops due to resampling (this fixes a bunch of audio popping-related bugs). Now Frame objects track their own max_audio_sample_count, as we add audio data... so we have an accurate bounds on each frame.