### PR TITLE
Fix version macros in bindings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,7 @@ message(STATUS "Determining Version Number (from Version.h file)")
 #### Get the lines related to libopenshot version from the Version.h header
 file(STRINGS ${CMAKE_CURRENT_SOURCE_DIR}/include/Version.h
      OPENSHOT_VERSION_LINES
-     REGEX "#define[ ]+OPENSHOT_VERSION_.*[0-9]+;.*")
+     REGEX "#define[ ]+OPENSHOT_VERSION_.*[0-9]+.*")
 
 #### Set each line into it's own variable
 list (GET OPENSHOT_VERSION_LINES 0 LINE_MAJOR)
@@ -54,10 +54,10 @@ list (GET OPENSHOT_VERSION_LINES 2 LINE_BUILD)
 list (GET OPENSHOT_VERSION_LINES 3 LINE_SO)
 
 #### Get the version number out of each line
-STRING(REGEX REPLACE "#define[ ]+OPENSHOT_VERSION_MAJOR[ ]+([0-9]+);(.*)" "\\1" MAJOR_VERSION "${LINE_MAJOR}")
-STRING(REGEX REPLACE "#define[ ]+OPENSHOT_VERSION_MINOR[ ]+([0-9]+);(.*)" "\\1" MINOR_VERSION "${LINE_MINOR}")
-STRING(REGEX REPLACE "#define[ ]+OPENSHOT_VERSION_BUILD[ ]+([0-9]+);(.*)" "\\1" BUILD_VERSION "${LINE_BUILD}")
-STRING(REGEX REPLACE "#define[ ]+OPENSHOT_VERSION_SO[ ]+([0-9]+);(.*)" "\\1" SO_VERSION "${LINE_SO}")
+STRING(REGEX REPLACE "#define[ ]+OPENSHOT_VERSION_MAJOR[ ]+([0-9]+)(.*)" "\\1" MAJOR_VERSION "${LINE_MAJOR}")
+STRING(REGEX REPLACE "#define[ ]+OPENSHOT_VERSION_MINOR[ ]+([0-9]+)(.*)" "\\1" MINOR_VERSION "${LINE_MINOR}")
+STRING(REGEX REPLACE "#define[ ]+OPENSHOT_VERSION_BUILD[ ]+([0-9]+)(.*)" "\\1" BUILD_VERSION "${LINE_BUILD}")
+STRING(REGEX REPLACE "#define[ ]+OPENSHOT_VERSION_SO[ ]+([0-9]+)(.*)" "\\1" SO_VERSION "${LINE_SO}")
 
 message(STATUS "MAJOR Version: ${MAJOR_VERSION}")
 message(STATUS "MINOR Version: ${MINOR_VERSION}")

--- a/include/Version.h
+++ b/include/Version.h
@@ -34,12 +34,12 @@
 	#define STRINGIZE(x) STRINGIZE_(x)
 #endif
 
-#define OPENSHOT_VERSION_MAJOR 0;   /// Major version number is incremented when huge features are added or improved.
-#define OPENSHOT_VERSION_MINOR 2;   /// Minor version is incremented when smaller (but still very important) improvements are added.
-#define OPENSHOT_VERSION_BUILD 3;   /// Build number is incremented when minor bug fixes and less important improvements are added.
-#define OPENSHOT_VERSION_SO 17;     /// Shared object version number. This increments any time the API and ABI changes (so old apps will no longer link)
-#define OPENSHOT_VERSION_MAJOR_MINOR STRINGIZE(OPENSHOT_VERSION_MAJOR) "." STRINGIZE(OPENSHOT_VERSION_MINOR); /// A string of the "Major.Minor" version
-#define OPENSHOT_VERSION_ALL STRINGIZE(OPENSHOT_VERSION_MAJOR) "." STRINGIZE(OPENSHOT_VERSION_MINOR) "." STRINGIZE(OPENSHOT_VERSION_BUILD); /// A string of the entire version "Major.Minor.Build"
+#define OPENSHOT_VERSION_MAJOR 0   /// Major version number is incremented when huge features are added or improved.
+#define OPENSHOT_VERSION_MINOR 2   /// Minor version is incremented when smaller (but still very important) improvements are added.
+#define OPENSHOT_VERSION_BUILD 3   /// Build number is incremented when minor bug fixes and less important improvements are added.
+#define OPENSHOT_VERSION_SO 17     /// Shared object version number. This increments any time the API and ABI changes (so old apps will no longer link)
+#define OPENSHOT_VERSION_MAJOR_MINOR STRINGIZE(OPENSHOT_VERSION_MAJOR) "." STRINGIZE(OPENSHOT_VERSION_MINOR) /// A string of the "Major.Minor" version
+#define OPENSHOT_VERSION_ALL STRINGIZE(OPENSHOT_VERSION_MAJOR) "." STRINGIZE(OPENSHOT_VERSION_MINOR) "." STRINGIZE(OPENSHOT_VERSION_BUILD) /// A string of the entire version "Major.Minor.Build"
 
 #include <sstream>
 using namespace std;


### PR DESCRIPTION
The `#define`s for the version information in `include/Version.h` have semicolons at the end, exactly the way `#define`s shouldn't:
https://github.com/OpenShot/libopenshot/blob/0d4ea7fe71e88bcee4a7fd1404bd52c8e2169997/include/Version.h#L37-L42

This doesn't _really_ affect the C++, but when those macros get translated into Python by the bindings, it very much does affect things:
```console
$ # Before
$ python3 -c 'import openshot; print(openshot.OPENSHOT_VERSION_ALL)'
0;.2;.3;
```
This PR removes the semicolons, and adjusts the regular expressions in `CMakeLists.txt` accordingly.
```console
$ # After
$ PYTHONPATH=/home/ferd/rpmbuild/REPOS/libopenshot/build/src/bindings/python
$ python3 -c 'import openshot; print(openshot.OPENSHOT_VERSION_ALL)'
0.2.3

