### PR TITLE
cmake: use GNUInstallDirs and fix documentation installation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,5 +87,4 @@ add_subdirectory(tests)
 # Find Doxygen (used for documentation)
 include(cmake/Modules/UseDoxygen.cmake)
 
-file(GLOB_RECURSE doc_files ${CMAKE_CURRENT_BINARY_DIR}/doc/html/*.*)
-INSTALL(FILES ${doc_files} DESTINATION ${CMAKE_INSTALL_DOCDIR}/libopenshot)
+INSTALL(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/doc/html/ DESTINATION ${CMAKE_INSTALL_DOCDIR}/libopenshot OPTIONAL)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,7 @@ MESSAGE("questions or issues, please visit <http://www.openshot.org/>.")
 
 ################ ADD CMAKE MODULES ##################
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/Modules")
+include(GNUInstallDirs)
 
 ################ GET VERSION INFORMATION FROM VERSION.H ##################
 MESSAGE("--------------------------------------------------------------")
@@ -87,4 +88,4 @@ add_subdirectory(tests)
 include(cmake/Modules/UseDoxygen.cmake)
 
 file(GLOB_RECURSE doc_files ${CMAKE_CURRENT_BINARY_DIR}/doc/html/*.*)
-INSTALL(FILES ${doc_files} DESTINATION share/doc/libopenshot)
+INSTALL(FILES ${doc_files} DESTINATION ${CMAKE_INSTALL_DOCDIR}/libopenshot)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -294,7 +294,7 @@ set_target_properties(openshot
 		PROPERTIES
 		VERSION ${PROJECT_VERSION}
 		SOVERSION ${SO_VERSION}
-		INSTALL_NAME_DIR "${CMAKE_INSTALL_PREFIX}/lib"
+		INSTALL_NAME_DIR "${CMAKE_INSTALL_LIBDIR}"
 		)
 
 ###############  LINK LIBRARY  #################
@@ -384,16 +384,14 @@ add_subdirectory(bindings)
 
 
 ############### INSTALL HEADERS & LIBRARY ################
-set(LIB_INSTALL_DIR lib${LIB_SUFFIX}) # determine correct lib folder
-
 # Install primary library
 INSTALL(  TARGETS openshot
-		ARCHIVE DESTINATION ${LIB_INSTALL_DIR}
-		LIBRARY DESTINATION ${LIB_INSTALL_DIR}
+		ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+		LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
 		COMPONENT library )
 
 INSTALL(DIRECTORY ${CMAKE_SOURCE_DIR}/include/
-		DESTINATION ${CMAKE_INSTALL_PREFIX}/include/libopenshot
+		DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/libopenshot
 		FILES_MATCHING PATTERN "*.h")
 
 ############### CPACK PACKAGING ##############


### PR DESCRIPTION
This allows customizing various installation folders.