### PR TITLE
Juce 5 changes

### DIFF
--- a/cmake/Modules/FindOpenShotAudio.cmake
+++ b/cmake/Modules/FindOpenShotAudio.cmake
@@ -7,30 +7,11 @@
 
 message("$ENV{LIBOPENSHOT_AUDIO_DIR}")
 
-# Find the base directory of juce includes
-find_path(LIBOPENSHOT_AUDIO_BASE_DIR JuceHeader.h
+# Find the libopenshot-audio header files
+find_path(LIBOPENSHOT_AUDIO_INCLUDE_DIR JuceHeader.h
 			PATHS $ENV{LIBOPENSHOT_AUDIO_DIR}/include/libopenshot-audio/
 			/usr/include/libopenshot-audio/
 			/usr/local/include/libopenshot-audio/ )
-
-# Get a list of all header file paths
-FILE(GLOB_RECURSE JUCE_HEADER_FILES
-  ${LIBOPENSHOT_AUDIO_BASE_DIR}/*.h
-)
-
-# Loop through each header file
-FOREACH(HEADER_PATH ${JUCE_HEADER_FILES})
-	# Get the directory of each header file
-	get_filename_component(HEADER_DIRECTORY ${HEADER_PATH}
-		PATH
-	)
-
-	# Append each directory into the HEADER_DIRECTORIES list
-	LIST(APPEND HEADER_DIRECTORIES ${HEADER_DIRECTORY})
-ENDFOREACH(HEADER_PATH)
-
-# Remove duplicates from the header directories list
-LIST(REMOVE_DUPLICATES HEADER_DIRECTORIES)
 
 # Find the libopenshot-audio.so (check env var first)
 find_library(LIBOPENSHOT_AUDIO_LIBRARY
@@ -48,9 +29,7 @@ find_library(LIBOPENSHOT_AUDIO_LIBRARY
 set(LIBOPENSHOT_AUDIO_LIBRARIES ${LIBOPENSHOT_AUDIO_LIBRARY})
 set(LIBOPENSHOT_AUDIO_LIBRARY ${LIBOPENSHOT_AUDIO_LIBRARIES})
 
-# Seems to work fine with just the base dir (rather than all the actual include folders)
-set(LIBOPENSHOT_AUDIO_INCLUDE_DIR ${LIBOPENSHOT_AUDIO_BASE_DIR} )
-set(LIBOPENSHOT_AUDIO_INCLUDE_DIRS ${LIBOPENSHOT_AUDIO_BASE_DIR} )
+set(LIBOPENSHOT_AUDIO_INCLUDE_DIRS ${LIBOPENSHOT_AUDIO_INCLUDE_DIR} )
 
 include(FindPackageHandleStandardArgs)
 # handle the QUIETLY and REQUIRED arguments and set LIBOPENSHOT_AUDIO_FOUND to TRUE

--- a/include/AudioBufferSource.h
+++ b/include/AudioBufferSource.h
@@ -37,7 +37,7 @@
 #endif
 
 #include <iomanip>
-#include "JuceLibraryCode/JuceHeader.h"
+#include "JuceHeader.h"
 
 using namespace std;
 

--- a/include/AudioReaderSource.h
+++ b/include/AudioReaderSource.h
@@ -37,7 +37,7 @@
 #endif
 
 #include <iomanip>
-#include "JuceLibraryCode/JuceHeader.h"
+#include "JuceHeader.h"
 #include "ReaderBase.h"
 
 using namespace std;

--- a/include/AudioResampler.h
+++ b/include/AudioResampler.h
@@ -38,7 +38,7 @@
 	#define _NDEBUG
 #endif
 
-#include "JuceLibraryCode/JuceHeader.h"
+#include "JuceHeader.h"
 #include "AudioBufferSource.h"
 #include "Exceptions.h"
 

--- a/include/Clip.h
+++ b/include/Clip.h
@@ -36,7 +36,7 @@
 #include <memory>
 #include <string>
 #include <QtGui/QImage>
-#include "JuceLibraryCode/JuceHeader.h"
+#include "JuceHeader.h"
 #include "AudioResampler.h"
 #include "ClipBase.h"
 #include "Color.h"

--- a/include/Frame.h
+++ b/include/Frame.h
@@ -56,7 +56,7 @@
 #ifdef USE_IMAGEMAGICK
 	#include "Magick++.h"
 #endif
-#include "JuceLibraryCode/JuceHeader.h"
+#include "JuceHeader.h"
 #include "ChannelLayouts.h"
 #include "AudioBufferSource.h"
 #include "AudioResampler.h"

--- a/include/Settings.h
+++ b/include/Settings.h
@@ -29,7 +29,7 @@
 #define OPENSHOT_SETTINGS_H
 
 
-#include "JuceLibraryCode/JuceHeader.h"
+#include "JuceHeader.h"
 #include <iostream>
 #include <iomanip>
 #include <fstream>

--- a/include/ZmqLogger.h
+++ b/include/ZmqLogger.h
@@ -29,7 +29,7 @@
 #define OPENSHOT_LOGGER_H
 
 
-#include "JuceLibraryCode/JuceHeader.h"
+#include "JuceHeader.h"
 #include <iostream>
 #include <iomanip>
 #include <fstream>


### PR DESCRIPTION
Adjustments to build libopenshot against a libopenshot-audio built with the new Juce 5.4.3 changes from my companion PR OpenShot/libopenshot-audio#37.

* All header files (7) which contained `#include "JuceLibraryCode/JuceHeader.h"` were changed to simply `#include "JuceHeader.h"`, which works in concert with the new include dir layout for libopenshot-audio.
* Savaged the `cmake/Modules/FindOpenShotAudio.cmake` discovery code to remove all of the recursive header-file discovery and `LIBOPENSHOT_AUDIO_BASE_DIR` noise. 
    Now it simply looks for the file `JuceHeader.h` and considers that location to be the `LIBOPENSHOT_AUDIO_INCLUDE_DIR`, which it is. So much simpler it's not even funny.

(Note: **DO NOT MERGE** until after the corresponding changes to libopenshot-audio are committed. See OpenShot/libopenshot-audio#37 .)