### PR TITLE
The default return value is present

### DIFF
--- a/src/KeyFrame.cpp
+++ b/src/KeyFrame.cpp
@@ -336,9 +336,8 @@ bool Keyframe::IsIncreasing(int index)
 			return false;
 		}
 	}
-	else
-		// return default true (since most curves increase)
-		return true;
+	// return default true (since most curves increase)
+	return true;
 }
 
 // Generate JSON string of this object


### PR DESCRIPTION
Remove else so that the default return value is used if no other return was used."else if" in line 334 had no else and therefore in some cases no return value was present.