### PR TITLE
free cache in FrameMapper::Close()

### DIFF
--- a/src/FrameMapper.cpp
+++ b/src/FrameMapper.cpp
@@ -651,6 +651,16 @@ void FrameMapper::Close()
 		// Close internal reader
 		reader->Close();
 
+		// Clear the fields & frames lists
+		fields.clear();
+		frames.clear();
+
+		// Mark as dirty
+		is_dirty = true;
+
+		// Clear cache
+		final_cache.Clear();
+
 		// Deallocate resample buffer
 		if (avr) {
 			SWR_CLOSE(avr);


### PR DESCRIPTION
- this hugely reduces the memory used by rendering a timeline
  with a lot of clips
- could be related to issue #239