### PR TITLE
Bumping version to 0.2.2 (SO: still 16)

### DIFF
--- a/include/Version.h
+++ b/include/Version.h
@@ -36,7 +36,7 @@
 
 #define OPENSHOT_VERSION_MAJOR 0;   /// Major version number is incremented when huge features are added or improved.
 #define OPENSHOT_VERSION_MINOR 2;   /// Minor version is incremented when smaller (but still very important) improvements are added.
-#define OPENSHOT_VERSION_BUILD 1;   /// Build number is incremented when minor bug fixes and less important improvements are added.
+#define OPENSHOT_VERSION_BUILD 2;   /// Build number is incremented when minor bug fixes and less important improvements are added.
 #define OPENSHOT_VERSION_SO 16;     /// Shared object version number. This increments any time the API and ABI changes (so old apps will no longer link)
 #define OPENSHOT_VERSION_MAJOR_MINOR STRINGIZE(OPENSHOT_VERSION_MAJOR) "." STRINGIZE(OPENSHOT_VERSION_MINOR); /// A string of the "Major.Minor" version
 #define OPENSHOT_VERSION_ALL STRINGIZE(OPENSHOT_VERSION_MAJOR) "." STRINGIZE(OPENSHOT_VERSION_MINOR) "." STRINGIZE(OPENSHOT_VERSION_BUILD); /// A string of the entire version "Major.Minor.Build"


### PR DESCRIPTION
Official release of 0.2.2 of libopenshot. This release includes a last minute bug fix related to transition effect crashes that I want to include in openshot-qt 2.4.3 (the upcoming release).