### PR TITLE
Supply default args for AppendDebugMethod

### DIFF
--- a/src/ZmqLogger.cpp
+++ b/src/ZmqLogger.cpp
@@ -159,12 +159,13 @@ void ZmqLogger::Close()
 }
 
 // Append debug information
-void ZmqLogger::AppendDebugMethod(string method_name, string arg1_name, float arg1_value,
-								   string arg2_name, float arg2_value,
-								   string arg3_name, float arg3_value,
-								   string arg4_name, float arg4_value,
-								   string arg5_name, float arg5_value,
-								   string arg6_name, float arg6_value)
+void ZmqLogger::AppendDebugMethod(string method_name,
+								  string arg1_name="", float arg1_value=-1,
+								  string arg2_name="", float arg2_value=-1,
+								  string arg3_name="", float arg3_value=-1,
+								  string arg4_name="", float arg4_value=-1,
+								  string arg5_name="", float arg5_value=-1,
+								  string arg6_name="", float arg6_value=-1)
 {
 	if (!enabled)
 		// Don't do anything


### PR DESCRIPTION
The crazy calls to the logging method all over the code were bugging me, things like this:

```cpp
// (From Timeline.cpp line 235)
ZmqLogger::Instance()->AppendDebugMethod("Timeline::GetOrCreateFrame (create blank)", 
    "number", number, "samples_in_frame", samples_in_frame, "", -1, "", -1, "", -1, "", -1);
//
// or...
//
// (From FFMpegWriter.cpp line 291)
ZmqLogger::Instance()->AppendDebugMethod("FFmpegWriter::SetOption (" + (string)name + ")",
    "stream == VIDEO_STREAM", stream == VIDEO_STREAM, "", -1, "", -1, "", -1, "", -1, "", -1);
```

C++ is too advanced a language for that to be necessary. And it isn't.

This change rewrites the `ZmqLogger::AppendDebugMethod()` method with default arguments of `""` and `-1`, respectively, for each pair of args after the first. Which means the function only _requires_ one arg, and the two calls above can become simply...

```cpp
ZmqLogger::Instance()->AppendDebugMethod("Timeline::GetOrCreateFrame (create blank)", 
    "number", number, "samples_in_frame", samples_in_frame);

ZmqLogger::Instance()->AppendDebugMethod("FFmpegWriter::SetOption (" + (string)name + ")",
    "stream == VIDEO_STREAM", stream == VIDEO_STREAM);
```

#### Technical details (for those who care)

At first I thought of just writing overloaded versions of the logging method with 3, 5, 7, 9, and 11 args, to go with the current 13-arg version. But then I looked into it, and every version of C++ (since back in 1998 at least) has allowed arguments to be omitted if they're specified with default values, same as in Python. (Only difference is, they're still positional, so all of the arguments with default values have to come at the _end_ of the list.)

It works just fine. _Technically_ this would also now be legal:
```cpp
ZmqLogger::Instance()->AppendDebugMethod("SomewhereInTheCode", "myvariable");
```
...and it would log `SomewhereInTheCode(myvariable=-1)` which is not ideal, so just don't do that.

(However, the function could be rewritten to check the value of the float args, and omit the `=arg#_value` part of the message for any float arg with a value of `-1`. Currently it's only conditional on the string arguments. But it's possible that someone would _actually_ want to log a value of `-1`, though, and I'm not sure how that could easily be detected, so I'm not going to make that change.)

Basically, still don't write log calls with even numbers of arguments, it should always be the one required arg (`method_name`) and then 0-6 `string, float` pairs. But it can now be any odd number of args: 1, 3, 5, 7, 9, 11, or 13; you don't have to supply the "dummy" args for the ones you don't use.

### Note:

I haven't _actually_ gone through and rewritten any of the `ZmqLogger::Instance()->AppendDebugMethod()` calls in the source, to remove their extra arguments. Yet. I certainly can, easily enough. And I'd be happy to do it, and push that change into this branch as well before merging.