### PR TITLE
Some polishing for the cmake ReSVG discovery

### DIFF
--- a/cmake/Modules/FindRESVG.cmake
+++ b/cmake/Modules/FindRESVG.cmake
@@ -3,7 +3,6 @@
 # RESVG_FOUND - System has RESVG
 # RESVG_INCLUDE_DIRS - The RESVG include directories
 # RESVG_LIBRARIES - The libraries needed to use RESVG
-# RESVG_DEFINITIONS - Compiler switches required for using RESVG
 find_path ( RESVG_INCLUDE_DIR ResvgQt.h
             PATHS ${RESVGDIR}/include/resvg
                   $ENV{RESVGDIR}/include/resvg

--- a/cmake/Modules/FindRESVG.cmake
+++ b/cmake/Modules/FindRESVG.cmake
@@ -22,14 +22,8 @@ find_library ( RESVG_LIBRARY NAMES resvg
 set ( RESVG_LIBRARIES ${RESVG_LIBRARY} )
 set ( RESVG_INCLUDE_DIRS ${RESVG_INCLUDE_DIR} )
 
-SET( RESVG_FOUND FALSE )
-
-IF ( RESVG_INCLUDE_DIR AND RESVG_LIBRARY )
-    SET ( RESVG_FOUND TRUE )
-
-    include ( FindPackageHandleStandardArgs )
-    # handle the QUIETLY and REQUIRED arguments and set RESVG_FOUND to TRUE
-    # if all listed variables are TRUE
-    find_package_handle_standard_args ( RESVG DEFAULT_MSG RESVG_LIBRARY RESVG_INCLUDE_DIR )
-ENDIF ( RESVG_INCLUDE_DIR AND RESVG_LIBRARY )
-
+include ( FindPackageHandleStandardArgs )
+# handle the QUIETLY and REQUIRED arguments and set RESVG_FOUND to TRUE
+# if all listed variables are TRUE
+find_package_handle_standard_args ( RESVG "Could NOT find RESVG, using Qt SVG parsing instead" RESVG_LIBRARY RESVG_INCLUDE_DIR )
+mark_as_advanced( RESVG_LIBRARY RESVG_INCLUDE_DIR )

--- a/cmake/Modules/FindRESVG.cmake
+++ b/cmake/Modules/FindRESVG.cmake
@@ -16,6 +16,7 @@ find_path ( RESVG_INCLUDE_DIR ResvgQt.h
 find_library ( RESVG_LIBRARY NAMES resvg
                PATHS /usr/lib
                     /usr/local/lib
+                    $ENV{RESVGDIR}
                     $ENV{RESVGDIR}/lib )
 
 set ( RESVG_LIBRARIES ${RESVG_LIBRARY} )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -194,8 +194,6 @@ if (RESVG_FOUND)
    # define a global var (used in the C++)
    add_definitions( -DUSE_RESVG=1 )
    SET(CMAKE_SWIG_FLAGS "-DUSE_RESVG=1")
-else(RESVG_FOUND)
-	message("-- Could NOT find libresvg (using Qt SVG parsing instead)")
 endif(RESVG_FOUND)
 
 ################### JSONCPP #####################

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -181,7 +181,7 @@ include_directories(${ZMQ_INCLUDE_DIRS})
 
 ################### RESVG #####################
 # Find resvg library (used for rendering svg files)
-FIND_PACKAGE(RESVG REQUIRED)
+FIND_PACKAGE(RESVG)
 
 # Include resvg headers (optional SVG library)
 if (RESVG_FOUND)


### PR DESCRIPTION
`find_package_handle_standard_args` is supposed to set the `_FOUND` variable automatically (as the comment right above it says), as well as handling things like `REQUIRED`, `QUIETLY`, etc. It should always be run at the end of a module, for this reason.
    
This change removes the conditionals around the call, lets it handle what it's meant to handle, and defines a custom failure message for discovery that replaces the manual one in `src/CMakeList.txt`.
    
In addition, the `REQUIRED` is removed from `tests/CMakeLists.txt`, since it's _supposed_ to mark the module as required (which ReSVG is not), and was only working due to the aforementioned improper
conditional wrapping of the module's cleanup.

With these changes, on my system libopenshot still builds and `make test` still runs successfully both with and without ReSVG being discovered. 

Additionally, if only one of the two parts is missing, cmake will automatically indicate that in the failure message:
```console
$ cd /tmp/resvg/target/release/
$ ln -s ../../capi/include .
$ ls
build  examples  incremental  libresvg.d        libresvg.rlib  libusvg.rlib
deps   include   libresvg.a   libresvg_qt.rlib  libresvg.so    native
$ rm libresvg.so libresvg.a # (To my great surprise, libresvg.a would be discovered and used!)
$ cd /tmp/libopenshot/
$ rm CMakeCache.txt
$ RESVGDIR=/tmp/resvg/target/release /usr/bin/cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr
[...]
-- Could NOT find RESVG, using Qt SVG parsing instead (missing: RESVG_LIBRARY) 
```
The message correctly indicates that only `RESVG_LIBRARY` was not found, because `RESVG_INCLUDE_DIR` was still successfully discovered as `/tmp/resvg/target/release/include/`.

Also:
* `$ENV{RESVGDIR}` is added to the search list for `find_path( RESVG_LIBRARY...`, so that copying/linking the `include` dir into `target/release/` and running `RESVGDIR=/path/to/resvg/target/release/ cmake ...` will successfully discover the library
* The comment in `FindRESVG.cmake` claiming it sets `RESVG_DEFINITIONS` is removed, because it doesn't