### PR TITLE
Make os_test depend on openshot-test

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -227,4 +227,5 @@ IF (NOT DISABLE_TESTS)
 	#################### MAKE TEST ######################
 	# Hook up the 'make os_test' target to the 'openshot-test' executable
 	ADD_CUSTOM_TARGET(os_test ${CMAKE_CURRENT_BINARY_DIR}/openshot-test)
+	add_dependencies(os_test openshot-test)
 ENDIF (NOT DISABLE_TESTS)


### PR DESCRIPTION
Previously if you ran `make os_test` immediately after generating the build tree, it would run successfully and ignore the fact that the `openshot-test` executable hadn't been built yet.

This change makes the "openshot-test" target a dependency of "os_test", so `make os_test` will trigger the full build process for the test executable, and even the library itself, if they haven't already been run.
