### PR TITLE
Invalid SetMaxSize Logic and Invalid CRF q settings in FFmpegWriter

### DIFF
--- a/src/FFmpegWriter.cpp
+++ b/src/FFmpegWriter.cpp
@@ -995,6 +995,16 @@ AVStream* FFmpegWriter::add_video_stream()
 	/* Init video encoder options */
 	if (info.video_bit_rate >= 1000) {
 		c->bit_rate = info.video_bit_rate;
+		if (info.video_bit_rate >= 1500000) {
+			c->qmin = 2;
+			c->qmax = 30;
+		}
+		// Here should be the setting for low fixed bitrate
+		// Defaults are used because mpeg2 otherwise had problems
+	}
+	else {
+		c->qmin = 0;
+		c->qmax = 63;
 	}
 
 	//TODO: Implement variable bitrate feature (which actually works). This implementation throws
@@ -1004,8 +1014,6 @@ AVStream* FFmpegWriter::add_video_stream()
 	//c->rc_buffer_size = FFMAX(c->rc_max_rate, 15000000) * 112L / 15000000 * 16384;
 	//if ( !c->rc_initial_buffer_occupancy )
 	//	c->rc_initial_buffer_occupancy = c->rc_buffer_size * 3/4;
-	c->qmin = 2;
-	c->qmax = 30;
 
 	/* resolution must be a multiple of two */
 	// TODO: require /2 height and width

--- a/src/Timeline.cpp
+++ b/src/Timeline.cpp
@@ -1442,7 +1442,7 @@ void Timeline::ClearAllCache() {
 // Set Max Image Size (used for performance optimization). Convenience function for setting
 // Settings::Instance()->MAX_WIDTH and Settings::Instance()->MAX_HEIGHT.
 void Timeline::SetMaxSize(int width, int height) {
-	// Init max image size
-	Settings::Instance()->MAX_WIDTH = width;
-	Settings::Instance()->MAX_HEIGHT = height;
+	// Init max image size (choose the smallest one)
+	Settings::Instance()->MAX_WIDTH = min(width, info.width);
+	Settings::Instance()->MAX_HEIGHT = min(height, info.height);
 }


### PR DESCRIPTION
When calling Timeline::SetMaxSize, it should never allow a size larger than the timeline's size, which solves broken previews for very small resolutions. Also, the q settings were incorrect when exporting a "low quality" CRF of 50 (this caused an exception before).