### PR TITLE
Crop.h: Remove nonexistent color argument

### DIFF
--- a/include/effects/Crop.h
+++ b/include/effects/Crop.h
@@ -69,7 +69,6 @@ namespace openshot
 
 		/// Default constructor, which takes 4 curves. These curves animate the crop over time.
 		///
-		/// @param color The curve to adjust the color of bars
 		/// @param left The curve to adjust the left bar size (between 0 and 1)
 		/// @param top The curve to adjust the top bar size (between 0 and 1)
 		/// @param right The curve to adjust the right bar size (between 0 and 1)


### PR DESCRIPTION
Doxygen caught this one: the default constructor for the `Crop()` effect doesn't take an argument `color`, though it was documented to.

With the changes in #245, this will eliminate all of the Doxygen warnings when building the docs. Submitting this as a separate PR, though, because it's not really about Doxygen.