### PR TITLE
Adding condition before calling av_frame_free (in AV_FREE_FRAME macro)

### DIFF
--- a/include/FFmpegUtilities.h
+++ b/include/FFmpegUtilities.h
@@ -141,7 +141,7 @@
 		#define AV_ALLOCATE_FRAME() av_frame_alloc()
 		#define AV_ALLOCATE_IMAGE(av_frame, pix_fmt, width, height) av_image_alloc(av_frame->data, av_frame->linesize, width, height, pix_fmt, 1)
 		#define AV_RESET_FRAME(av_frame) av_frame_unref(av_frame)
-    	#define AV_FREE_FRAME(av_frame) av_frame_free(av_frame)
+    	#define AV_FREE_FRAME(av_frame) if (av_frame) av_frame_free(av_frame)
 		#define AV_FREE_PACKET(av_packet) av_packet_unref(av_packet)
 		#define AV_FREE_CONTEXT(av_context) avcodec_free_context(&av_context)
 		#define AV_GET_CODEC_TYPE(av_stream) av_stream->codecpar->codec_type
@@ -176,7 +176,7 @@
 		#define AV_ALLOCATE_FRAME() av_frame_alloc()
 		#define AV_ALLOCATE_IMAGE(av_frame, pix_fmt, width, height) av_image_alloc(av_frame->data, av_frame->linesize, width, height, pix_fmt, 1)
 		#define AV_RESET_FRAME(av_frame) av_frame_unref(av_frame)
-    	#define AV_FREE_FRAME(av_frame) av_frame_free(av_frame)
+    	#define AV_FREE_FRAME(av_frame) if(av_frame) av_frame_free(av_frame)
 		#define AV_FREE_PACKET(av_packet) av_packet_unref(av_packet)
 		#define AV_FREE_CONTEXT(av_context) avcodec_free_context(&av_context)
 		#define AV_GET_CODEC_TYPE(av_stream) av_stream->codecpar->codec_type
@@ -211,7 +211,7 @@
 		#define AV_ALLOCATE_FRAME() av_frame_alloc()
 		#define AV_ALLOCATE_IMAGE(av_frame, pix_fmt, width, height) avpicture_alloc((AVPicture *) av_frame, pix_fmt, width, height)
 		#define AV_RESET_FRAME(av_frame) av_frame_unref(av_frame)
-    	#define AV_FREE_FRAME(av_frame) av_frame_free(av_frame)
+    	#define AV_FREE_FRAME(av_frame) if (av_frame) av_frame_free(av_frame)
 		#define AV_FREE_PACKET(av_packet) av_packet_unref(av_packet)
 		#define AV_FREE_CONTEXT(av_context) avcodec_close(av_context)
 		#define AV_GET_CODEC_TYPE(av_stream) av_stream->codec->codec_type
@@ -241,7 +241,7 @@
 		#define AV_ALLOCATE_FRAME() avcodec_alloc_frame()
 		#define AV_ALLOCATE_IMAGE(av_frame, pix_fmt, width, height) avpicture_alloc((AVPicture *) av_frame, pix_fmt, width, height)
 		#define AV_RESET_FRAME(av_frame) avcodec_get_frame_defaults(av_frame)
-		#define AV_FREE_FRAME(av_frame) avcodec_free_frame(av_frame)
+		#define AV_FREE_FRAME(av_frame) if(av_frame) avcodec_free_frame(av_frame)
 		#define AV_FREE_PACKET(av_packet) av_free_packet(av_packet)
 		#define AV_FREE_CONTEXT(av_context) avcodec_close(av_context)
 		#define AV_GET_CODEC_TYPE(av_stream) av_stream->codec->codec_type


### PR DESCRIPTION
Fixing regression on Windows (introduced in https://github.com/OpenShot/libopenshot/commit/e0ec60396592780110e5ca1ab930a0eaa9a7ff29#commitcomment-31949787). Adding in a conditional to prevent a crash on Windows.