### PR TITLE
Limiting threads for both FFmpeg and OpenMP

### DIFF
--- a/include/OpenMPUtilities.h
+++ b/include/OpenMPUtilities.h
@@ -32,8 +32,10 @@
 #include <stdlib.h>
 #include <string.h>
 
-// Calculate the # of OpenMP Threads to allow
-#define OPEN_MP_NUM_PROCESSORS omp_get_num_procs()
+// Calculate the # of OpenMP and FFmpeg Threads to allow. We are limiting both
+// of these based on our own performance tests (more is not always better).
+#define OPEN_MP_NUM_PROCESSORS (min(omp_get_num_procs(), 6))
+#define FF_NUM_PROCESSORS (min(omp_get_num_procs(), 12))
 
 using namespace std;
 

--- a/src/FFmpegReader.cpp
+++ b/src/FFmpegReader.cpp
@@ -153,7 +153,7 @@ void FFmpegReader::Open()
 			pCodecCtx = AV_GET_CODEC_CONTEXT(pStream, pCodec);
 
 			// Set number of threads equal to number of processors (not to exceed 16)
-			pCodecCtx->thread_count = min(OPEN_MP_NUM_PROCESSORS, 16);
+			pCodecCtx->thread_count = min(FF_NUM_PROCESSORS, 16);
 
 			if (pCodec == NULL) {
 				throw InvalidCodec("A valid video codec could not be found for this file.", path);
@@ -191,7 +191,7 @@ void FFmpegReader::Open()
 			aCodecCtx = AV_GET_CODEC_CONTEXT(aStream, aCodec);
 
 			// Set number of threads equal to number of processors (not to exceed 16)
-			aCodecCtx->thread_count = min(OPEN_MP_NUM_PROCESSORS, 16);
+			aCodecCtx->thread_count = min(FF_NUM_PROCESSORS, 16);
 
 			if (aCodec == NULL) {
 				throw InvalidCodec("A valid audio codec could not be found for this file.", path);

--- a/src/FFmpegWriter.cpp
+++ b/src/FFmpegWriter.cpp
@@ -1026,7 +1026,7 @@ void FFmpegWriter::open_audio(AVFormatContext *oc, AVStream *st)
 	AV_GET_CODEC_FROM_STREAM(st, audio_codec)
 
 	// Set number of threads equal to number of processors (not to exceed 16)
-	audio_codec->thread_count = min(OPEN_MP_NUM_PROCESSORS, 16);
+	audio_codec->thread_count = min(FF_NUM_PROCESSORS, 16);
 
 	// Find the audio encoder
 	codec = avcodec_find_encoder_by_name(info.acodec.c_str());
@@ -1100,7 +1100,7 @@ void FFmpegWriter::open_video(AVFormatContext *oc, AVStream *st)
 	AV_GET_CODEC_FROM_STREAM(st, video_codec)
 
 	// Set number of threads equal to number of processors (not to exceed 16)
-	video_codec->thread_count = min(OPEN_MP_NUM_PROCESSORS, 16);
+	video_codec->thread_count = min(FF_NUM_PROCESSORS, 16);
 
 	/* find the video encoder */
 	codec = avcodec_find_encoder_by_name(info.vcodec.c_str());


### PR DESCRIPTION
Limiting threads for both FFmpeg and OpenMP, attempting to find a balance of parallel performance, while not spawning too many threads). Sometimes more is not always better.