### PR TITLE
FFmpegUtilities: inline av_make_error_string

### DIFF
--- a/include/FFmpegUtilities.h
+++ b/include/FFmpegUtilities.h
@@ -91,12 +91,11 @@
 	#endif
 
 	// This wraps an unsafe C macro to be C++ compatible function
-	static const std::string av_make_error_string(int errnum)
+	inline static const std::string av_make_error_string(int errnum)
 	{
 		char errbuf[AV_ERROR_MAX_STRING_SIZE];
 		av_strerror(errnum, errbuf, AV_ERROR_MAX_STRING_SIZE);
-		std::string errstring(errbuf);
-		return errstring;
+		return (std::string)errbuf;
 	}
 
 	// Redefine the C macro to use our new C++ function


### PR DESCRIPTION
We've discussed how it would be good to enable `-Wall` when building libopenshot, to take advantage of gcc's sanity checks. (See, for example, [this comment thread](https://github.com/OpenShot/libopenshot/pull/224#discussion_r294090333) on #224.)

Unfortunately, current libopenshot produces a _lot_ of warnings with `-Wall`, some of them repeatedly because they're triggered in headers. This is one of those. As-is, `g++` will complain every time `FFmpegUtilities.h` is included that the `av_make_error_string()` function is unused, since there are no visible calls to it (they're all produced by a macro). Inlining the function causes it to be copied into each implementation where it's used, which gets it out of the header, eliminates those warnings, and arguably represents cleaner code since implementations in header files are considered bad practice in C++.

Specific implementation borrowed from an old ZoneMinder wrapper:
https://github.com/ZoneMinder/zoneminder/blob/222f14523085f996a8d0dd3dd8beea722ea957e1/src/zm_ffmpeg.h#L241