### PR TITLE
Cmake 3.1+ project updates (and 3.12+ SWIG build fixes)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 #
 # @section LICENSE
 #
-# Copyright (c) 2008-2014 OpenShot Studios, LLC
+# Copyright (c) 2008-2019 OpenShot Studios, LLC
 # <http://www.openshotstudios.com/>. This file is part of
 # OpenShot Library (libopenshot), an open-source project dedicated to
 # delivering high quality video editing and animation solutions to the
@@ -59,13 +59,17 @@ STRING(REGEX REPLACE "#define[ ]+OPENSHOT_VERSION_MINOR[ ]+([0-9]+);(.*)" "\\1" 
 STRING(REGEX REPLACE "#define[ ]+OPENSHOT_VERSION_BUILD[ ]+([0-9]+);(.*)" "\\1" BUILD_VERSION "${LINE_BUILD}")
 STRING(REGEX REPLACE "#define[ ]+OPENSHOT_VERSION_SO[ ]+([0-9]+);(.*)" "\\1" SO_VERSION "${LINE_SO}")
 
+message(STATUS "MAJOR Version: ${MAJOR_VERSION}")
+message(STATUS "MINOR Version: ${MINOR_VERSION}")
+message(STATUS "BUILD Version: ${BUILD_VERSION}")
+message(STATUS "SO/API/ABI Version: ${SO_VERSION}")
 message(STATUS "Determining Version Number - done")
 
 ################### SETUP PROJECT ###################
 PROJECT(libopenshot LANGUAGES CXX
         VERSION ${MAJOR_VERSION}.${MINOR_VERSION}.${BUILD_VERSION})
 
-message("\
+message("
 Generating build files for OpenShot
   Building ${PROJECT_NAME} (version ${PROJECT_VERSION})
   SO/API/ABI Version: ${SO_VERSION}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,7 +66,7 @@ message(STATUS "SO/API/ABI Version: ${SO_VERSION}")
 message(STATUS "Determining Version Number - done")
 
 ################### SETUP PROJECT ###################
-PROJECT(libopenshot LANGUAGES CXX
+PROJECT(libopenshot LANGUAGES C CXX
         VERSION ${MAJOR_VERSION}.${MINOR_VERSION}.${BUILD_VERSION})
 
 message("

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,8 +6,8 @@
 #
 # Copyright (c) 2008-2014 OpenShot Studios, LLC
 # <http://www.openshotstudios.com/>. This file is part of
-# OpenShot Library (libopenshot), an open-source project dedicated to 
-# delivering high quality video editing and animation solutions to the 
+# OpenShot Library (libopenshot), an open-source project dedicated to
+# delivering high quality video editing and animation solutions to the
 # world. For more information visit <http://www.openshot.org/>.
 #
 # OpenShot Library (libopenshot) is free software: you can redistribute it
@@ -24,24 +24,29 @@
 # along with OpenShot Library. If not, see <http://www.gnu.org/licenses/>.
 ################################################################################
 
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.1...3.14 FATAL_ERROR)
 
-MESSAGE("--------------------------------------------------------------")
-MESSAGE("Welcome to the OpenShot Build System! CMake will now check for all required build")
-MESSAGE("dependencies and notify you of any missing files or other issues. If you have any")
-MESSAGE("questions or issues, please visit <http://www.openshot.org/>.")
+message("\
+-----------------------------------------------------------------
+          Welcome to the OpenShot Build System!
+
+CMake will now check libopenshot's build dependencies and inform
+you of any missing files or other issues.
+
+For more information, please visit <http://www.openshot.org/>.
+-----------------------------------------------------------------")
 
 ################ ADD CMAKE MODULES ##################
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/Modules")
 
 ################ GET VERSION INFORMATION FROM VERSION.H ##################
-MESSAGE("--------------------------------------------------------------")
-MESSAGE("Determining Version Number (from Version.h file)")
+message(STATUS "Determining Version Number (from Version.h file)")
 
 #### Get the lines related to libopenshot version from the Version.h header
-file(STRINGS ${CMAKE_CURRENT_SOURCE_DIR}/include/Version.h OPENSHOT_VERSION_LINES
-  REGEX "#define[ ]+OPENSHOT_VERSION_.*[0-9]+;.*")
-  
+file(STRINGS ${CMAKE_CURRENT_SOURCE_DIR}/include/Version.h
+     OPENSHOT_VERSION_LINES
+     REGEX "#define[ ]+OPENSHOT_VERSION_.*[0-9]+;.*")
+
 #### Set each line into it's own variable
 list (GET OPENSHOT_VERSION_LINES 0 LINE_MAJOR)
 list (GET OPENSHOT_VERSION_LINES 1 LINE_MINOR)
@@ -53,22 +58,23 @@ STRING(REGEX REPLACE "#define[ ]+OPENSHOT_VERSION_MAJOR[ ]+([0-9]+);(.*)" "\\1" 
 STRING(REGEX REPLACE "#define[ ]+OPENSHOT_VERSION_MINOR[ ]+([0-9]+);(.*)" "\\1" MINOR_VERSION "${LINE_MINOR}")
 STRING(REGEX REPLACE "#define[ ]+OPENSHOT_VERSION_BUILD[ ]+([0-9]+);(.*)" "\\1" BUILD_VERSION "${LINE_BUILD}")
 STRING(REGEX REPLACE "#define[ ]+OPENSHOT_VERSION_SO[ ]+([0-9]+);(.*)" "\\1" SO_VERSION "${LINE_SO}")
-set(PROJECT_VERSION "${MAJOR_VERSION}.${MINOR_VERSION}.${BUILD_VERSION}")
 
-MESSAGE("--> MAJOR Version: ${MAJOR_VERSION}")
-MESSAGE("--> MINOR Version: ${MINOR_VERSION}")
-MESSAGE("--> BUILD Version: ${BUILD_VERSION}")
-MESSAGE("--> SO/API/ABI Version: ${SO_VERSION}")
-MESSAGE("--> VERSION: ${PROJECT_VERSION}")
-MESSAGE("")
+message(STATUS "Determining Version Number - done")
 
 ################### SETUP PROJECT ###################
-PROJECT(openshot)
-MESSAGE("--------------------------------------------------------------")
-MESSAGE("Generating build files for ${PROJECT_NAME} (${PROJECT_VERSION})")
+PROJECT(libopenshot LANGUAGES CXX
+        VERSION ${MAJOR_VERSION}.${MINOR_VERSION}.${BUILD_VERSION})
+
+message("\
+Generating build files for OpenShot
+  Building ${PROJECT_NAME} (version ${PROJECT_VERSION})
+  SO/API/ABI Version: ${SO_VERSION}
+")
 
 #### Enable C++11 (for std::shared_ptr support)
-set(CMAKE_CXX_FLAGS "-std=c++11")
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 IF (WIN32)
 	SET_PROPERTY(GLOBAL PROPERTY WIN32 "WIN32")

--- a/cmake/Modules/UseDoxygen.cmake
+++ b/cmake/Modules/UseDoxygen.cmake
@@ -1,4 +1,30 @@
-# - Run Doxygen
+# Redistribution and use is allowed according to the terms of the New
+# BSD license:
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+# 3. The name of the author may not be used to endorse or promote products
+#    derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+# IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+# OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+# IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+# NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+# THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#  - Run Doxygen
 #
 # Adds a doxygen target that runs doxygen to generate the html
 # and optionally the LaTeX API documentation.
@@ -48,7 +74,6 @@
 #
 #  Redistribution and use is allowed according to the terms of the New
 #  BSD license.
-#  For details see the accompanying COPYING-CMAKE-SCRIPTS file.
 #
 
 macro(usedoxygen_set_default name value type docstring)
@@ -134,7 +159,9 @@ if(DOXYGEN_FOUND AND DOXYFILE_IN_FOUND)
 
 	configure_file("${DOXYFILE_IN}" "${DOXYFILE}" @ONLY)
 
-	get_target_property(DOC_TARGET doc TYPE)
+	if(TARGET doc)
+		get_target_property(DOC_TARGET doc TYPE)
+	endif()
 	if(NOT DOC_TARGET)
 		add_custom_target(doc)
 	endif()

--- a/src/bindings/python/CMakeLists.txt
+++ b/src/bindings/python/CMakeLists.txt
@@ -6,8 +6,8 @@
 #
 # Copyright (c) 2008-2014 OpenShot Studios, LLC
 # <http://www.openshotstudios.com/>. This file is part of
-# OpenShot Library (libopenshot), an open-source project dedicated to 
-# delivering high quality video editing and animation solutions to the 
+# OpenShot Library (libopenshot), an open-source project dedicated to
+# delivering high quality video editing and animation solutions to the
 # world. For more information visit <http://www.openshot.org/>.
 #
 # OpenShot Library (libopenshot) is free software: you can redistribute it
@@ -29,37 +29,56 @@
 FIND_PACKAGE(SWIG 2.0 REQUIRED)
 INCLUDE(${SWIG_USE_FILE})
 
+### Enable some legacy SWIG behaviors, in newer CMAKE
+cmake_policy(SET CMP0078 OLD)
+cmake_policy(SET CMP0086 OLD)
+
 FIND_PACKAGE(PythonLibs 3)
 FIND_PACKAGE(PythonInterp 3)
-IF (PYTHONLIBS_FOUND)
-	IF (PYTHONINTERP_FOUND)
+if (PYTHONLIBS_FOUND AND PYTHONINTERP_FOUND)
 
-		### Include Python header files
-		INCLUDE_DIRECTORIES(${PYTHON_INCLUDE_PATH})
-		INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR})
-		
-		### Enable C++ support in SWIG
-		SET_SOURCE_FILES_PROPERTIES(openshot.i PROPERTIES CPLUSPLUS ON)
-		SET(CMAKE_SWIG_FLAGS "")
-		
-		### Add the SWIG interface file (which defines all the SWIG methods)
-		SWIG_ADD_MODULE(openshot python openshot.i)
+	### Include Python header files
+	INCLUDE_DIRECTORIES(${PYTHON_INCLUDE_PATH})
+	INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR})
 
-		### Link the new python wrapper library with libopenshot
-		SWIG_LINK_LIBRARIES(openshot ${PYTHON_LIBRARIES} openshot)
+	### Enable C++ support in SWIG
+	set_property(SOURCE openshot.i PROPERTY CPLUSPLUS ON)
+	set_property(SOURCE openshot.i PROPERTY SWIG_MODULE_NAME openshot)
+	SET(CMAKE_SWIG_FLAGS "")
 
-		### FIND THE PYTHON INTERPRETER (AND THE SITE PACKAGES FOLDER)
-		EXECUTE_PROCESS ( COMMAND ${PYTHON_EXECUTABLE} -c "import site; print(site.getsitepackages()[0])"
-		                     OUTPUT_VARIABLE _ABS_PYTHON_MODULE_PATH
-		                     OUTPUT_STRIP_TRAILING_WHITESPACE )
-		GET_FILENAME_COMPONENT(_ABS_PYTHON_MODULE_PATH "${_ABS_PYTHON_MODULE_PATH}" ABSOLUTE)
-		FILE(RELATIVE_PATH _REL_PYTHON_MODULE_PATH ${CMAKE_INSTALL_PREFIX} ${_ABS_PYTHON_MODULE_PATH})
-		SET(PYTHON_MODULE_PATH ${_REL_PYTHON_MODULE_PATH})
+	### Add the SWIG interface file (which defines all the SWIG methods)
+	if (CMAKE_VERSION VERSION_LESS 3.8.0)
+		swig_add_module(pyopenshot python openshot.i)
+	else()
+		swig_add_library(pyopenshot LANGUAGE python SOURCES openshot.i)
+	endif()
 
-		############### INSTALL HEADERS & LIBRARY ################
-		### Install Python bindings
-		INSTALL(TARGETS _openshot DESTINATION ${PYTHON_MODULE_PATH} )
-		INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/openshot.py DESTINATION ${PYTHON_MODULE_PATH} )
+	### Set output name of target
+	set_target_properties(${SWIG_MODULE_pyopenshot_REAL_NAME} PROPERTIES
+	                      PREFIX "_" OUTPUT_NAME "openshot")
 
-	ENDIF(PYTHONINTERP_FOUND)
-ENDIF (PYTHONLIBS_FOUND)
+	### Link the new python wrapper library with libopenshot
+	target_link_libraries(${SWIG_MODULE_pyopenshot_REAL_NAME}
+	                      ${PYTHON_LIBRARIES} openshot)
+
+	### FIND THE PYTHON INTERPRETER (AND THE SITE PACKAGES FOLDER)
+	execute_process ( COMMAND ${PYTHON_EXECUTABLE} -c "\
+from distutils.sysconfig import get_python_lib; \
+print( get_python_lib( plat_specific=True, prefix='${CMAKE_INSTALL_PREFIX}' ) )"
+	                  OUTPUT_VARIABLE _ABS_PYTHON_MODULE_PATH
+	                  OUTPUT_STRIP_TRAILING_WHITESPACE )
+
+	GET_FILENAME_COMPONENT(_ABS_PYTHON_MODULE_PATH
+	                       "${_ABS_PYTHON_MODULE_PATH}" ABSOLUTE)
+	FILE(RELATIVE_PATH _REL_PYTHON_MODULE_PATH
+	     ${CMAKE_INSTALL_PREFIX} ${_ABS_PYTHON_MODULE_PATH})
+	SET(PYTHON_MODULE_PATH ${_REL_PYTHON_MODULE_PATH})
+
+	############### INSTALL HEADERS & LIBRARY ################
+	### Install Python bindings
+	INSTALL(TARGETS ${SWIG_MODULE_pyopenshot_REAL_NAME}
+	        LIBRARY DESTINATION ${PYTHON_MODULE_PATH} )
+	INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/openshot.py
+	        DESTINATION ${PYTHON_MODULE_PATH} )
+
+endif ()

--- a/src/bindings/python/CMakeLists.txt~
+++ b/src/bindings/python/CMakeLists.txt~
@@ -6,8 +6,8 @@
 #
 # Copyright (c) 2008-2014 OpenShot Studios, LLC
 # <http://www.openshotstudios.com/>. This file is part of
-# OpenShot Library (libopenshot), an open-source project dedicated to
-# delivering high quality video editing and animation solutions to the
+# OpenShot Library (libopenshot), an open-source project dedicated to 
+# delivering high quality video editing and animation solutions to the 
 # world. For more information visit <http://www.openshot.org/>.
 #
 # OpenShot Library (libopenshot) is free software: you can redistribute it
@@ -29,14 +29,6 @@
 FIND_PACKAGE(SWIG 2.0 REQUIRED)
 INCLUDE(${SWIG_USE_FILE})
 
-### Enable some legacy SWIG behaviors, in newer CMAKEs
-if (CMAKE_VERSION VERSION_GREATER 3.13)
-	cmake_policy(SET CMP0078 OLD)
-endif()
-if (CMAKE_VERSION VERSION_GREATER 3.14)
-	cmake_policy(SET CMP0086 OLD)
-endif()
-
 FIND_PACKAGE(PythonLibs 3)
 FIND_PACKAGE(PythonInterp 3)
 if (PYTHONLIBS_FOUND AND PYTHONINTERP_FOUND)
@@ -51,31 +43,23 @@ if (PYTHONLIBS_FOUND AND PYTHONINTERP_FOUND)
 	SET(CMAKE_SWIG_FLAGS "")
 
 	### Add the SWIG interface file (which defines all the SWIG methods)
-	if (CMAKE_VERSION VERSION_LESS 3.8.0)
-		swig_add_module(pyopenshot python openshot.i)
-	else()
-		swig_add_library(pyopenshot LANGUAGE python SOURCES openshot.i)
-	endif()
+	swig_add_library(pyopenshot LANGUAGE python SOURCES openshot.i)
 
 	### Set output name of target
 	set_target_properties(${SWIG_MODULE_pyopenshot_REAL_NAME} PROPERTIES
 	                      PREFIX "_" OUTPUT_NAME "openshot")
 
 	### Link the new python wrapper library with libopenshot
-	target_link_libraries(${SWIG_MODULE_pyopenshot_REAL_NAME}
-	                      ${PYTHON_LIBRARIES} openshot)
+	target_link_libraries(${SWIG_MODULE_pyopenshot_REAL_NAME} ${PYTHON_LIBRARIES} openshot)
 
 	### FIND THE PYTHON INTERPRETER (AND THE SITE PACKAGES FOLDER)
-	execute_process ( COMMAND ${PYTHON_EXECUTABLE} -c "\
-from distutils.sysconfig import get_python_lib; \
-print( get_python_lib( plat_specific=True, prefix='${CMAKE_INSTALL_PREFIX}' ) )"
-	                  OUTPUT_VARIABLE _ABS_PYTHON_MODULE_PATH
-	                  OUTPUT_STRIP_TRAILING_WHITESPACE )
+	execute_process ( COMMAND ${PYTHON_EXECUTABLE} -c 
+		"from distutils.sysconfig import get_python_lib; print( get_python_lib( plat_specific=True, prefix='${CMAKE_INSTALL_PREFIX}' ) )"
+		OUTPUT_VARIABLE _ABS_PYTHON_MODULE_PATH
+		OUTPUT_STRIP_TRAILING_WHITESPACE )
 
-	GET_FILENAME_COMPONENT(_ABS_PYTHON_MODULE_PATH
-	                       "${_ABS_PYTHON_MODULE_PATH}" ABSOLUTE)
-	FILE(RELATIVE_PATH _REL_PYTHON_MODULE_PATH
-	     ${CMAKE_INSTALL_PREFIX} ${_ABS_PYTHON_MODULE_PATH})
+	GET_FILENAME_COMPONENT(_ABS_PYTHON_MODULE_PATH "${_ABS_PYTHON_MODULE_PATH}" ABSOLUTE)
+	FILE(RELATIVE_PATH _REL_PYTHON_MODULE_PATH ${CMAKE_INSTALL_PREFIX} ${_ABS_PYTHON_MODULE_PATH})
 	SET(PYTHON_MODULE_PATH ${_REL_PYTHON_MODULE_PATH})
 
 	############### INSTALL HEADERS & LIBRARY ################

--- a/src/bindings/ruby/CMakeLists.txt
+++ b/src/bindings/ruby/CMakeLists.txt
@@ -6,8 +6,8 @@
 #
 # Copyright (c) 2008-2014 OpenShot Studios, LLC
 # <http://www.openshotstudios.com/>. This file is part of
-# OpenShot Library (libopenshot), an open-source project dedicated to 
-# delivering high quality video editing and animation solutions to the 
+# OpenShot Library (libopenshot), an open-source project dedicated to
+# delivering high quality video editing and animation solutions to the
 # world. For more information visit <http://www.openshot.org/>.
 #
 # OpenShot Library (libopenshot) is free software: you can redistribute it
@@ -29,35 +29,49 @@
 FIND_PACKAGE(SWIG 2.0 REQUIRED)
 INCLUDE(${SWIG_USE_FILE})
 
+### Enable some legacy SWIG behaviors, in newer CMAKE
+cmake_policy(SET CMP0078 OLD)
+cmake_policy(SET CMP0086 OLD)
+
 FIND_PACKAGE(Ruby)
 IF (RUBY_FOUND)
 
 	### Include the Ruby header files
 	INCLUDE_DIRECTORIES(${RUBY_INCLUDE_DIRS})
 	INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR})
-	
+
 	### Enable C++ in SWIG
-	SET_SOURCE_FILES_PROPERTIES(openshot.i PROPERTIES CPLUSPLUS ON)
+	set_property(SOURCE openshot.i PROPERTY CPLUSPLUS ON)
+	set_property(SOURCE openshot.i PROPERTY SWIG_MODULE_NAME openshot)
+
 	SET(CMAKE_SWIG_FLAGS "")
 
 	### Add the SWIG interface file (which defines all the SWIG methods)
-	SWIG_ADD_MODULE(rbopenshot ruby openshot.i)
-	
+	if (CMAKE_VERSION VERSION_LESS 3.8.0)
+		swig_add_module(rbopenshot ruby openshot.i)
+	else()
+		swig_add_library(rbopenshot LANGUAGE ruby SOURCES openshot.i)
+	endif()
+
 	### Set name of target (with no prefix, since Ruby does not like that)
-	SET_TARGET_PROPERTIES(rbopenshot PROPERTIES PREFIX "" OUTPUT_NAME "openshot")
+	SET_TARGET_PROPERTIES(${SWIG_MODULE_rbopenshot_REAL_NAME} PROPERTIES
+	                      PREFIX "" OUTPUT_NAME "openshot")
 
 	### Link the new Ruby wrapper library with libopenshot
-	SWIG_LINK_LIBRARIES(rbopenshot ${RUBY_LIBRARY} openshot)
-	
+	target_link_libraries(${SWIG_MODULE_rbopenshot_REAL_NAME}
+	                      ${RUBY_LIBRARY} openshot)
+
 	### FIND THE RUBY INTERPRETER (AND THE LOAD_PATH FOLDER)
-	EXECUTE_PROCESS(COMMAND ${RUBY_EXECUTABLE} -r rbconfig -e "print RbConfig::CONFIG['vendorarchdir']" OUTPUT_VARIABLE RUBY_VENDOR_ARCH_DIR)
+	EXECUTE_PROCESS(COMMAND ${RUBY_EXECUTABLE}
+	                -r rbconfig -e "print RbConfig::CONFIG['vendorarchdir']"
+	                OUTPUT_VARIABLE RUBY_VENDOR_ARCH_DIR)
 	MESSAGE(STATUS "Ruby executable: ${RUBY_EXECUTABLE}")
 	MESSAGE(STATUS "Ruby vendor arch dir: ${RUBY_VENDOR_ARCH_DIR}")
 	MESSAGE(STATUS "Ruby include path: ${RUBY_INCLUDE_PATH}")
-	
 
 	############### INSTALL HEADERS & LIBRARY ################
 	# Install Ruby bindings
-	INSTALL(TARGETS rbopenshot LIBRARY DESTINATION ${RUBY_VENDOR_ARCH_DIR})
-	
+	install(TARGETS ${SWIG_MODULE_rbopenshot_REAL_NAME}
+	        LIBRARY DESTINATION ${RUBY_VENDOR_ARCH_DIR} )
+
 ENDIF (RUBY_FOUND)

--- a/src/bindings/ruby/CMakeLists.txt~
+++ b/src/bindings/ruby/CMakeLists.txt~
@@ -6,8 +6,8 @@
 #
 # Copyright (c) 2008-2014 OpenShot Studios, LLC
 # <http://www.openshotstudios.com/>. This file is part of
-# OpenShot Library (libopenshot), an open-source project dedicated to
-# delivering high quality video editing and animation solutions to the
+# OpenShot Library (libopenshot), an open-source project dedicated to 
+# delivering high quality video editing and animation solutions to the 
 # world. For more information visit <http://www.openshot.org/>.
 #
 # OpenShot Library (libopenshot) is free software: you can redistribute it
@@ -29,21 +29,13 @@
 FIND_PACKAGE(SWIG 2.0 REQUIRED)
 INCLUDE(${SWIG_USE_FILE})
 
-### Enable some legacy SWIG behaviors, in newer CMAKEs
-if (CMAKE_VERSION VERSION_GREATER 3.13)
-	cmake_policy(SET CMP0078 OLD)
-endif()
-if (CMAKE_VERSION VERSION_GREATER 3.14)
-	cmake_policy(SET CMP0086 OLD)
-endif()
-
 FIND_PACKAGE(Ruby)
 IF (RUBY_FOUND)
 
 	### Include the Ruby header files
 	INCLUDE_DIRECTORIES(${RUBY_INCLUDE_DIRS})
 	INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR})
-
+	
 	### Enable C++ in SWIG
 	set_property(SOURCE openshot.i PROPERTY CPLUSPLUS ON)
 	set_property(SOURCE openshot.i PROPERTY SWIG_MODULE_NAME openshot)
@@ -51,31 +43,24 @@ IF (RUBY_FOUND)
 	SET(CMAKE_SWIG_FLAGS "")
 
 	### Add the SWIG interface file (which defines all the SWIG methods)
-	if (CMAKE_VERSION VERSION_LESS 3.8.0)
-		swig_add_module(rbopenshot ruby openshot.i)
-	else()
-		swig_add_library(rbopenshot LANGUAGE ruby SOURCES openshot.i)
-	endif()
-
+	swig_add_library(rbopenshot LANGUAGE ruby SOURCES openshot.i)
+	
 	### Set name of target (with no prefix, since Ruby does not like that)
-	SET_TARGET_PROPERTIES(${SWIG_MODULE_rbopenshot_REAL_NAME} PROPERTIES
-	                      PREFIX "" OUTPUT_NAME "openshot")
+	SET_TARGET_PROPERTIES(${SWIG_MODULE_rbopenshot_REAL_NAME}
+	                       PROPERTIES PREFIX "" OUTPUT_NAME "openshot")
 
 	### Link the new Ruby wrapper library with libopenshot
-	target_link_libraries(${SWIG_MODULE_rbopenshot_REAL_NAME}
-	                      ${RUBY_LIBRARY} openshot)
-
+	target_link_libraries(${SWIG_MODULE_rbopenshot_REAL_NAME} ${RUBY_LIBRARY} openshot)
+	
 	### FIND THE RUBY INTERPRETER (AND THE LOAD_PATH FOLDER)
-	EXECUTE_PROCESS(COMMAND ${RUBY_EXECUTABLE}
-	                -r rbconfig -e "print RbConfig::CONFIG['vendorarchdir']"
-	                OUTPUT_VARIABLE RUBY_VENDOR_ARCH_DIR)
+	EXECUTE_PROCESS(COMMAND ${RUBY_EXECUTABLE} -r rbconfig -e "print RbConfig::CONFIG['vendorarchdir']" OUTPUT_VARIABLE RUBY_VENDOR_ARCH_DIR)
 	MESSAGE(STATUS "Ruby executable: ${RUBY_EXECUTABLE}")
 	MESSAGE(STATUS "Ruby vendor arch dir: ${RUBY_VENDOR_ARCH_DIR}")
 	MESSAGE(STATUS "Ruby include path: ${RUBY_INCLUDE_PATH}")
+	
 
 	############### INSTALL HEADERS & LIBRARY ################
 	# Install Ruby bindings
-	install(TARGETS ${SWIG_MODULE_rbopenshot_REAL_NAME}
-	        LIBRARY DESTINATION ${RUBY_VENDOR_ARCH_DIR} )
-
+	install(TARGETS ${SWIG_MODULE_rbopenshot_REAL_NAME} LIBRARY DESTINATION ${RUBY_VENDOR_ARCH_DIR} )
+	
 ENDIF (RUBY_FOUND)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -24,7 +24,7 @@
 # along with OpenShot Library. If not, see <http://www.gnu.org/licenses/>.
 ################################################################################
 
-SET(TEST_MEDIA_PATH "${openshot_SOURCE_DIR}/src/examples/")
+SET(TEST_MEDIA_PATH "${PROJECT_SOURCE_DIR}/src/examples/")
 
 ################ WINDOWS ##################
 # Set some compiler options for Windows


### PR DESCRIPTION
Like the libopenshot changes, mostly enhancements to use CMake 3.1+ features
- Enforce the minimum CMake version, and set 3.14 as max tested (as it's what I'm using)
  (Using CMake > 3.14 won't fail, instead it'll automatically set compatibility options for new 3.14+ features)
- Update Doxygen module, as (implicitly) removing 2.x compatibility options breaks it
- Configure for C++11 standard in the recommended CMake manner

However, this also contains critical fixes to the `CMakeLists.txt` files for the bindings, which currently will not build under very recent CMake versions, since `SWIG_ADD_MODULE()` is completely deprecated. However, since its replacement `swig_add_library()` didn't even exist until CMake 3.8, that logic is conditionalized e.g.:
```cmake
	### Add the SWIG interface file (which defines all the SWIG methods)
	if (CMAKE_VERSION VERSION_LESS 3.8.0)
		swig_add_module(pyopenshot python openshot.i)
	else()
		swig_add_library(pyopenshot LANGUAGE python SOURCES openshot.i)
	endif()
```
The SWIG tools didn't create real target names until very recently, but now `swig_add_library()` can — and that's why `swig_add_module()` was dropped — but that's functionality we're disabling anyway for backwards compatibility, so instead we use `${SWIG_MODULE_pyopenshot_REAL_NAME}` and similar as the target name everywhere, as that's supposed to be supported on all CMake 3.1...3.14.

Fixes #140