### PR TITLE
Improving cache performance by preventing the cache from getting behind

### DIFF
--- a/src/Qt/PlayerPrivate.cpp
+++ b/src/Qt/PlayerPrivate.cpp
@@ -149,7 +149,7 @@ namespace openshot
 		else
 		{
 			// Update cache on which frame was retrieved
-			videoCache->current_display_frame = video_position;
+			videoCache->setCurrentFramePosition(video_position);
 
 			// return frame from reader
 			return reader->GetFrame(video_position);

--- a/src/Qt/VideoCacheThread.cpp
+++ b/src/Qt/VideoCacheThread.cpp
@@ -102,6 +102,12 @@ namespace openshot
 				// Ignore out of bounds frame exceptions
 			}
 
+			// Is cache position behind current display frame?
+			if (position < current_display_frame) {
+				// Jump ahead
+				position = current_display_frame;
+			}
+
 	    	// Increment frame number
 	    	position++;
 	    }


### PR DESCRIPTION
Improving cache performance by preventing the cache from getting behind the currently displaying frame #. This will dramatically improve performance for certain types of playback scenarios. Before the cache could get behind, and would actually be requesting frames < 10 or 20 frames from the current location, which would case the Reader to Seek backwards for no reason, causing stops and pauses.