### PR TITLE
Add backwards-compatible Imagemagick 7 support

### DIFF
--- a/include/Frame.h
+++ b/include/Frame.h
@@ -53,14 +53,14 @@
 #include <memory>
 #include <unistd.h>
 #include "ZmqLogger.h"
-#ifdef USE_IMAGEMAGICK
-	#include "Magick++.h"
-#endif
 #include "ChannelLayouts.h"
 #include "AudioBufferSource.h"
 #include "AudioResampler.h"
 #include "Fraction.h"
 #include "JuceHeader.h"
+#ifdef USE_IMAGEMAGICK
+	#include "MagickUtilities.h"
+#endif
 
 #pragma SWIG nowarn=362
 using namespace std;

--- a/include/ImageReader.h
+++ b/include/ImageReader.h
@@ -28,6 +28,9 @@
 #ifndef OPENSHOT_IMAGE_READER_H
 #define OPENSHOT_IMAGE_READER_H
 
+// Require ImageMagick support
+#ifdef USE_IMAGEMAGICK
+
 #include "ReaderBase.h"
 
 #include <cmath>
@@ -36,9 +39,9 @@
 #include <omp.h>
 #include <stdio.h>
 #include <memory>
-#include "Magick++.h"
 #include "CacheMemory.h"
 #include "Exceptions.h"
+#include "MagickUtilities.h"
 
 using namespace std;
 
@@ -113,4 +116,5 @@ namespace openshot
 
 }
 
-#endif
+#endif //USE_IMAGEMAGICK
+#endif //OPENSHOT_IMAGE_READER_H

--- a/include/ImageWriter.h
+++ b/include/ImageWriter.h
@@ -32,9 +32,10 @@
  * along with OpenShot Library. If not, see <http://www.gnu.org/licenses/>.
  */
 
-
 #ifndef OPENSHOT_IMAGE_WRITER_H
 #define OPENSHOT_IMAGE_WRITER_H
+
+#ifdef USE_IMAGEMAGICK
 
 #include "ReaderBase.h"
 #include "WriterBase.h"
@@ -44,11 +45,10 @@
 #include <iostream>
 #include <stdio.h>
 #include <unistd.h>
-#include "Magick++.h"
 #include "CacheMemory.h"
 #include "Exceptions.h"
 #include "OpenMPUtilities.h"
-
+#include "MagickUtilities.h"
 
 using namespace std;
 
@@ -145,4 +145,5 @@ namespace openshot
 
 }
 
-#endif
+#endif //USE_IMAGEMAGICK
+#endif //OPENSHOT_IMAGE_WRITER_H

--- a/include/MagickUtilities.h
+++ b/include/MagickUtilities.h
@@ -1,0 +1,61 @@
+/**
+ * @file
+ * @brief Header file for MagickUtilities (IM6/IM7 compatibility overlay)
+ * @author Jonathan Thomas <jonathan@openshot.org>
+ * @author FeRD (Frank Dana) <ferdnyc@gmail.com>
+ */
+
+/* LICENSE
+ *
+ * Copyright (c) 2008-2019 OpenShot Studios, LLC
+ * <http://www.openshotstudios.com/>. This file is part of
+ * OpenShot Library (libopenshot), an open-source project dedicated to
+ * delivering high quality video editing and animation solutions to the
+ * world. For more information visit <http://www.openshot.org/>.
+ *
+ * OpenShot Library (libopenshot) is free software: you can redistribute it
+ * and/or modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * OpenShot Library (libopenshot) is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with OpenShot Library. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef OPENSHOT_MAGICK_UTILITIES_H
+#define OPENSHOT_MAGICK_UTILITIES_H
+
+#ifdef USE_IMAGEMAGICK
+
+    #include "Magick++.h"
+
+    // Determine ImageMagick version, as IM7 isn't fully
+    // backwards compatible
+    #ifndef NEW_MAGICK
+	   #define NEW_MAGICK (MagickLibVersion >= 0x700)
+	#endif
+
+    // IM7: <Magick::Image>->alpha(bool)
+    // IM6: <Magick::Image>->matte(bool)
+    #if NEW_MAGICK
+        #define MAGICK_IMAGE_ALPHA(im, a) im->alpha((a))
+    #else
+        #define MAGICK_IMAGE_ALPHA(im, a) im->matte((a))
+    #endif
+
+    // IM7: vector<Magick::Drawable>
+    // IM6: list<Magick::Drawable>
+    // (both have the push_back() method which is all we use)
+    #if NEW_MAGICK
+        #define MAGICK_DRAWABLE vector<Magick::Drawable>
+    #else
+        #define MAGICK_DRAWABLE list<Magick::Drawable>
+    #endif
+
+#endif
+#endif

--- a/include/TextReader.h
+++ b/include/TextReader.h
@@ -28,6 +28,9 @@
 #ifndef OPENSHOT_TEXT_READER_H
 #define OPENSHOT_TEXT_READER_H
 
+// Require ImageMagick support
+#ifdef USE_IMAGEMAGICK
+
 #include "ReaderBase.h"
 
 #include <cmath>
@@ -36,10 +39,10 @@
 #include <omp.h>
 #include <stdio.h>
 #include <memory>
-#include "Magick++.h"
 #include "CacheMemory.h"
 #include "Enums.h"
 #include "Exceptions.h"
+#include "MagickUtilities.h"
 
 using namespace std;
 
@@ -91,7 +94,7 @@ namespace openshot
 		string text_color;
 		string background_color;
 		std::shared_ptr<Magick::Image> image;
-		list<Magick::Drawable> lines;
+		MAGICK_DRAWABLE lines;
 		bool is_open;
 		GravityType gravity;
 
@@ -144,4 +147,5 @@ namespace openshot
 
 }
 
-#endif
+#endif //USE_IMAGEMAGICK
+#endif //OPENSHOT_TEXT_READER_H

--- a/include/effects/Mask.h
+++ b/include/effects/Mask.h
@@ -25,8 +25,8 @@
  * along with OpenShot Library. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef OPENSHOT_WIPE_EFFECT_H
-#define OPENSHOT_WIPE_EFFECT_H
+#ifndef OPENSHOT_MASK_EFFECT_H
+#define OPENSHOT_MASK_EFFECT_H
 
 #include "../EffectBase.h"
 
@@ -45,6 +45,7 @@
 #include "../QtImageReader.h"
 #include "../ChunkReader.h"
 #ifdef USE_IMAGEMAGICK
+	#include "../MagickUtilities.h"
 	#include "../ImageReader.h"
 #endif
 
@@ -54,7 +55,7 @@ namespace openshot
 {
 
 	/**
-	 * @brief This class uses the ImageMagick++ libraries, to apply alpha (or transparency) masks
+	 * @brief This class uses the image libraries to apply alpha (or transparency) masks
 	 * to any frame. It can also be animated, and used as a powerful Wipe transition.
 	 *
 	 * These masks / wipes can also be combined, such as a transparency mask on top of a clip, which

--- a/src/ImageReader.cpp
+++ b/src/ImageReader.cpp
@@ -25,6 +25,9 @@
  * along with OpenShot Library. If not, see <http://www.gnu.org/licenses/>.
  */
 
+// Require ImageMagick support
+#ifdef USE_IMAGEMAGICK
+
 #include "../include/ImageReader.h"
 
 using namespace openshot;
@@ -59,7 +62,7 @@ void ImageReader::Open()
 
 			// Give image a transparent background color
 			image->backgroundColor(Magick::Color("none"));
-			image->matte(true);
+			MAGICK_IMAGE_ALPHA(image, true);
 		}
 		catch (Magick::Exception e) {
 			// raise exception
@@ -106,7 +109,7 @@ void ImageReader::Close()
 	{
 		// Mark as "closed"
 		is_open = false;
-		
+
 		// Delete the image
 		image.reset();
 	}
@@ -188,3 +191,5 @@ void ImageReader::SetJsonValue(Json::Value root) {
 		Open();
 	}
 }
+
+#endif //USE_IMAGEMAGICK

--- a/src/ImageWriter.cpp
+++ b/src/ImageWriter.cpp
@@ -28,6 +28,9 @@
  * along with OpenShot Library. If not, see <http://www.gnu.org/licenses/>.
  */
 
+//Require ImageMagick support
+#ifdef USE_IMAGEMAGICK
+
 #include "../include/ImageWriter.h"
 
 using namespace openshot;
@@ -97,7 +100,7 @@ void ImageWriter::WriteFrame(std::shared_ptr<Frame> frame)
 	std::shared_ptr<Magick::Image> frame_image = frame->GetMagickImage();
 	frame_image->magick( info.vcodec );
 	frame_image->backgroundColor(Magick::Color("none"));
-	frame_image->matte(true);
+	MAGICK_IMAGE_ALPHA(frame_image, true);
 	frame_image->quality(image_quality);
 	frame_image->animationDelay(info.video_timebase.ToFloat() * 100);
 	frame_image->animationIterations(number_of_loops);
@@ -153,3 +156,4 @@ void ImageWriter::Close()
 	ZmqLogger::Instance()->AppendDebugMethod("ImageWriter::Close", "", -1, "", -1, "", -1, "", -1, "", -1, "", -1);
 }
 
+#endif //USE_IMAGEMAGICK

--- a/src/TextReader.cpp
+++ b/src/TextReader.cpp
@@ -25,6 +25,9 @@
  * along with OpenShot Library. If not, see <http://www.gnu.org/licenses/>.
  */
 
+// Require ImageMagick support
+#ifdef USE_IMAGEMAGICK
+
 #include "../include/TextReader.h"
 
 using namespace openshot;
@@ -254,3 +257,5 @@ void TextReader::SetJsonValue(Json::Value root) {
 		Open();
 	}
 }
+
+#endif //USE_IMAGEMAGICK

--- a/src/effects/Mask.cpp
+++ b/src/effects/Mask.cpp
@@ -234,11 +234,11 @@ void Mask::SetJsonValue(Json::Value root) {
 					reader->SetJsonValue(root["reader"]);
 
 	#ifdef USE_IMAGEMAGICK
-					} else if (type == "ImageReader") {
+				} else if (type == "ImageReader") {
 
-						// Create new reader
-						reader = new ImageReader(root["reader"]["path"].asString());
-						reader->SetJsonValue(root["reader"]);
+					// Create new reader
+					reader = new ImageReader(root["reader"]["path"].asString());
+					reader->SetJsonValue(root["reader"]);
 	#endif
 
 				} else if (type == "QtImageReader") {
@@ -290,4 +290,3 @@ string Mask::PropertiesJSON(int64_t requested_frame) {
 	// Return formatted string
 	return root.toStyledString();
 }
-


### PR DESCRIPTION
This PR is an alternative to #250 by @steils — honestly, it was never my intention to step on anyone's toes with this, and I wouldn't have continued with it if it wasn't already in progress by the time @steils submitted #250. But, it was, and I discovered a couple of things along the way that I thought made it worth continuing with. But I apologize to @steils for duplicating their work.

Just as in #250, this adds ImageMagick 7 compatibility to libopenshot without sacrificing ImageMagick 6 support. In the case of this PR, a new header `imclude/MagickUtilities.h` is created to hold the compatibility `#define`s.

Out of an overabundance of caution, I also wrapped the three headers and the three source files that are ImageMagick-only in `#ifdef USE_IMAGEMAGICK` statements. Even though the various places they're used are also wrapped, and therefore they shouldn't ever be accessed anyway unless ImageMagick support is enabled.

The image-conversion code in `src/Frame.cpp` received the only major changes, which warrant explanation.

When I was reading through the ImageMagick APIs looking for ways to make that code version-agnostic, I discovered `ExportImagePixels()` in the `MagickCore` API, which contains basically _all_ of the same code. That function existed in IM6 and continues to exist in IM7. The API of that function is _**unchanged**_ from IM6 to IM7. So instead of doing the export by hand (and having to account for changes in the underlying API), it uses `MagickCore::ExportImagePixels()` which accounts for all of the API changes for us. 

The big revelation was when I discovered `image->constImage()`, which lets me convert the `Magick::Image` we're working with into a `const MagickCore::Image` that I can pass into `MagickCore::ExportImagePixels()`. 

All in all this means that I was able to replace all of this:
```cpp
    // Iterate through the pixel packets, and load our own buffer
        // Each color needs to be scaled to 8 bit (using the ImageMagick built-in ScaleQuantumToChar function)
        int numcopied = 0;
    Magick::PixelPacket *pixels = new_image->getPixels(0,0, new_image->columns(), new_image->rows());
    for (int n = 0, i = 0; n < new_image->columns() * new_image->rows(); n += 1, i += 4) {
        buffer[i+0] = MagickCore::ScaleQuantumToChar((Magick::Quantum) pixels[n].red);
        buffer[i+1] = MagickCore::ScaleQuantumToChar((Magick::Quantum) pixels[n].green);
        buffer[i+2] = MagickCore::ScaleQuantumToChar((Magick::Quantum) pixels[n].blue);
        buffer[i+3] = 255 - MagickCore::ScaleQuantumToChar((Magick::Quantum) pixels[n].opacity);
        numcopied+=4;
    }
```
with just:
```cpp
        MagickCore::ExceptionInfo exception;
        // TODO: Actually do something, if we get an exception here
        MagickCore::ExportImagePixels(new_image->constImage(), 0, 0, new_image->columns(),
                new_image->rows(), "RGBA", Magick::CharPixel, buffer, &exception);
```

(As you can see, there's a TODO in the code pointing out that `MagickCore::ExportImagePixels()` will populate an `exception` struct if it encounters any problems. Currently the code ignores that possibility, which it should not, but I wasn't clear enough on how exception-handling is actually done in the Frame code to feel safe doing anything with it.)

The new code compiles cleanly under IM6. It compiles cleanly under IM7. The tests in `tests/ImageWriter.cpp`, which DO test this code path via `ImageWriter::WriteFrame()`, run successfully when built against either version of ImageMagick.

Unrelatedly, but because I was in there and caught it, the include guard in `include/effects/Mask.h` was using the identifier `OPENSHOT_WIPE_EFFECT_H`. Which only wasn't a problem because we don't _have_ a wipe effect. Still, I changed it to `OPENSHOT_MASK_EFFECT_H` for safety.