### PR TITLE
Improved Keyframe Performance

### DIFF
--- a/include/Clip.h
+++ b/include/Clip.h
@@ -127,7 +127,7 @@ namespace openshot {
 		std::shared_ptr<Frame> GetOrCreateFrame(int64_t number);
 
 		/// Adjust the audio and image of a time mapped frame
-		std::shared_ptr<Frame> get_time_mapped_frame(std::shared_ptr<Frame> frame, int64_t frame_number);
+		void get_time_mapped_frame(std::shared_ptr<Frame> frame, int64_t frame_number);
 
 		/// Init default settings for a clip
 		void init_settings();

--- a/include/Coordinate.h
+++ b/include/Coordinate.h
@@ -52,11 +52,6 @@ namespace openshot {
 	 * \endcode
 	 */
 	class Coordinate {
-	private:
-		bool increasing; ///< Is the Y value increasing or decreasing?
-		Fraction repeated; ///< Fraction of repeated Y values (for example, 1/3 would be the first Y value of 3 repeated values)
-		double delta; ///< This difference in Y value (from the previous unique Y value)
-
 	public:
 		double X; ///< The X value of the coordinate (usually representing the frame #)
 		double Y; ///< The Y value of the coordinate (usually representing the value of the property being animated)
@@ -68,27 +63,6 @@ namespace openshot {
 		/// @param x The X coordinate (usually representing the frame #)
 		/// @param y The Y coordinate (usually representing the value of the property being animated)
 		Coordinate(double x, double y);
-
-		/// @brief Set the repeating Fraction (used internally on the timeline, to track changes to coordinates)
-		/// @param is_repeated The fraction representing how many times this coordinate Y value repeats (only used on the timeline)
-		void Repeat(Fraction is_repeated) { repeated=is_repeated; }
-
-		/// Get the repeating Fraction (used internally on the timeline, to track changes to coordinates)
-		Fraction Repeat() { return repeated; }
-
-		/// @brief Set the increasing flag (used internally on the timeline, to track changes to coordinates)
-		/// @param is_increasing Indicates if this coordinate Y value is increasing (when compared to the previous coordinate)
-		void IsIncreasing(bool is_increasing) { increasing = is_increasing; }
-
-		/// Get the increasing flag (used internally on the timeline, to track changes to coordinates)
-		bool IsIncreasing() { return increasing; }
-
-		/// @brief Set the delta / difference between previous coordinate value (used internally on the timeline, to track changes to coordinates)
-		/// @param new_delta Indicates how much this Y value differs from the previous Y value
-		void Delta(double new_delta) { delta=new_delta; }
-
-		/// Get the delta / difference between previous coordinate value (used internally on the timeline, to track changes to coordinates)
-		float Delta() { return delta; }
 
 		/// Get and Set JSON methods
 		string Json(); ///< Generate JSON string of this object

--- a/src/Coordinate.cpp
+++ b/src/Coordinate.cpp
@@ -32,12 +32,12 @@ using namespace openshot;
 
 // Default constructor for a coordinate, which defaults the X and Y to zero (0,0)
 Coordinate::Coordinate() :
-	X(0), Y(0), increasing(true), repeated(1,1), delta(0.0) {
+	X(0), Y(0) {
 }
 
 // Constructor which also allows the user to set the X and Y
 Coordinate::Coordinate(double x, double y) :
-	X(x), Y(y), increasing(true), repeated(1,1), delta(0.0)  {
+	X(x), Y(y) {
 }
 
 
@@ -96,15 +96,4 @@ void Coordinate::SetJsonValue(Json::Value root) {
 		X = root["X"].asDouble();
 	if (!root["Y"].isNull())
 		Y = root["Y"].asDouble();
-	if (!root["increasing"].isNull())
-		increasing = root["increasing"].asBool();
-	if (!root["repeated"].isNull() && root["repeated"].isObject())
-	{
-		if (!root["repeated"]["num"].isNull())
-			repeated.num = root["repeated"]["num"].asInt();
-		if (!root["repeated"]["den"].isNull())
-			repeated.den = root["repeated"]["den"].asInt();
-	}
-	if (!root["delta"].isNull())
-		delta = root["delta"].asDouble();
 }

--- a/src/FrameMapper.cpp
+++ b/src/FrameMapper.cpp
@@ -207,7 +207,7 @@ void FrameMapper::Init()
 		int64_t new_length = reader->info.video_length * rate_diff;
 
 		// Calculate the value difference
-		double value_increment = reader->info.video_length / (double) (new_length);
+		double value_increment = (reader->info.video_length + 1) / (double) (new_length);
 
 		// Loop through curve, and build list of frames
 		double original_frame_num = 1.0f;

--- a/tests/KeyFrame_Tests.cpp
+++ b/tests/KeyFrame_Tests.cpp
@@ -193,28 +193,26 @@ TEST(Keyframe_Check_Direction_and_Repeat_Fractions)
 
 	// Spot check values from the curve
 	CHECK_EQUAL(kf.GetInt(1), 500);
-	CHECK_EQUAL(kf.IsIncreasing(1), false);
-	CHECK_EQUAL(kf.GetRepeatFraction(1).num, 1);
-	CHECK_EQUAL(kf.GetRepeatFraction(1).den, 12);
-	CHECK_EQUAL(kf.GetDelta(1), 500);
+	CHECK_EQUAL(kf.IsIncreasing(1), true);
+	CHECK_CLOSE(kf.GetDelta(1), 500, 0.01);
 
 	CHECK_EQUAL(kf.GetInt(24), 498);
 	CHECK_EQUAL(kf.IsIncreasing(24), false);
-	CHECK_EQUAL(kf.GetRepeatFraction(24).num, 3);
-	CHECK_EQUAL(kf.GetRepeatFraction(24).den, 6);
-	CHECK_EQUAL(kf.GetDelta(24), 0);
+	CHECK_EQUAL(kf.GetRepeatFraction(24).num, 1);
+	CHECK_EQUAL(kf.GetRepeatFraction(24).den, 1);
+	CHECK_CLOSE(kf.GetDelta(24), -0.1717, 0.01);
 
-	CHECK_EQUAL(kf.GetLong(390), 100);
-	CHECK_EQUAL(kf.IsIncreasing(390), true);
-	CHECK_EQUAL(kf.GetRepeatFraction(390).num, 3);
-	CHECK_EQUAL(kf.GetRepeatFraction(390).den, 15);
-	CHECK_EQUAL(kf.GetDelta(390), 0);
+	CHECK_EQUAL(kf.GetLong(400), 100);
+	CHECK_EQUAL(kf.IsIncreasing(400), false);
+	CHECK_EQUAL(kf.GetRepeatFraction(400).num, 1);
+	CHECK_EQUAL(kf.GetRepeatFraction(400).den, 1);
+	CHECK_CLOSE(kf.GetDelta(400), -0.0019, 0.01);
 
-	CHECK_EQUAL(kf.GetLong(391), 100);
-	CHECK_EQUAL(kf.IsIncreasing(391), true);
-	CHECK_EQUAL(kf.GetRepeatFraction(391).num, 4);
-	CHECK_EQUAL(kf.GetRepeatFraction(391).den, 15);
-	CHECK_EQUAL(kf.GetDelta(388), -1);
+	CHECK_EQUAL(kf.GetLong(401), 100);
+	CHECK_EQUAL(kf.IsIncreasing(401), true);
+	CHECK_EQUAL(kf.GetRepeatFraction(401).num, 1);
+	CHECK_EQUAL(kf.GetRepeatFraction(401).den, 1);
+	CHECK_CLOSE(kf.GetDelta(401), 0.1174, 0.01);
 }
 
 
@@ -377,4 +375,20 @@ TEST(Keyframe_Remove_Duplicate_Point)
 	// Spot check values from the curve
 	CHECK_EQUAL(kf.GetLength(), 1);
 	CHECK_CLOSE(kf.GetPoint(0).co.Y, 2.0, 0.01);
+}
+
+TEST(Keyframe_Large_Number_Values)
+{
+	// Large value
+	int64_t large_value = 30 * 60 * 90;
+
+	// Create a keyframe curve with 2 points
+	Keyframe kf;
+	kf.AddPoint(1, 1.0);
+	kf.AddPoint(large_value, 100.0); // 90 minutes long
+
+	// Spot check values from the curve
+	CHECK_EQUAL(kf.GetLength(), large_value + 1);
+	CHECK_CLOSE(kf.GetPoint(0).co.Y, 1.0, 0.01);
+	CHECK_CLOSE(kf.GetPoint(1).co.Y, 100.0, 0.01);
 }

--- a/tests/KeyFrame_Tests.cpp
+++ b/tests/KeyFrame_Tests.cpp
@@ -193,26 +193,28 @@ TEST(Keyframe_Check_Direction_and_Repeat_Fractions)
 
 	// Spot check values from the curve
 	CHECK_EQUAL(kf.GetInt(1), 500);
-	CHECK_EQUAL(kf.IsIncreasing(1), true);
-	CHECK_CLOSE(kf.GetDelta(1), 500, 0.01);
+	CHECK_EQUAL(kf.IsIncreasing(1), false);
+	CHECK_EQUAL(kf.GetRepeatFraction(1).num, 1);
+	CHECK_EQUAL(kf.GetRepeatFraction(1).den, 12);
+	CHECK_EQUAL(kf.GetDelta(1), 500);
 
 	CHECK_EQUAL(kf.GetInt(24), 498);
 	CHECK_EQUAL(kf.IsIncreasing(24), false);
-	CHECK_EQUAL(kf.GetRepeatFraction(24).num, 1);
-	CHECK_EQUAL(kf.GetRepeatFraction(24).den, 1);
-	CHECK_CLOSE(kf.GetDelta(24), -0.1717, 0.01);
+	CHECK_EQUAL(kf.GetRepeatFraction(24).num, 3);
+	CHECK_EQUAL(kf.GetRepeatFraction(24).den, 6);
+	CHECK_EQUAL(kf.GetDelta(24), 0);
 
-	CHECK_EQUAL(kf.GetLong(400), 100);
-	CHECK_EQUAL(kf.IsIncreasing(400), false);
-	CHECK_EQUAL(kf.GetRepeatFraction(400).num, 1);
-	CHECK_EQUAL(kf.GetRepeatFraction(400).den, 1);
-	CHECK_CLOSE(kf.GetDelta(400), -0.0019, 0.01);
+	CHECK_EQUAL(kf.GetLong(390), 100);
+	CHECK_EQUAL(kf.IsIncreasing(390), true);
+	CHECK_EQUAL(kf.GetRepeatFraction(390).num, 3);
+	CHECK_EQUAL(kf.GetRepeatFraction(390).den, 15);
+	CHECK_EQUAL(kf.GetDelta(390), 0);
 
-	CHECK_EQUAL(kf.GetLong(401), 100);
-	CHECK_EQUAL(kf.IsIncreasing(401), true);
-	CHECK_EQUAL(kf.GetRepeatFraction(401).num, 1);
-	CHECK_EQUAL(kf.GetRepeatFraction(401).den, 1);
-	CHECK_CLOSE(kf.GetDelta(401), 0.1174, 0.01);
+	CHECK_EQUAL(kf.GetLong(391), 100);
+	CHECK_EQUAL(kf.IsIncreasing(391), true);
+	CHECK_EQUAL(kf.GetRepeatFraction(391).num, 4);
+	CHECK_EQUAL(kf.GetRepeatFraction(391).den, 15);
+	CHECK_EQUAL(kf.GetDelta(388), -1);
 }
 
 


### PR DESCRIPTION
I've done some heavy refactoring to our Keyframes and Framemapper, to allow for faster loading of OpenShot projects, and deferring some of the actual Keyframe number crunching until absolutely needed. Also, the Keyframes are magnitudes faster now, since I've removed some horribly inefficient looping calculating... especially for long clips which require hundreds of thousands of coordinates in those Keyframes.

This also touches how time mapping works a little bit, and there are still some issues with respects to the time mapping feature... audio crackles and audio dead spots... but those bugs already existed, and continue to exist after this refactor.