### PR TITLE
Protect effects with critical (prevents crashing and freezing around transitions)

### DIFF
--- a/src/Timeline.cpp
+++ b/src/Timeline.cpp
@@ -281,6 +281,7 @@ void Timeline::add_layer(std::shared_ptr<Frame> new_frame, Clip* source_clip, in
 	/* Apply effects to the source frame (if any). If multiple clips are overlapping, only process the
 	 * effects on the top clip. */
 	if (is_top_clip && source_frame)
+		#pragma omp critical (T_addLayer)
 		source_frame = apply_effects(source_frame, timeline_frame_number, source_clip->Layer());
 
 	// Declare an image to hold the source frame's image


### PR DESCRIPTION
Protect effects with critical (prevents crashing and freezing around transitions). Thanks Peter and Michael Sloan!