### PR TITLE
Silence compiler warnings

### DIFF
--- a/include/CrashHandler.h
+++ b/include/CrashHandler.h
@@ -56,10 +56,10 @@ namespace openshot {
 		CrashHandler(){}; 						 // Don't allow user to create an instance of this singleton
 
 		/// Default copy method
-		CrashHandler(CrashHandler const&){};             // Don't allow the user to copy this instance
+		CrashHandler(CrashHandler const&) = delete;             // Don't allow the user to copy this instance
 
 		/// Default assignment operator
-		CrashHandler & operator=(CrashHandler const&){};  // Don't allow the user to assign this instance
+		CrashHandler & operator=(CrashHandler const&) = delete;  // Don't allow the user to assign this instance
 
 		/// Private variable to keep track of singleton instance
 		static CrashHandler *m_pInstance;

--- a/include/ZmqLogger.h
+++ b/include/ZmqLogger.h
@@ -73,10 +73,10 @@ namespace openshot {
 		ZmqLogger(){}; 						 // Don't allow user to create an instance of this singleton
 
 		/// Default copy method
-		ZmqLogger(ZmqLogger const&){};             // Don't allow the user to copy this instance
+		ZmqLogger(ZmqLogger const&) = delete;             // Don't allow the user to copy this instance
 
 		/// Default assignment operator
-		ZmqLogger & operator=(ZmqLogger const&){};  // Don't allow the user to assign this instance
+		ZmqLogger & operator=(ZmqLogger const&) = delete;  // Don't allow the user to assign this instance
 
 		/// Private variable to keep track of singleton instance
 		static ZmqLogger * m_pInstance;

--- a/tests/ReaderBase_Tests.cpp
+++ b/tests/ReaderBase_Tests.cpp
@@ -44,9 +44,9 @@ TEST(ReaderBase_Derived_Class)
 		std::shared_ptr<Frame> GetFrame(int64_t number) { std::shared_ptr<Frame> f(new Frame()); return f; }
 		void Close() { };
 		void Open() { };
-		string Json() { };
+		string Json() { return ""; };
 		void SetJson(string value) { };
-		Json::Value JsonValue() { };
+		Json::Value JsonValue() { return 0; };
 		void SetJsonValue(Json::Value root) { };
 		bool IsOpen() { return true; };
 		string Name() { return "TestReader"; };


### PR DESCRIPTION
The libopenshot code causes a _ton_ of compiler warnings when built with gcc 8, and since a number of them are in common header files they show up for every source file.

This change fixes up the code that gcc warns about (mostly methods with return types that don't actually return anything, a no-no) to use the proper, supported C++11 idioms for achieving the intended goal.