### PR TITLE
Add 2 new multiplexing presets for mp4, mov files

### DIFF
--- a/src/FFmpegWriter.cpp
+++ b/src/FFmpegWriter.cpp
@@ -38,6 +38,9 @@ using namespace openshot;
 #pragma message "You are compiling only with software encode"
 #endif
 
+// Multiplexer parameters temporary storage
+AVDictionary *mux_dict = NULL;
+
 #if IS_FFMPEG_3_2
 int hw_en_on = 1;					// Is set in UI
 int hw_en_supported = 0;	// Is set by FFmpegWriter
@@ -464,6 +467,17 @@ void FFmpegWriter::SetOption(StreamType stream, string name, string value) {
 
 		ZmqLogger::Instance()->AppendDebugMethod("FFmpegWriter::SetOption (" + (string)name + ")", "stream == VIDEO_STREAM", stream == VIDEO_STREAM, "", -1, "", -1, "", -1, "", -1, "", -1);
 
+	// Muxing dictionary is not part of the codec context.
+	// Just reusing SetOption function to set popular multiplexing presets.
+	} else if (name == "muxing_preset") {
+		if (value == "mp4_faststart") {
+			// 'moov' box to the beginning; only for MOV, MP4
+			av_dict_set(&mux_dict, "movflags", "faststart", 0);
+		} else if (value == "mp4_fragmented") {
+			// write selfcontained fragmented file, minimum length of the fragment 8 sec; only for MOV, MP4
+			av_dict_set(&mux_dict, "movflags", "frag_keyframe", 0);
+			av_dict_set(&mux_dict, "min_frag_duration", "8000000", 0);
+			}
 	} else {
 		throw InvalidOptions("The option is not valid for this codec.", path);
 	}
@@ -511,16 +525,28 @@ void FFmpegWriter::WriteHeader() {
 	snprintf(oc->AV_FILENAME, sizeof(oc->AV_FILENAME), "%s", path.c_str());
 
 	// Write the stream header, if any
-	// TODO: add avoptions / parameters instead of NULL
 
 	// Add general metadata (if any)
 	for (std::map<string, string>::iterator iter = info.metadata.begin(); iter != info.metadata.end(); ++iter) {
 		av_dict_set(&oc->metadata, iter->first.c_str(), iter->second.c_str(), 0);
 	}
 
-	if (avformat_write_header(oc, NULL) != 0) {
+	// Set multiplexing parameters
+	AVDictionary *dict = NULL;
+
+	bool is_mp4 = strcmp(oc->oformat->name, "mp4");
+	bool is_mov = strcmp(oc->oformat->name, "mov");
+	// Set dictionary preset only for MP4 and MOV files
+	if (is_mp4 || is_mov)
+		av_dict_copy(&dict, mux_dict, 0);
+
+	if (avformat_write_header(oc, &dict) != 0) {
 		throw InvalidFile("Could not write header to file.", path);
 	};
+
+	// Free multiplexing dictionaries sets
+	if (dict) av_dict_free(&dict);
+	if (mux_dict) av_dict_free(&mux_dict);
 
 	// Mark as 'written'
 	write_header = true;


### PR DESCRIPTION
Add 2 new multiplexing presets for mp4, mov files:
* mp4_faststart
* mp4_fragmented

The Preset usage from openshot-qt export.py as follows (example):
w.SetOption(openshot.VIDEO_STREAM, "muxing_preset", "mp4_faststart")

YouTube suggest to use streamable file formats to process the uploading
videos faster (by starting its processing when upload not yet complete)
MP4, MOV files export requires additional dictionary keys to be set in
this case.

MP4/MOV is popular, so instead of using external utils, add support for
streamable export directly to OpenShot.

Cons (-):
- The fragmented output requires modern player to playback, otherwise
only first 4-8sec of footage will playback.
- Placing 'moov' box to the begging of the file doing more write operations
to the disk (box moved when file finished).

Pros (+):
+ Fragmented selfcontained mp4 file export allows to
preview the file when encoding is not yet complete, also it requires
slightly less memory for writing, because there is no need to store
whole 'moov' box of mp4 when encoding frames.
+ YouTube starts its processing as soon as first few MB of file was
transferred.

Default setting is none of the muxing options is set.

**Future use and development.**
Later, any custom option may be set by extending _name_ variable
to _name_="muxing_custom", the _value_ to two sub-strings like
_value_="key,value" or similar that can be easily parsed inside SetOption.

Right now no output errors logged because the mentioned dictionary
keys is safe to ignore if set fails. There is no need to throw exception
on this.