### PR TITLE
Fix path to Settings.h

### DIFF
--- a/include/OpenMPUtilities.h
+++ b/include/OpenMPUtilities.h
@@ -32,7 +32,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "../include/Settings.h"
+#include "Settings.h"
 
 using namespace std;
 using namespace openshot;


### PR DESCRIPTION
When I build libopenshot and then `sudo make install` it, when I build my own software that uses the library I get an error:

```
/usr/local/include/libopenshot/effects/../OpenMPUtilities.h:35:10: fatal error: ../include/Settings.h: No such file or directory
```

It works with the new path in the PR.