### PR TITLE
Cmake 3.12 updates

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@
 # along with OpenShot Library. If not, see <http://www.gnu.org/licenses/>.
 ################################################################################
 
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.2.0)
 
 MESSAGE("--------------------------------------------------------------")
 MESSAGE("Welcome to the OpenShot Build System! CMake will now check for all required build")
@@ -53,7 +53,9 @@ STRING(REGEX REPLACE "#define[ ]+OPENSHOT_VERSION_MAJOR[ ]+([0-9]+);(.*)" "\\1" 
 STRING(REGEX REPLACE "#define[ ]+OPENSHOT_VERSION_MINOR[ ]+([0-9]+);(.*)" "\\1" MINOR_VERSION "${LINE_MINOR}")
 STRING(REGEX REPLACE "#define[ ]+OPENSHOT_VERSION_BUILD[ ]+([0-9]+);(.*)" "\\1" BUILD_VERSION "${LINE_BUILD}")
 STRING(REGEX REPLACE "#define[ ]+OPENSHOT_VERSION_SO[ ]+([0-9]+);(.*)" "\\1" SO_VERSION "${LINE_SO}")
-set(PROJECT_VERSION "${MAJOR_VERSION}.${MINOR_VERSION}.${BUILD_VERSION}")
+
+################### SETUP PROJECT ###################
+PROJECT(libopenshot VERSION ${MAJOR_VERSION}.${MINOR_VERSION}.${BUILD_VERSION})
 
 MESSAGE("--> MAJOR Version: ${MAJOR_VERSION}")
 MESSAGE("--> MINOR Version: ${MINOR_VERSION}")
@@ -61,9 +63,6 @@ MESSAGE("--> BUILD Version: ${BUILD_VERSION}")
 MESSAGE("--> SO/API/ABI Version: ${SO_VERSION}")
 MESSAGE("--> VERSION: ${PROJECT_VERSION}")
 MESSAGE("")
-
-################### SETUP PROJECT ###################
-PROJECT(openshot)
 MESSAGE("--------------------------------------------------------------")
 MESSAGE("Generating build files for ${PROJECT_NAME} (${PROJECT_VERSION})")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,21 +26,24 @@
 
 cmake_minimum_required(VERSION 3.2.0)
 
-MESSAGE("--------------------------------------------------------------")
-MESSAGE("Welcome to the OpenShot Build System! CMake will now check for all required build")
-MESSAGE("dependencies and notify you of any missing files or other issues. If you have any")
-MESSAGE("questions or issues, please visit <http://www.openshot.org/>.")
+message("-----------------------------------------------------------------
+          Welcome to the OpenShot Build System!
+
+CMake will now check libopenshot's build dependencies and inform
+you of any missing files or other issues.
+
+For more information, please visit <http://www.openshot.org/>.
+-----------------------------------------------------------------")
 
 ################ ADD CMAKE MODULES ##################
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/Modules")
 
 ################ GET VERSION INFORMATION FROM VERSION.H ##################
-MESSAGE("--------------------------------------------------------------")
-MESSAGE("Determining Version Number (from Version.h file)")
+MESSAGE(STATUS "Determining Version Number (from Version.h file)")
 
 #### Get the lines related to libopenshot version from the Version.h header
 file(STRINGS ${CMAKE_CURRENT_SOURCE_DIR}/include/Version.h OPENSHOT_VERSION_LINES
-  REGEX "#define[ ]+OPENSHOT_VERSION_.*[0-9]+;.*")
+     REGEX "#define[ ]+OPENSHOT_VERSION_.*[0-9]+;.*")
   
 #### Set each line into it's own variable
 list (GET OPENSHOT_VERSION_LINES 0 LINE_MAJOR)
@@ -54,17 +57,18 @@ STRING(REGEX REPLACE "#define[ ]+OPENSHOT_VERSION_MINOR[ ]+([0-9]+);(.*)" "\\1" 
 STRING(REGEX REPLACE "#define[ ]+OPENSHOT_VERSION_BUILD[ ]+([0-9]+);(.*)" "\\1" BUILD_VERSION "${LINE_BUILD}")
 STRING(REGEX REPLACE "#define[ ]+OPENSHOT_VERSION_SO[ ]+([0-9]+);(.*)" "\\1" SO_VERSION "${LINE_SO}")
 
+MESSAGE(STATUS "MAJOR Version: ${MAJOR_VERSION}")
+MESSAGE(STATUS "MINOR Version: ${MINOR_VERSION}")
+MESSAGE(STATUS "BUILD Version: ${BUILD_VERSION}")
+MESSAGE(STATUS "SO/API/ABI Version: ${SO_VERSION}")
+
 ################### SETUP PROJECT ###################
 PROJECT(libopenshot VERSION ${MAJOR_VERSION}.${MINOR_VERSION}.${BUILD_VERSION})
 
-MESSAGE("--> MAJOR Version: ${MAJOR_VERSION}")
-MESSAGE("--> MINOR Version: ${MINOR_VERSION}")
-MESSAGE("--> BUILD Version: ${BUILD_VERSION}")
-MESSAGE("--> SO/API/ABI Version: ${SO_VERSION}")
-MESSAGE("--> VERSION: ${PROJECT_VERSION}")
-MESSAGE("")
-MESSAGE("--------------------------------------------------------------")
-MESSAGE("Generating build files for ${PROJECT_NAME} (${PROJECT_VERSION})")
+MESSAGE("Generating build files for OpenShot
+
+  Building ${PROJECT_NAME} (version ${PROJECT_VERSION})
+  SO/API/ABI Version: ${SO_VERSION}")
 
 #### Enable C++11 (for std::shared_ptr support)
 set(CMAKE_CXX_FLAGS "-std=c++11")

--- a/cmake/Modules/UseDoxygen.cmake
+++ b/cmake/Modules/UseDoxygen.cmake
@@ -159,9 +159,9 @@ if(DOXYGEN_FOUND AND DOXYFILE_IN_FOUND)
 
 	configure_file("${DOXYFILE_IN}" "${DOXYFILE}" @ONLY)
 
-    if(TARGET doc)
-        get_target_property(DOC_TARGET doc TYPE)
-    endif()
+	if(TARGET doc)
+		get_target_property(DOC_TARGET doc TYPE)
+	endif()
 	if(NOT DOC_TARGET)
 		add_custom_target(doc)
 	endif()

--- a/cmake/Modules/UseDoxygen.cmake
+++ b/cmake/Modules/UseDoxygen.cmake
@@ -1,4 +1,30 @@
-# - Run Doxygen
+# Redistribution and use is allowed according to the terms of the New
+# BSD license:
+# 
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 
+# 1. Redistributions of source code must retain the copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+# 3. The name of the author may not be used to endorse or promote products 
+#    derived from this software without specific prior written permission.
+# 
+# THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+# IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+# OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+# IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+# NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+# THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#  - Run Doxygen
 #
 # Adds a doxygen target that runs doxygen to generate the html
 # and optionally the LaTeX API documentation.
@@ -48,7 +74,6 @@
 #
 #  Redistribution and use is allowed according to the terms of the New
 #  BSD license.
-#  For details see the accompanying COPYING-CMAKE-SCRIPTS file.
 #
 
 macro(usedoxygen_set_default name value type docstring)
@@ -134,7 +159,9 @@ if(DOXYGEN_FOUND AND DOXYFILE_IN_FOUND)
 
 	configure_file("${DOXYFILE_IN}" "${DOXYFILE}" @ONLY)
 
-	get_target_property(DOC_TARGET doc TYPE)
+    if(TARGET doc)
+        get_target_property(DOC_TARGET doc TYPE)
+    endif()
 	if(NOT DOC_TARGET)
 		add_custom_target(doc)
 	endif()

--- a/src/bindings/python/CMakeLists.txt
+++ b/src/bindings/python/CMakeLists.txt
@@ -31,35 +31,39 @@ INCLUDE(${SWIG_USE_FILE})
 
 FIND_PACKAGE(PythonLibs 3)
 FIND_PACKAGE(PythonInterp 3)
-IF (PYTHONLIBS_FOUND)
-	IF (PYTHONINTERP_FOUND)
+if (PYTHONLIBS_FOUND AND PYTHONINTERP_FOUND)
 
-		### Include Python header files
-		INCLUDE_DIRECTORIES(${PYTHON_INCLUDE_PATH})
-		INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR})
-		
-		### Enable C++ support in SWIG
-		SET_SOURCE_FILES_PROPERTIES(openshot.i PROPERTIES CPLUSPLUS ON)
-		SET(CMAKE_SWIG_FLAGS "")
-		
-		### Add the SWIG interface file (which defines all the SWIG methods)
-		SWIG_ADD_MODULE(openshot python openshot.i)
+	### Include Python header files
+	INCLUDE_DIRECTORIES(${PYTHON_INCLUDE_PATH})
+	INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR})
+	
+	### Enable C++ support in SWIG
+	SET_SOURCE_FILES_PROPERTIES(openshot.i PROPERTIES CPLUSPLUS ON)
+	set_property(SOURCE openshot.i PROPERTY SWIG_MODULE_NAME openshot)
+	SET(CMAKE_SWIG_FLAGS "")
+	
+	### Add the SWIG interface file (which defines all the SWIG methods)
+	swig_add_library(pyopenshot LANGUAGE python SOURCES openshot.i)
 
-		### Link the new python wrapper library with libopenshot
-		SWIG_LINK_LIBRARIES(openshot ${PYTHON_LIBRARIES} openshot)
+	### Set output name of target
+	#set_target_properties(_pyopenshot PROPERTIES PREFIX "" OUTPUT_NAME "openshot")
 
-		### FIND THE PYTHON INTERPRETER (AND THE SITE PACKAGES FOLDER)
-		EXECUTE_PROCESS ( COMMAND ${PYTHON_EXECUTABLE} -c "import site; print(site.getsitepackages()[0])"
-		                     OUTPUT_VARIABLE _ABS_PYTHON_MODULE_PATH
-		                     OUTPUT_STRIP_TRAILING_WHITESPACE )
-		GET_FILENAME_COMPONENT(_ABS_PYTHON_MODULE_PATH "${_ABS_PYTHON_MODULE_PATH}" ABSOLUTE)
-		FILE(RELATIVE_PATH _REL_PYTHON_MODULE_PATH ${CMAKE_INSTALL_PREFIX} ${_ABS_PYTHON_MODULE_PATH})
-		SET(PYTHON_MODULE_PATH ${_REL_PYTHON_MODULE_PATH})
+	### Link the new python wrapper library with libopenshot
+	swig_link_libraries(pyopenshot ${PYTHON_LIBRARIES} openshot)
 
-		############### INSTALL HEADERS & LIBRARY ################
-		### Install Python bindings
-		INSTALL(TARGETS _openshot DESTINATION ${PYTHON_MODULE_PATH} )
-		INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/openshot.py DESTINATION ${PYTHON_MODULE_PATH} )
+	### FIND THE PYTHON INTERPRETER (AND THE SITE PACKAGES FOLDER)
+	execute_process ( COMMAND ${PYTHON_EXECUTABLE} -c 
+		"from distutils.sysconfig import get_python_lib; print( get_python_lib( plat_specific=True, prefix='${CMAKE_INSTALL_PREFIX}' ) )"
+	                  OUTPUT_VARIABLE _ABS_PYTHON_MODULE_PATH
+	                  OUTPUT_STRIP_TRAILING_WHITESPACE )
 
-	ENDIF(PYTHONINTERP_FOUND)
-ENDIF (PYTHONLIBS_FOUND)
+	GET_FILENAME_COMPONENT(_ABS_PYTHON_MODULE_PATH "${_ABS_PYTHON_MODULE_PATH}" ABSOLUTE)
+	FILE(RELATIVE_PATH _REL_PYTHON_MODULE_PATH ${CMAKE_INSTALL_PREFIX} ${_ABS_PYTHON_MODULE_PATH})
+	SET(PYTHON_MODULE_PATH ${_REL_PYTHON_MODULE_PATH})
+
+	############### INSTALL HEADERS & LIBRARY ################
+	### Install Python bindings
+	INSTALL(TARGETS ${SWIG_MODULE_pyopenshot_REAL_NAME} LIBRARY DESTINATION ${PYTHON_MODULE_PATH} )
+	INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/openshot.py DESTINATION ${PYTHON_MODULE_PATH} )
+
+endif ()

--- a/src/bindings/python/CMakeLists.txt
+++ b/src/bindings/python/CMakeLists.txt
@@ -50,7 +50,7 @@ if (PYTHONLIBS_FOUND AND PYTHONINTERP_FOUND)
 						  PREFIX "_" OUTPUT_NAME "openshot")
 
 	### Link the new python wrapper library with libopenshot
-	swig_link_libraries(pyopenshot ${PYTHON_LIBRARIES} openshot)
+	target_link_libraries(${SWIG_MODULE_pyopenshot_REAL_NAME} ${PYTHON_LIBRARIES} openshot)
 
 	### FIND THE PYTHON INTERPRETER (AND THE SITE PACKAGES FOLDER)
 	execute_process ( COMMAND ${PYTHON_EXECUTABLE} -c 

--- a/src/bindings/python/CMakeLists.txt
+++ b/src/bindings/python/CMakeLists.txt
@@ -38,15 +38,16 @@ if (PYTHONLIBS_FOUND AND PYTHONINTERP_FOUND)
 	INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR})
 	
 	### Enable C++ support in SWIG
-	SET_SOURCE_FILES_PROPERTIES(openshot.i PROPERTIES CPLUSPLUS ON)
+	set_property(SOURCE openshot.i PROPERTY CPLUSPLUS ON)
 	set_property(SOURCE openshot.i PROPERTY SWIG_MODULE_NAME openshot)
 	SET(CMAKE_SWIG_FLAGS "")
 	
 	### Add the SWIG interface file (which defines all the SWIG methods)
 	swig_add_library(pyopenshot LANGUAGE python SOURCES openshot.i)
 
-	### Set output name of target
-	#set_target_properties(_pyopenshot PROPERTIES PREFIX "" OUTPUT_NAME "openshot")
+	### Set output name of target (...this seems super dumb)
+	set_target_properties(${SWIG_MODULE_pyopenshot_REAL_NAME} PROPERTIES
+						  PREFIX "_" OUTPUT_NAME "openshot")
 
 	### Link the new python wrapper library with libopenshot
 	swig_link_libraries(pyopenshot ${PYTHON_LIBRARIES} openshot)

--- a/src/bindings/ruby/CMakeLists.txt
+++ b/src/bindings/ruby/CMakeLists.txt
@@ -46,7 +46,7 @@ IF (RUBY_FOUND)
 	swig_add_library(rbopenshot LANGUAGE ruby SOURCES openshot.i)
 	
 	### Set name of target (with no prefix, since Ruby does not like that)
-	#SET_TARGET_PROPERTIES(rbopenshot PROPERTIES PREFIX "" OUTPUT_NAME "openshot")
+	SET_TARGET_PROPERTIES(rbopenshot PROPERTIES PREFIX "" OUTPUT_NAME "openshot")
 
 	### Link the new Ruby wrapper library with libopenshot
 	SWIG_LINK_LIBRARIES(rbopenshot ${RUBY_LIBRARY} openshot)

--- a/src/bindings/ruby/CMakeLists.txt
+++ b/src/bindings/ruby/CMakeLists.txt
@@ -37,14 +37,16 @@ IF (RUBY_FOUND)
 	INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR})
 	
 	### Enable C++ in SWIG
-	SET_SOURCE_FILES_PROPERTIES(openshot.i PROPERTIES CPLUSPLUS ON)
+	set_property(SOURCE openshot.i PROPERTY CPLUSPLUS ON)
+	set_property(SOURCE openshot.i PROPERTY SWIG_MODULE_NAME openshot)
+
 	SET(CMAKE_SWIG_FLAGS "")
 
 	### Add the SWIG interface file (which defines all the SWIG methods)
-	SWIG_ADD_MODULE(rbopenshot ruby openshot.i)
+	swig_add_library(rbopenshot LANGUAGE ruby SOURCES openshot.i)
 	
 	### Set name of target (with no prefix, since Ruby does not like that)
-	SET_TARGET_PROPERTIES(rbopenshot PROPERTIES PREFIX "" OUTPUT_NAME "openshot")
+	#SET_TARGET_PROPERTIES(rbopenshot PROPERTIES PREFIX "" OUTPUT_NAME "openshot")
 
 	### Link the new Ruby wrapper library with libopenshot
 	SWIG_LINK_LIBRARIES(rbopenshot ${RUBY_LIBRARY} openshot)
@@ -58,6 +60,6 @@ IF (RUBY_FOUND)
 
 	############### INSTALL HEADERS & LIBRARY ################
 	# Install Ruby bindings
-	INSTALL(TARGETS rbopenshot LIBRARY DESTINATION ${RUBY_VENDOR_ARCH_DIR})
+	install(TARGETS ${SWIG_MODULE_rbopenshot_REAL_NAME} LIBRARY DESTINATION ${RUBY_VENDOR_ARCH_DIR} )
 	
 ENDIF (RUBY_FOUND)

--- a/src/bindings/ruby/CMakeLists.txt
+++ b/src/bindings/ruby/CMakeLists.txt
@@ -46,10 +46,11 @@ IF (RUBY_FOUND)
 	swig_add_library(rbopenshot LANGUAGE ruby SOURCES openshot.i)
 	
 	### Set name of target (with no prefix, since Ruby does not like that)
-	SET_TARGET_PROPERTIES(rbopenshot PROPERTIES PREFIX "" OUTPUT_NAME "openshot")
+	SET_TARGET_PROPERTIES(${SWIG_MODULE_rbopenshot_REAL_NAME}
+	                       PROPERTIES PREFIX "" OUTPUT_NAME "openshot")
 
 	### Link the new Ruby wrapper library with libopenshot
-	SWIG_LINK_LIBRARIES(rbopenshot ${RUBY_LIBRARY} openshot)
+	target_link_libraries(${SWIG_MODULE_rbopenshot_REAL_NAME} ${RUBY_LIBRARY} openshot)
 	
 	### FIND THE RUBY INTERPRETER (AND THE LOAD_PATH FOLDER)
 	EXECUTE_PROCESS(COMMAND ${RUBY_EXECUTABLE} -r rbconfig -e "print RbConfig::CONFIG['vendorarchdir']" OUTPUT_VARIABLE RUBY_VENDOR_ARCH_DIR)


### PR DESCRIPTION
@Polynomial-C reported (#140) that the build environment generation was failing with cmake-3.12, which reports that `SWIG_LINK_LIBRARY()` is deprecated.

So I took the opportunity to go through and modernize a _lot_ of our cmake environment, refreshing semantics and removing legacy kludges. The result is that I've wiped out most (hopefully all) of those deprecation messages and other warnings when generating Makefiles, while getting identical build output to the previous configs. (At least, in my testing with cmake-3.11.2. I don't have cmake-3.12 available yet.)

I was initially going to wait for Polynomial-C to test the updated `src/bindings/python/` and `src/bindings/ruby/` `CMakeLists.txt` files before submitting this PR, but I've tested it enough to think it should be OK, and I can always push in more commits if there are any remaining issues reported.

Addresses: #140 