### PR TITLE
Adding FFmpegWriter::IsValidCodec static function

### DIFF
--- a/include/FFmpegWriter.h
+++ b/include/FFmpegWriter.h
@@ -258,6 +258,9 @@ namespace openshot
 		/// Determine if writer is open or closed
 		bool IsOpen() { return is_open; };
 
+		/// Determine if codec name is valid
+		static bool IsValidCodec(string codec_name);
+
 		/// Open writer
 		void Open();
 

--- a/src/FFmpegWriter.cpp
+++ b/src/FFmpegWriter.cpp
@@ -296,6 +296,15 @@ void FFmpegWriter::SetOption(StreamType stream, string name, string value)
 
 }
 
+/// Determine if codec name is valid
+bool FFmpegWriter::IsValidCodec(string codec_name) {
+	// Find the codec (if any)
+	if (avcodec_find_encoder_by_name(codec_name.c_str()) == NULL)
+		return false;
+	else
+		return true;
+}
+
 // Prepare & initialize streams and open codecs
 void FFmpegWriter::PrepareStreams()
 {


### PR DESCRIPTION
Adding FFmpegWriter::IsValidCodec static function to check if any codec name is valid and installed on the user's system. This is needed for AAC support, since there are many encoder versions.