### PR TITLE
Upgrade to JUCE 5

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -56,6 +56,36 @@ mac-builder:
   tags:
     - mac
 
+windows-builder-x64:
+  stage: build-libopenshot
+  artifacts:
+    expire_in: 6 months
+    paths:
+    - build\install-x64\*
+  script:
+    - try { Invoke-WebRequest -Uri "http://gitlab.openshot.org/OpenShot/libopenshot-audio/-/jobs/artifacts/$CI_COMMIT_REF_NAME/download?job=windows-builder-x64" -Headers @{"PRIVATE-TOKEN"="$ACCESS_TOKEN"} -OutFile "artifacts.zip" } catch { $_.Exception.Response.StatusCode.Value__ }
+    - if (-not (Test-Path "artifacts.zip")) { Invoke-WebRequest -Uri "http://gitlab.openshot.org/OpenShot/libopenshot-audio/-/jobs/artifacts/develop/download?job=windows-builder-x64" -Headers @{"PRIVATE-TOKEN"="$ACCESS_TOKEN"} -OutFile "artifacts.zip" }
+    - Expand-Archive -Path artifacts.zip -DestinationPath .
+    - $env:LIBOPENSHOT_AUDIO_DIR = "$CI_PROJECT_DIR\build\install-x64"
+    - $env:UNITTEST_DIR = "C:\msys64\usr"
+    - $env:ZMQDIR = "C:\msys64\usr"
+    - $env:Path = "C:\msys64\mingw64\bin;C:\msys64\mingw64\lib;C:\msys64\usr\lib\cmake\UnitTest++;C:\msys64\home\jonathan\depot_tools;C:\msys64\usr;C:\msys64\usr\lib;" + $env:Path;
+    - New-Item -ItemType Directory -Force -Path build
+    - New-Item -ItemType Directory -Force -Path build\install-x64\python
+    - cd build
+    - cmake -D"CMAKE_INSTALL_PREFIX:PATH=$CI_PROJECT_DIR\build\install-x64" -G "MinGW Makefiles" -D"CMAKE_BUILD_TYPE:STRING=Release" ../
+    - mingw32-make install
+    - Move-Item -Force -path "C:\msys64\mingw64\lib\python3.6\site-packages\*openshot*" -destination "install-x64\python\"
+    - cp src\libopenshot.dll install-x64\lib
+    - New-Item -path "install-x64/share/" -Name "$CI_PROJECT_NAME" -Value "CI_PROJECT_NAME:$CI_PROJECT_NAME`nCI_COMMIT_REF_NAME:$CI_COMMIT_REF_NAME`nCI_COMMIT_SHA:$CI_COMMIT_SHA`nCI_JOB_ID:$CI_JOB_ID" -ItemType file -force
+    - $PREV_GIT_LABEL=(git describe --tags --abbrev=0)
+    - git log "$PREV_GIT_LABEL..HEAD" --oneline --pretty=format:"%C(auto,yellow)%h%C(auto,magenta)% %C(auto,blue)%>(12,trunc)%ad %C(auto,green)%<(25,trunc)%aN%C(auto,reset)%s%C(auto,red)% gD% D" --date=short > "install-x64/share/$CI_PROJECT_NAME.log"
+  when: always
+  except:
+  - tags
+  tags:
+    - windows
+
 windows-builder-x86:
   stage: build-libopenshot
   artifacts:
@@ -81,36 +111,6 @@ windows-builder-x86:
     - New-Item -path "install-x86/share/" -Name "$CI_PROJECT_NAME" -Value "CI_PROJECT_NAME:$CI_PROJECT_NAME`nCI_COMMIT_REF_NAME:$CI_COMMIT_REF_NAME`nCI_COMMIT_SHA:$CI_COMMIT_SHA`nCI_JOB_ID:$CI_JOB_ID" -ItemType file -force
     - $PREV_GIT_LABEL=(git describe --tags --abbrev=0)
     - git log "$PREV_GIT_LABEL..HEAD" --oneline --pretty=format:"%C(auto,yellow)%h%C(auto,magenta)% %C(auto,blue)%>(12,trunc)%ad %C(auto,green)%<(25,trunc)%aN%C(auto,reset)%s%C(auto,red)% gD% D" --date=short > "install-x86/share/$CI_PROJECT_NAME.log"
-  when: always
-  except:
-  - tags
-  tags:
-    - windows
-
-windows-builder-x64:
-  stage: build-libopenshot
-  artifacts:
-    expire_in: 6 months
-    paths:
-    - build\install-x64\*
-  script:
-    - try { Invoke-WebRequest -Uri "http://gitlab.openshot.org/OpenShot/libopenshot-audio/-/jobs/artifacts/$CI_COMMIT_REF_NAME/download?job=windows-builder-x64" -Headers @{"PRIVATE-TOKEN"="$ACCESS_TOKEN"} -OutFile "artifacts.zip" } catch { $_.Exception.Response.StatusCode.Value__ }
-    - if (-not (Test-Path "artifacts.zip")) { Invoke-WebRequest -Uri "http://gitlab.openshot.org/OpenShot/libopenshot-audio/-/jobs/artifacts/develop/download?job=windows-builder-x64" -Headers @{"PRIVATE-TOKEN"="$ACCESS_TOKEN"} -OutFile "artifacts.zip" }
-    - Expand-Archive -Path artifacts.zip -DestinationPath .
-    - $env:LIBOPENSHOT_AUDIO_DIR = "$CI_PROJECT_DIR\build\install-x64"
-    - $env:UNITTEST_DIR = "C:\msys64\usr"
-    - $env:ZMQDIR = "C:\msys64\usr"
-    - $env:Path = "C:\msys64\mingw64\bin;C:\msys64\mingw64\lib;C:\msys64\usr\lib\cmake\UnitTest++;C:\msys64\home\jonathan\depot_tools;C:\msys64\usr;C:\msys64\usr\lib;" + $env:Path;
-    - New-Item -ItemType Directory -Force -Path build
-    - New-Item -ItemType Directory -Force -Path build\install-x64\python
-    - cd build
-    - cmake -D"CMAKE_INSTALL_PREFIX:PATH=$CI_PROJECT_DIR\build\install-x64" -G "MinGW Makefiles" -D"CMAKE_BUILD_TYPE:STRING=Release" ../
-    - mingw32-make install
-    - Move-Item -Force -path "C:\msys64\mingw64\lib\python3.6\site-packages\*openshot*" -destination "install-x64\python\"
-    - cp src\libopenshot.dll install-x64\lib
-    - New-Item -path "install-x64/share/" -Name "$CI_PROJECT_NAME" -Value "CI_PROJECT_NAME:$CI_PROJECT_NAME`nCI_COMMIT_REF_NAME:$CI_COMMIT_REF_NAME`nCI_COMMIT_SHA:$CI_COMMIT_SHA`nCI_JOB_ID:$CI_JOB_ID" -ItemType file -force
-    - $PREV_GIT_LABEL=(git describe --tags --abbrev=0)
-    - git log "$PREV_GIT_LABEL..HEAD" --oneline --pretty=format:"%C(auto,yellow)%h%C(auto,magenta)% %C(auto,blue)%>(12,trunc)%ad %C(auto,green)%<(25,trunc)%aN%C(auto,reset)%s%C(auto,red)% gD% D" --date=short > "install-x64/share/$CI_PROJECT_NAME.log"
   when: always
   except:
   - tags

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 dist: xenial
+sudo: required
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: trusty
+dist: xenial
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ matrix:
       name: "FFmpeg 2"
       before_script:
       - sudo add-apt-repository ppa:openshot.developers/libopenshot-daily -y
-      - sudo add-apt-repository ppa:beineri/opt-qt58-trusty -y
+      - sudo add-apt-repository ppa:beineri/opt-qt-5.10.0-xenial -y
       - sudo apt-get update -qq
       - sudo apt-get install gcc-4.8 cmake libavcodec-dev libavformat-dev libswscale-dev libavresample-dev libavutil-dev libopenshot-audio-dev libopenshot-dev libfdk-aac-dev libfdk-aac-dev libjsoncpp-dev libmagick++-dev libopenshot-audio-dev libunittest++-dev libzmq3-dev pkg-config python3-dev qtbase5-dev qtmultimedia5-dev swig -y
       - sudo apt autoremove -y
@@ -21,7 +21,7 @@ matrix:
       name: "FFmpeg 3"
       before_script:
       - sudo add-apt-repository ppa:openshot.developers/libopenshot-daily -y
-      - sudo add-apt-repository ppa:beineri/opt-qt58-trusty -y
+      - sudo add-apt-repository ppa:beineri/opt-qt-5.10.0-xenial -y
       - sudo add-apt-repository ppa:jonathonf/ffmpeg-3 -y
       - sudo apt-get update -qq
       - sudo apt-get install gcc-4.8 cmake libavcodec-dev libavformat-dev libswscale-dev libavresample-dev libavutil-dev libopenshot-audio-dev libopenshot-dev libfdk-aac-dev libfdk-aac-dev libjsoncpp-dev libmagick++-dev libopenshot-audio-dev libunittest++-dev libzmq3-dev pkg-config python3-dev qtbase5-dev qtmultimedia5-dev swig -y
@@ -36,7 +36,7 @@ matrix:
       name: "FFmpeg 4"
       before_script:
       - sudo add-apt-repository ppa:openshot.developers/libopenshot-daily -y
-      - sudo add-apt-repository ppa:beineri/opt-qt58-trusty -y
+      - sudo add-apt-repository ppa:beineri/opt-qt-5.10.0-xenial -y
       - sudo add-apt-repository ppa:jonathonf/ffmpeg -y
       - sudo add-apt-repository ppa:jonathonf/ffmpeg-4 -y
       - sudo add-apt-repository ppa:jonathonf/backports -y

--- a/cmake/Modules/FindOpenShotAudio.cmake
+++ b/cmake/Modules/FindOpenShotAudio.cmake
@@ -7,30 +7,11 @@
 
 message("$ENV{LIBOPENSHOT_AUDIO_DIR}")
 
-# Find the base directory of juce includes
-find_path(LIBOPENSHOT_AUDIO_BASE_DIR JuceHeader.h
+# Find the libopenshot-audio header files
+find_path(LIBOPENSHOT_AUDIO_INCLUDE_DIR JuceHeader.h
 			PATHS $ENV{LIBOPENSHOT_AUDIO_DIR}/include/libopenshot-audio/
 			/usr/include/libopenshot-audio/
 			/usr/local/include/libopenshot-audio/ )
-
-# Get a list of all header file paths
-FILE(GLOB_RECURSE JUCE_HEADER_FILES
-  ${LIBOPENSHOT_AUDIO_BASE_DIR}/*.h
-)
-
-# Loop through each header file
-FOREACH(HEADER_PATH ${JUCE_HEADER_FILES})
-	# Get the directory of each header file
-	get_filename_component(HEADER_DIRECTORY ${HEADER_PATH}
-		PATH
-	)
-
-	# Append each directory into the HEADER_DIRECTORIES list
-	LIST(APPEND HEADER_DIRECTORIES ${HEADER_DIRECTORY})
-ENDFOREACH(HEADER_PATH)
-
-# Remove duplicates from the header directories list
-LIST(REMOVE_DUPLICATES HEADER_DIRECTORIES)
 
 # Find the libopenshot-audio.so (check env var first)
 find_library(LIBOPENSHOT_AUDIO_LIBRARY
@@ -48,9 +29,7 @@ find_library(LIBOPENSHOT_AUDIO_LIBRARY
 set(LIBOPENSHOT_AUDIO_LIBRARIES ${LIBOPENSHOT_AUDIO_LIBRARY})
 set(LIBOPENSHOT_AUDIO_LIBRARY ${LIBOPENSHOT_AUDIO_LIBRARIES})
 
-# Seems to work fine with just the base dir (rather than all the actual include folders)
-set(LIBOPENSHOT_AUDIO_INCLUDE_DIR ${LIBOPENSHOT_AUDIO_BASE_DIR} )
-set(LIBOPENSHOT_AUDIO_INCLUDE_DIRS ${LIBOPENSHOT_AUDIO_BASE_DIR} )
+set(LIBOPENSHOT_AUDIO_INCLUDE_DIRS ${LIBOPENSHOT_AUDIO_INCLUDE_DIR} )
 
 include(FindPackageHandleStandardArgs)
 # handle the QUIETLY and REQUIRED arguments and set LIBOPENSHOT_AUDIO_FOUND to TRUE

--- a/include/AudioBufferSource.h
+++ b/include/AudioBufferSource.h
@@ -37,7 +37,7 @@
 #endif
 
 #include <iomanip>
-#include "JuceLibraryCode/JuceHeader.h"
+#include "JuceHeader.h"
 
 using namespace std;
 

--- a/include/AudioReaderSource.h
+++ b/include/AudioReaderSource.h
@@ -37,8 +37,8 @@
 #endif
 
 #include <iomanip>
-#include "JuceHeader.h"
 #include "ReaderBase.h"
+#include "JuceHeader.h"
 
 using namespace std;
 

--- a/include/AudioReaderSource.h
+++ b/include/AudioReaderSource.h
@@ -37,7 +37,7 @@
 #endif
 
 #include <iomanip>
-#include "JuceLibraryCode/JuceHeader.h"
+#include "JuceHeader.h"
 #include "ReaderBase.h"
 
 using namespace std;

--- a/include/AudioResampler.h
+++ b/include/AudioResampler.h
@@ -38,7 +38,7 @@
 	#define _NDEBUG
 #endif
 
-#include "JuceLibraryCode/JuceHeader.h"
+#include "JuceHeader.h"
 #include "AudioBufferSource.h"
 #include "Exceptions.h"
 

--- a/include/AudioResampler.h
+++ b/include/AudioResampler.h
@@ -38,9 +38,9 @@
 	#define _NDEBUG
 #endif
 
-#include "JuceHeader.h"
 #include "AudioBufferSource.h"
 #include "Exceptions.h"
+#include "JuceHeader.h"
 
 namespace openshot {
 

--- a/include/Clip.h
+++ b/include/Clip.h
@@ -36,7 +36,7 @@
 #include <memory>
 #include <string>
 #include <QtGui/QImage>
-#include "JuceLibraryCode/JuceHeader.h"
+#include "JuceHeader.h"
 #include "AudioResampler.h"
 #include "ClipBase.h"
 #include "Color.h"

--- a/include/Clip.h
+++ b/include/Clip.h
@@ -36,7 +36,6 @@
 #include <memory>
 #include <string>
 #include <QtGui/QImage>
-#include "JuceHeader.h"
 #include "AudioResampler.h"
 #include "ClipBase.h"
 #include "Color.h"
@@ -47,6 +46,7 @@
 #include "Fraction.h"
 #include "KeyFrame.h"
 #include "ReaderBase.h"
+#include "JuceHeader.h"
 
 using namespace std;
 using namespace openshot;

--- a/include/EffectBase.h
+++ b/include/EffectBase.h
@@ -32,8 +32,8 @@
 #include <iomanip>
 #include <memory>
 #include "ClipBase.h"
-#include "Frame.h"
 #include "Json.h"
+#include "Frame.h"
 
 using namespace std;
 

--- a/include/Frame.h
+++ b/include/Frame.h
@@ -56,7 +56,7 @@
 #ifdef USE_IMAGEMAGICK
 	#include "Magick++.h"
 #endif
-#include "JuceLibraryCode/JuceHeader.h"
+#include "JuceHeader.h"
 #include "ChannelLayouts.h"
 #include "AudioBufferSource.h"
 #include "AudioResampler.h"

--- a/include/Frame.h
+++ b/include/Frame.h
@@ -56,11 +56,11 @@
 #ifdef USE_IMAGEMAGICK
 	#include "Magick++.h"
 #endif
-#include "JuceHeader.h"
 #include "ChannelLayouts.h"
 #include "AudioBufferSource.h"
 #include "AudioResampler.h"
 #include "Fraction.h"
+#include "JuceHeader.h"
 
 #pragma SWIG nowarn=362
 using namespace std;

--- a/include/Qt/AudioPlaybackThread.h
+++ b/include/Qt/AudioPlaybackThread.h
@@ -57,12 +57,15 @@ namespace openshot
 	class AudioDeviceManagerSingleton {
 	private:
 		/// Default constructor (Don't allow user to create an instance of this singleton)
-		AudioDeviceManagerSingleton(){};
+		AudioDeviceManagerSingleton(){ initialise_error=""; };
 
 		/// Private variable to keep track of singleton instance
 		static AudioDeviceManagerSingleton * m_pInstance;
 
 	public:
+		/// Error found during JUCE initialise method
+		string initialise_error;
+
 		/// Create or get an instance of this singleton (invoke the class with this method)
 		static AudioDeviceManagerSingleton * Instance(int numChannels);
 
@@ -78,52 +81,55 @@ namespace openshot
      */
     class AudioPlaybackThread : Thread
     {
-	AudioSourcePlayer player;
-	AudioTransportSource transport;
-	MixerAudioSource mixer;
-	AudioReaderSource *source;
-	double sampleRate;
-	int numChannels;
-	WaitableEvent play;
-	WaitableEvent played;
-	int buffer_size;
-	bool is_playing;
-	SafeTimeSliceThread time_thread;
-	
-	/// Constructor
-	AudioPlaybackThread();
-	/// Destructor
-	~AudioPlaybackThread();
+		AudioSourcePlayer player;
+		AudioTransportSource transport;
+		MixerAudioSource mixer;
+		AudioReaderSource *source;
+		double sampleRate;
+		int numChannels;
+		WaitableEvent play;
+		WaitableEvent played;
+		int buffer_size;
+		bool is_playing;
+		SafeTimeSliceThread time_thread;
 
-	/// Set the current thread's reader
-	void Reader(ReaderBase *reader);
+		/// Constructor
+		AudioPlaybackThread();
+		/// Destructor
+		~AudioPlaybackThread();
 
-	/// Get the current frame object (which is filling the buffer)
-	std::shared_ptr<Frame> getFrame();
+		/// Set the current thread's reader
+		void Reader(ReaderBase *reader);
 
-	/// Get the current frame number being played
-	int64_t getCurrentFramePosition();
+		/// Get the current frame object (which is filling the buffer)
+		std::shared_ptr<Frame> getFrame();
 
-	/// Play the audio
-	void Play();
+		/// Get the current frame number being played
+		int64_t getCurrentFramePosition();
 
-	/// Seek the audio thread
-	void Seek(int64_t new_position);
+		/// Play the audio
+		void Play();
 
-	/// Stop the audio playback
-	void Stop();
+		/// Seek the audio thread
+		void Seek(int64_t new_position);
 
-	/// Start thread
-	void run();
-	
-    /// Set Speed (The speed and direction to playback a reader (1=normal, 2=fast, 3=faster, -1=rewind, etc...)
-    void setSpeed(int new_speed) { if (source) source->setSpeed(new_speed); }
+		/// Stop the audio playback
+		void Stop();
 
-    /// Get Speed (The speed and direction to playback a reader (1=normal, 2=fast, 3=faster, -1=rewind, etc...)
-    int getSpeed() const { if (source) return source->getSpeed(); else return 1; }
+		/// Start thread
+		void run();
 
-	friend class PlayerPrivate;
-	friend class QtPlayer;
+		/// Set Speed (The speed and direction to playback a reader (1=normal, 2=fast, 3=faster, -1=rewind, etc...)
+		void setSpeed(int new_speed) { if (source) source->setSpeed(new_speed); }
+
+		/// Get Speed (The speed and direction to playback a reader (1=normal, 2=fast, 3=faster, -1=rewind, etc...)
+		int getSpeed() const { if (source) return source->getSpeed(); else return 1; }
+
+		/// Get Audio Error (if any)
+		string getError() { return AudioDeviceManagerSingleton::Instance(numChannels)->initialise_error; }
+
+		friend class PlayerPrivate;
+		friend class QtPlayer;
     };
 
 }

--- a/include/QtPlayer.h
+++ b/include/QtPlayer.h
@@ -59,6 +59,9 @@ namespace openshot
 	/// Close audio device
 	void CloseAudioDevice();
 
+	/// Get Error (if any)
+	string GetError();
+
 	/// Play the video
 	void Play();
 	

--- a/include/Settings.h
+++ b/include/Settings.h
@@ -29,7 +29,7 @@
 #define OPENSHOT_SETTINGS_H
 
 
-#include "JuceLibraryCode/JuceHeader.h"
+#include "JuceHeader.h"
 #include <iostream>
 #include <iomanip>
 #include <fstream>

--- a/include/Settings.h
+++ b/include/Settings.h
@@ -29,7 +29,6 @@
 #define OPENSHOT_SETTINGS_H
 
 
-#include "JuceHeader.h"
 #include <iostream>
 #include <iomanip>
 #include <fstream>
@@ -40,6 +39,7 @@
 #include <time.h>
 #include <zmq.hpp>
 #include <unistd.h>
+#include "JuceHeader.h"
 
 
 using namespace std;

--- a/include/ZmqLogger.h
+++ b/include/ZmqLogger.h
@@ -29,7 +29,7 @@
 #define OPENSHOT_LOGGER_H
 
 
-#include "JuceLibraryCode/JuceHeader.h"
+#include "JuceHeader.h"
 #include <iostream>
 #include <iomanip>
 #include <fstream>

--- a/include/ZmqLogger.h
+++ b/include/ZmqLogger.h
@@ -29,7 +29,6 @@
 #define OPENSHOT_LOGGER_H
 
 
-#include "JuceHeader.h"
 #include <iostream>
 #include <iomanip>
 #include <fstream>
@@ -40,6 +39,7 @@
 #include <time.h>
 #include <zmq.hpp>
 #include <unistd.h>
+#include "JuceHeader.h"
 
 
 using namespace std;

--- a/src/Frame.cpp
+++ b/src/Frame.cpp
@@ -953,11 +953,15 @@ void Frame::Play()
 		return;
 
 	AudioDeviceManager deviceManager;
-	deviceManager.initialise (0, /* number of input channels */
+	String error = deviceManager.initialise (0, /* number of input channels */
 	        2, /* number of output channels */
 	        0, /* no XML settings.. */
 	        true  /* select default device on failure */);
-	//deviceManager.playTestSound();
+
+	// Output error (if any)
+	if (error.isNotEmpty()) {
+		cout << "Error on initialise(): " << error.toStdString() << endl;
+	}
 
 	AudioSourcePlayer audioSourcePlayer;
 	deviceManager.addAudioCallback (&audioSourcePlayer);

--- a/src/Qt/AudioPlaybackThread.cpp
+++ b/src/Qt/AudioPlaybackThread.cpp
@@ -42,11 +42,18 @@ namespace openshot
 			m_pInstance = new AudioDeviceManagerSingleton;
 
 			// Initialize audio device only 1 time
-            m_pInstance->audioDeviceManager.initialise (
+			String error = m_pInstance->audioDeviceManager.initialise (
 					0, /* number of input channels */
                     numChannels, /* number of output channels */
 					0, /* no XML settings.. */
 					true  /* select default device on failure */);
+
+			// Persist any errors detected
+			if (error.isNotEmpty()) {
+				m_pInstance->initialise_error = error.toStdString();
+			} else {
+				m_pInstance->initialise_error = "";
+			}
 		}
 
 		return m_pInstance;

--- a/src/QtPlayer.cpp
+++ b/src/QtPlayer.cpp
@@ -59,21 +59,27 @@ void QtPlayer::CloseAudioDevice()
 	AudioDeviceManagerSingleton::Instance(0)->CloseAudioDevice();
 }
 
+// Return any error string during initialization
+string QtPlayer::GetError() {
+	if (reader && threads_started) {
+		// Get error from audio thread (if any)
+		return p->audioPlayback->getError();
+	} else {
+		return "";
+	}
+}
+
 void QtPlayer::SetSource(const std::string &source)
 {
 	FFmpegReader *ffreader = new FFmpegReader(source);
 	ffreader->DisplayInfo();
 
-	//reader = new FrameMapper(ffreader, ffreader->info.fps, PULLDOWN_NONE, ffreader->info.sample_rate, ffreader->info.channels, ffreader->info.channel_layout);
 	reader = new Timeline(ffreader->info.width, ffreader->info.height, ffreader->info.fps, ffreader->info.sample_rate, ffreader->info.channels, ffreader->info.channel_layout);
 	Clip *c = new Clip(source);
 
 	Timeline* tm = (Timeline*)reader;
 	tm->AddClip(c);
 	tm->Open();
-
-//	ZmqLogger::Instance()->Path("/home/jonathan/.openshot_qt/libopenshot.log");
-//	ZmqLogger::Instance()->Enable(true);
 
     // Set the reader
 	Reader(reader);


### PR DESCRIPTION
Some header path changes to libopenshot based on the new JUCE 5 refactor in libopenshot-audio. Also, adding some error persistence when initializing JUCE DeviceManager (if an error occurs, such as a WASAPI Windows error, where the playback and recording device have different sample rates, etc...)