### PR TITLE
Travis CI: Also run `make install`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,8 @@ matrix:
       - cmake -D"CMAKE_BUILD_TYPE:STRING=Debug" ../
       - make VERBOSE=1
       - make os_test
-
+      - make install DESTDIR=dist/
+      
     - language: cpp
       name: "FFmpeg 3"
       before_script:
@@ -31,7 +32,8 @@ matrix:
       - cmake -D"CMAKE_BUILD_TYPE:STRING=Debug" ../
       - make VERBOSE=1
       - make os_test
-
+      - make install DESTDIR=dist/
+      
     - language: cpp
       name: "FFmpeg 4"
       before_script:
@@ -48,3 +50,4 @@ matrix:
       - cmake -D"CMAKE_BUILD_TYPE:STRING=Debug" ../
       - make VERBOSE=1
       - make os_test
+      - make install DESTDIR=dist/


### PR DESCRIPTION
Taking my own suggestion, this adds a `make install` step to all three (overkill, maybe?) Travis builds, using `DESTDIR=dist/` to keep the files local to the build dir. Meant to bring the CMake-managed install logic under CI verification.