### PR TITLE
Add a text background colored box option to the text reader

### DIFF
--- a/include/TextReader.h
+++ b/include/TextReader.h
@@ -90,6 +90,7 @@ namespace openshot
 		double size;
 		string text_color;
 		string background_color;
+		string text_background_color;
 		std::shared_ptr<Magick::Image> image;
 		list<Magick::Drawable> lines;
 		bool is_open;
@@ -110,8 +111,12 @@ namespace openshot
 		/// @param font The font of the text
 		/// @param size The size of the text
 		/// @param text_color The color of the text
-		/// @param background_color The background color of the text (also supports Transparent)
+		/// @param background_color The background color of the text frame image (also supports Transparent)
 		TextReader(int width, int height, int x_offset, int y_offset, GravityType gravity, string text, string font, double size, string text_color, string background_color);
+
+		/// Draw a box under rendered text using the specified color.
+		/// @param text_background_color The background color behind the text
+		void SetTextBackgroundColor(string color);
 
 		/// Close Reader
 		void Close();

--- a/src/TextReader.cpp
+++ b/src/TextReader.cpp
@@ -45,6 +45,14 @@ TextReader::TextReader(int width, int height, int x_offset, int y_offset, Gravit
 	Close();
 }
 
+void TextReader::SetTextBackgroundColor(string color) {
+	text_background_color = color;
+
+	// Open and Close the reader, to populate it's attributes (such as height, width, etc...) plus the text background color
+	Open();
+	Close();
+}
+
 // Open reader
 void TextReader::Open()
 {
@@ -96,6 +104,10 @@ void TextReader::Open()
 		lines.push_back(Magick::DrawableFont(font));
 		lines.push_back(Magick::DrawablePointSize(size));
 		lines.push_back(Magick::DrawableText(x_offset, y_offset, text));
+
+		if (!text_background_color.empty()) {
+			lines.push_back(Magick::DrawableTextUnderColor(Magick::Color(text_background_color)));
+		}
 
 		// Draw image
 		image->draw(lines);
@@ -190,6 +202,7 @@ Json::Value TextReader::JsonValue() {
 	root["size"] = size;
 	root["text_color"] = text_color;
 	root["background_color"] = background_color;
+	root["text_background_color"] = text_background_color;
 	root["gravity"] = gravity;
 
 	// return JsonValue
@@ -244,6 +257,8 @@ void TextReader::SetJsonValue(Json::Value root) {
 		text_color = root["text_color"].asString();
 	if (!root["background_color"].isNull())
 		background_color = root["background_color"].asString();
+	if (!root["text_background_color"].isNull())
+		text_background_color = root["text_background_color"].asString();
 	if (!root["gravity"].isNull())
 		gravity = (GravityType) root["gravity"].asInt();
 


### PR DESCRIPTION
I'm keen to make some enhancements to the TextReader including text stroke. First I have added the ability to add a colored box around text. See the example image of how this looks:

![title-sample](https://user-images.githubusercontent.com/1064199/50042238-7693f780-00b5-11e9-90bc-91c84d031808.JPG)

I didn't want to add any more params to the constructor as it already has 10 params so I added a setter method.

Looking for feedback if I am taking the right approach before doing the stroke and to see whether these enhancements are desired by maintainers/users.