### PR TITLE
Add -no-integrated-cpp for G++ < 9

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,6 +75,13 @@ Generating build files for OpenShot
   SO/API/ABI Version: ${SO_VERSION}
 ")
 
+#### Work around a GCC < 9 bug with handling of _Pragma() in macros
+#### See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=55578
+if ((${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU") AND
+    (${CMAKE_CXX_COMPILER_VERSION} VERSION_LESS "9.0.0"))
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -no-integrated-cpp")
+endif()
+
 #### Enable C++11 (for std::shared_ptr support)
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)


### PR DESCRIPTION
This switches on the compiler option `-no-integrated-cpp` for GCC versions < 9, to work around a bug in the handling of `_Pragma()` directives in macros. This is necessary to make the "preferred" form of the PR #241 fixes (to silence deprecation warnings on some versions of FFmpeg) work with those GCC versions.

See [GCC bug 55578](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=55578) and the discussion at #241 starting from [this comment](https://github.com/OpenShot/libopenshot/pull/241#issuecomment-503786187) for more details.

I tested this on my system, `-no-integrated-cpp` was inserted into the compiler command line with GCC 7.3.0, but was not with GCC 9.1.1. It should never be inserted with any compiler that doesn't have the short identifier "GNU", so it's safe around other build environments.

Facilitates #241