### PR TITLE
Make os_test use openshot-test target

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -226,5 +226,5 @@ IF (NOT DISABLE_TESTS)
 
 	#################### MAKE TEST ######################
 	# Hook up the 'make os_test' target to the 'openshot-test' executable
-	ADD_CUSTOM_TARGET(os_test ${CMAKE_CURRENT_BINARY_DIR}/openshot-test)
+	ADD_CUSTOM_TARGET(os_test COMMAND openshot-test)
 ENDIF (NOT DISABLE_TESTS)


### PR DESCRIPTION
By specifying `COMMAND openshot-test` for the custom target,
the path to the compiled executable is automatically used
and the openshot-test target is automatically made a dependency.