### PR TITLE
Fixing Scale Mode (None) in previews

### DIFF
--- a/src/FFmpegReader.cpp
+++ b/src/FFmpegReader.cpp
@@ -1973,6 +1973,7 @@ void FFmpegReader::RemoveAVFrame(AVFrame* remove_frame)
     {
         // Free memory
 		av_freep(&remove_frame->data[0]);
+		AV_FREE_FRAME(&remove_frame);
 	}
 }
 

--- a/src/FFmpegWriter.cpp
+++ b/src/FFmpegWriter.cpp
@@ -1383,7 +1383,7 @@ void FFmpegWriter::write_audio_packets(bool final)
 
 			} else {
 				// Create a new array
-				final_samples = new int16_t[audio_input_position * (av_get_bytes_per_sample(audio_codec->sample_fmt) / av_get_bytes_per_sample(AV_SAMPLE_FMT_S16))];
+				final_samples = (int16_t*)av_malloc(sizeof(int16_t) * audio_input_position * (av_get_bytes_per_sample(audio_codec->sample_fmt) / av_get_bytes_per_sample(AV_SAMPLE_FMT_S16)));
 
 				// Copy audio into buffer for frame
 				memcpy(final_samples, samples, audio_input_position * av_get_bytes_per_sample(audio_codec->sample_fmt));


### PR DESCRIPTION
Often in a preview, **Scale: None** renders differently than on final render, due to optimizations in previews which reduce the image size. Now disabling scaling works correctly in both preview and final render.