### PR TITLE
MP3 Special Handling & Missing Frame Refactor

### DIFF
--- a/include/Timeline.h
+++ b/include/Timeline.h
@@ -152,7 +152,6 @@ namespace openshot {
 		map<Clip*, Clip*> open_clips; ///<List of 'opened' clips on this timeline
 		list<EffectBase*> effects; ///<List of clips on this timeline
 		CacheBase *final_cache; ///<Final cache of timeline frames
-		map<Clip*, int64_t> clip_last_sample; ///<List of last audio sample referrenced by each clip object
 
 		/// Process a new layer of video or audio
 		void add_layer(std::shared_ptr<Frame> new_frame, Clip* source_clip, int64_t clip_frame_number, int64_t timeline_frame_number, bool is_top_clip, float max_volume);

--- a/include/Timeline.h
+++ b/include/Timeline.h
@@ -152,6 +152,7 @@ namespace openshot {
 		map<Clip*, Clip*> open_clips; ///<List of 'opened' clips on this timeline
 		list<EffectBase*> effects; ///<List of clips on this timeline
 		CacheBase *final_cache; ///<Final cache of timeline frames
+		map<Clip*, int64_t> clip_last_sample; ///<List of last audio sample referrenced by each clip object
 
 		/// Process a new layer of video or audio
 		void add_layer(std::shared_ptr<Frame> new_frame, Clip* source_clip, int64_t clip_frame_number, int64_t timeline_frame_number, bool is_top_clip, float max_volume);


### PR DESCRIPTION
MP3 files are unique, in that they typically contain a single video frame, and then the rest of the data is audio frames. So, I've added a condition to better support that, so OpenShot doesn't spend forever looking for missing video frames. Also, I've refactored the missing frame logic to better handle audio data and video data which is missing (I've separated the logic), and all my broken test files work great now!