### PR TITLE
Adding new CheckPixel method to validate certain colors

### DIFF
--- a/include/Frame.h
+++ b/include/Frame.h
@@ -249,6 +249,9 @@ namespace openshot
 		/// Get pixel data (for only a single scan-line)
 		const unsigned char* GetPixels(int row);
 
+		/// Check a specific pixel color value (returns True/False)
+		bool CheckPixel(int row, int col, int red, int green, int blue, int alpha);
+
 		/// Get height of image
 		int GetHeight();
 

--- a/src/FFmpegReader.cpp
+++ b/src/FFmpegReader.cpp
@@ -934,9 +934,7 @@ std::shared_ptr<Frame> FFmpegReader::ReadStream(int64_t requested_frame) {
 							// down processing considerably, but might be more stable on some systems.
 #pragma omp taskwait
 						}
-					} else {
-                        RemoveAVFrame(pFrame);
-                    }
+					}
 
 				}
 				// Audio packet

--- a/src/Frame.cpp
+++ b/src/Frame.cpp
@@ -480,6 +480,28 @@ const unsigned char* Frame::GetPixels(int row)
 	return image->scanLine(row);
 }
 
+// Check a specific pixel color value (returns True/False)
+bool Frame::CheckPixel(int row, int col, int red, int green, int blue, int alpha) {
+	int col_pos = col * 4; // Find column array position
+	if (!image || row < 0 || row >= (height - 1) ||
+		col_pos < 0 || col_pos >= (width - 1) ) {
+		// invalid row / col
+		return false;
+	}
+	// Check pixel color
+	const unsigned char* pixels = GetPixels(row);
+	if (pixels[col_pos + 0] == red &&
+		pixels[col_pos + 1] == green &&
+		pixels[col_pos + 2] == blue &&
+		pixels[col_pos + 3] == alpha) {
+		// Pixel color matches successfully
+		return true;
+	} else {
+		// Pixel color does not match
+		return false;
+	}
+}
+
 // Set Pixel Aspect Ratio
 void Frame::SetPixelRatio(int num, int den)
 {

--- a/src/examples/Example.cpp
+++ b/src/examples/Example.cpp
@@ -38,7 +38,7 @@ int main(int argc, char* argv[]) {
 
 	Settings *s = Settings::Instance();
 	s->HARDWARE_DECODER = 2; // 1 VA-API, 2 NVDEC
-	s->HW_DE_DEVICE_SET = 1;
+	s->HW_DE_DEVICE_SET = 0;
 
     FFmpegReader r9("/home/jonathan/Videos/sintel_trailer-720p.mp4");
     r9.Open();

--- a/tests/FFmpegReader_Tests.cpp
+++ b/tests/FFmpegReader_Tests.cpp
@@ -100,6 +100,10 @@ TEST(FFmpegReader_Check_Video_File)
 	CHECK_EQUAL(0, (int)pixels[pixel_index + 2]);
 	CHECK_EQUAL(255, (int)pixels[pixel_index + 3]);
 
+	// Check pixel function
+	CHECK_EQUAL(true, f->CheckPixel(10, 112, 21, 191, 0, 255));
+	CHECK_EQUAL(false, f->CheckPixel(10, 112, 0, 0, 0, 0));
+
 	// Get frame 1
 	f = r.GetFrame(2);
 
@@ -112,6 +116,10 @@ TEST(FFmpegReader_Check_Video_File)
 	CHECK_EQUAL(96, (int)pixels[pixel_index + 1]);
 	CHECK_EQUAL(188, (int)pixels[pixel_index + 2]);
 	CHECK_EQUAL(255, (int)pixels[pixel_index + 3]);
+
+	// Check pixel function
+	CHECK_EQUAL(true, f->CheckPixel(10, 112, 0, 96, 188, 255));
+	CHECK_EQUAL(false, f->CheckPixel(10, 112, 0, 0, 0, 0));
 
 	// Close reader
 	r.Close();


### PR DESCRIPTION
Adding CheckPixel method and fixing a crash with certain hardware decode options enabled (which appears to be a recent regression). Also adding some new unit tests for this new method.