### PR TITLE
Silence deprecated warnings in ffmpeg 3.x

### DIFF
--- a/include/FFmpegUtilities.h
+++ b/include/FFmpegUtilities.h
@@ -209,9 +209,12 @@
 		#define AV_FORMAT_NEW_STREAM(oc, st_codec, av_codec, av_st) 	av_st = avformat_new_stream(oc, NULL);\
 			if (!av_st) \
 				throw OutOfMemory("Could not allocate memory for the video stream.", path); \
-			c = avcodec_alloc_context3(av_codec); \
-			st_codec = c; \
-			av_st->codecpar->codec_id = av_codec->id;
+			_Pragma ("GCC diagnostic push"); \
+			_Pragma ("GCC diagnostic ignored \"-Wdeprecated-declarations\""); \
+			avcodec_get_context_defaults3(av_st->codec, av_codec); \
+			c = av_st->codec; \
+			_Pragma ("GCC diagnostic pop"); \
+			st_codec = c;
 		#define AV_COPY_PARAMS_FROM_CONTEXT(av_stream, av_codec) avcodec_parameters_from_context(av_stream->codecpar, av_codec);
 	#elif LIBAVFORMAT_VERSION_MAJOR >= 55
 		#define AV_REGISTER_ALL av_register_all();

--- a/src/FFmpegWriter.cpp
+++ b/src/FFmpegWriter.cpp
@@ -992,14 +992,7 @@ AVStream *FFmpegWriter::add_audio_stream() {
 		throw InvalidCodec("A valid audio codec could not be found for this file.", path);
 
 	// Create a new audio stream
-#if (IS_FFMPEG_3_2 && (LIBAVFORMAT_VERSION_MAJOR < 58))
-_Pragma ("GCC diagnostic push")
-_Pragma ("GCC diagnostic ignored \"-Wdeprecated-declarations\"")
-#endif
 	AV_FORMAT_NEW_STREAM(oc, audio_codec, codec, st)
-#if (IS_FFMPEG_3_2 && (LIBAVFORMAT_VERSION_MAJOR < 58))
-_Pragma ("GCC diagnostic pop")
-#endif
 
 	c->codec_id = codec->id;
 #if LIBAVFORMAT_VERSION_MAJOR >= 53
@@ -1082,14 +1075,7 @@ AVStream *FFmpegWriter::add_video_stream() {
 		throw InvalidCodec("A valid video codec could not be found for this file.", path);
 
 	// Create a new video stream
-#if (IS_FFMPEG_3_2 && (LIBAVFORMAT_VERSION_MAJOR < 58))
-_Pragma ("GCC diagnostic push")
-_Pragma ("GCC diagnostic ignored \"-Wdeprecated-declarations\"")
-#endif
 	AV_FORMAT_NEW_STREAM(oc, video_codec, codec, st)
-#if (IS_FFMPEG_3_2 && (LIBAVFORMAT_VERSION_MAJOR < 58))
-_Pragma ("GCC diagnostic pop")
-#endif
 
 	c->codec_id = codec->id;
 #if LIBAVFORMAT_VERSION_MAJOR >= 53

--- a/src/FFmpegWriter.cpp
+++ b/src/FFmpegWriter.cpp
@@ -992,7 +992,14 @@ AVStream *FFmpegWriter::add_audio_stream() {
 		throw InvalidCodec("A valid audio codec could not be found for this file.", path);
 
 	// Create a new audio stream
+#if (IS_FFMPEG_3_2 && (LIBAVFORMAT_VERSION_MAJOR < 58))
+_Pragma ("GCC diagnostic push")
+_Pragma ("GCC diagnostic ignored \"-Wdeprecated-declarations\"")
+#endif
 	AV_FORMAT_NEW_STREAM(oc, audio_codec, codec, st)
+#if (IS_FFMPEG_3_2 && (LIBAVFORMAT_VERSION_MAJOR < 58))
+_Pragma ("GCC diagnostic pop")
+#endif
 
 	c->codec_id = codec->id;
 #if LIBAVFORMAT_VERSION_MAJOR >= 53
@@ -1075,7 +1082,14 @@ AVStream *FFmpegWriter::add_video_stream() {
 		throw InvalidCodec("A valid video codec could not be found for this file.", path);
 
 	// Create a new video stream
+#if (IS_FFMPEG_3_2 && (LIBAVFORMAT_VERSION_MAJOR < 58))
+_Pragma ("GCC diagnostic push")
+_Pragma ("GCC diagnostic ignored \"-Wdeprecated-declarations\"")
+#endif
 	AV_FORMAT_NEW_STREAM(oc, video_codec, codec, st)
+#if (IS_FFMPEG_3_2 && (LIBAVFORMAT_VERSION_MAJOR < 58))
+_Pragma ("GCC diagnostic pop")
+#endif
 
 	c->codec_id = codec->id;
 #if LIBAVFORMAT_VERSION_MAJOR >= 53


### PR DESCRIPTION
The deprecated calls are and will be present in ffmpeg 3.x and later version use other calls. Therefore, the warning is useless and obscures only important warnings.