### PR TITLE
Removing duplicate destructor definitions and implementations

### DIFF
--- a/include/CacheBase.h
+++ b/include/CacheBase.h
@@ -63,8 +63,6 @@ namespace openshot {
 		/// @param max_bytes The maximum bytes to allow in the cache. Once exceeded, the cache will purge the oldest frames.
 		CacheBase(int64_t max_bytes);
 
-		virtual ~CacheBase();
-
 		/// @brief Add a Frame to the cache
 		/// @param frame The openshot::Frame object needing to be cached.
 		virtual void Add(std::shared_ptr<Frame> frame) = 0;

--- a/include/ClipBase.h
+++ b/include/ClipBase.h
@@ -72,7 +72,6 @@ namespace openshot {
 
 		/// Constructor for the base clip
 		ClipBase() { };
-		virtual ~ClipBase();
 
 		// Compare a clip using the Position() property
 		bool operator< ( ClipBase& a) { return (Position() < a.Position()); }

--- a/include/ReaderBase.h
+++ b/include/ReaderBase.h
@@ -110,8 +110,6 @@ namespace openshot
 		/// Constructor for the base reader, where many things are initialized.
 	    ReaderBase();
 
-	    virtual ~ReaderBase();
-
 		/// Information about the current media file
 		ReaderInfo info;
 

--- a/src/CacheBase.cpp
+++ b/src/CacheBase.cpp
@@ -45,9 +45,6 @@ CacheBase::CacheBase(int64_t max_bytes) : max_bytes(max_bytes) {
 	cacheCriticalSection = new CriticalSection();
 };
 
-CacheBase::~CacheBase() {
-};
-
 // Set maximum bytes to a different amount based on a ReaderInfo struct
 void CacheBase::SetMaxBytesFromInfo(int64_t number_of_frames, int width, int height, int sample_rate, int channels)
 {

--- a/src/ClipBase.cpp
+++ b/src/ClipBase.cpp
@@ -32,9 +32,6 @@
 
 using namespace openshot;
 
-ClipBase::~ClipBase() {
-}
-
 // Generate Json::JsonValue for this object
 Json::Value ClipBase::JsonValue() {
 

--- a/src/ReaderBase.cpp
+++ b/src/ReaderBase.cpp
@@ -66,9 +66,6 @@ ReaderBase::ReaderBase()
 	parent = NULL;
 }
 
-ReaderBase::~ReaderBase() {
-}
-
 // Display file information
 void ReaderBase::DisplayInfo() {
 	cout << fixed << setprecision(2) << boolalpha;


### PR DESCRIPTION
Removing duplicate destructor definitions and implementations, so virtual destructors will not break on older toolchains. This PR is in response to https://github.com/OpenShot/libopenshot/pull/224.