### PR TITLE
De-limit amount of threads.

### DIFF
--- a/include/OpenMPUtilities.h
+++ b/include/OpenMPUtilities.h
@@ -32,10 +32,9 @@
 #include <stdlib.h>
 #include <string.h>
 
-// Calculate the # of OpenMP and FFmpeg Threads to allow. We are limiting both
-// of these based on our own performance tests (more is not always better).
-#define OPEN_MP_NUM_PROCESSORS (min(omp_get_num_procs(), 6))
-#define FF_NUM_PROCESSORS (min(omp_get_num_procs(), 12))
+// Calculate the # of OpenMP and FFmpeg Threads to allow.
+#define OPEN_MP_NUM_PROCESSORS omp_get_num_procs()
+#define FF_NUM_PROCESSORS omp_get_num_procs()
 
 using namespace std;
 


### PR DESCRIPTION
I propose we remove the set limit from the function that calculates the amount of threads used.

Before my commit, the function took the maximum of the processor threads and 6 for OpenShot, and maximum of the processor threads and 12 for FFmpeg.

The code states that this was based on "performance tests," yet, if there are results from those, where are the results?