### PR TITLE
Exceptions: catch-by-reference and other cleanup

### DIFF
--- a/include/Exceptions.h
+++ b/include/Exceptions.h
@@ -32,7 +32,6 @@
 #define OPENSHOT_EXCEPTIONS_H
 
 #include <string>
-using namespace std;
 
 namespace openshot {
 
@@ -45,11 +44,11 @@ namespace openshot {
 	class BaseException : public std::exception //: public exception
 	{
 	protected:
-		string m_message;
+		std::string m_message;
 	public:
-		BaseException(string message) : m_message(message) { }
-		virtual ~BaseException() throw () {}
-		virtual const char* what() const throw () {
+		BaseException(std::string message) : m_message(message) { }
+		virtual ~BaseException() noexcept {}
+		virtual const char* what() const noexcept {
 			// return custom message
 			return m_message.c_str();
 		}
@@ -59,13 +58,12 @@ namespace openshot {
 	class ChunkNotFound : public BaseException
 	{
 	public:
-		string file_path;
 		int64_t frame_number;
 		int64_t chunk_number;
 		int64_t chunk_frame;
-		ChunkNotFound(string message, int64_t frame_number, int64_t chunk_number, int64_t chunk_frame)
+		ChunkNotFound(std::string message, int64_t frame_number, int64_t chunk_number, int64_t chunk_frame)
 			: BaseException(message), frame_number(frame_number), chunk_number(chunk_number), chunk_frame(chunk_frame) { }
-		virtual ~ChunkNotFound() throw () {}
+		virtual ~ChunkNotFound() noexcept {}
 	};
 
 
@@ -73,132 +71,129 @@ namespace openshot {
 	class DecklinkError : public BaseException
 	{
 	public:
-		DecklinkError(string message)
+		DecklinkError(std::string message)
 			: BaseException(message) { }
-		virtual ~DecklinkError() throw () {}
+		virtual ~DecklinkError() noexcept {}
 	};
 
 	/// Exception when decoding audio packet
 	class ErrorDecodingAudio : public BaseException
 	{
 	public:
-		string file_path;
 		int64_t frame_number;
-		ErrorDecodingAudio(string message, int64_t frame_number)
+		ErrorDecodingAudio(std::string message, int64_t frame_number)
 			: BaseException(message), frame_number(frame_number) { }
-		virtual ~ErrorDecodingAudio() throw () {}
+		virtual ~ErrorDecodingAudio() noexcept {}
 	};
 
 	/// Exception when encoding audio packet
 	class ErrorEncodingAudio : public BaseException
 	{
 	public:
-		string file_path;
 		int64_t frame_number;
-		ErrorEncodingAudio(string message, int64_t frame_number)
+		ErrorEncodingAudio(std::string message, int64_t frame_number)
 			: BaseException(message), frame_number(frame_number) { }
-		virtual ~ErrorEncodingAudio() throw () {}
+		virtual ~ErrorEncodingAudio() noexcept {}
 	};
 
 	/// Exception when encoding audio packet
 	class ErrorEncodingVideo : public BaseException
 	{
 	public:
-		string file_path;
 		int64_t frame_number;
-		ErrorEncodingVideo(string message, int64_t frame_number)
+		ErrorEncodingVideo(std::string message, int64_t frame_number)
 			: BaseException(message), frame_number(frame_number) { }
-		virtual ~ErrorEncodingVideo() throw () {}
+		virtual ~ErrorEncodingVideo() noexcept {}
 	};
 
 	/// Exception when an invalid # of audio channels are detected
 	class InvalidChannels : public BaseException
 	{
 	public:
-		string file_path;
-		InvalidChannels(string message, string file_path)
+		std::string file_path;
+		InvalidChannels(std::string message, std::string file_path)
 			: BaseException(message), file_path(file_path) { }
-		virtual ~InvalidChannels() throw () {}
+		virtual ~InvalidChannels() noexcept {}
 	};
 
 	/// Exception when no valid codec is found for a file
 	class InvalidCodec : public BaseException
 	{
 	public:
-		string file_path;
-		InvalidCodec(string message, string file_path)
+		std::string file_path;
+		InvalidCodec(std::string message, std::string file_path)
 			: BaseException(message), file_path(file_path) { }
-		virtual ~InvalidCodec() throw () {}
+		virtual ~InvalidCodec() noexcept {}
 	};
 
 	/// Exception for files that can not be found or opened
 	class InvalidFile : public BaseException
 	{
 	public:
-		string file_path;
-		InvalidFile(string message, string file_path)
+		std::string file_path;
+		InvalidFile(std::string message, std::string file_path)
 			: BaseException(message), file_path(file_path) { }
-		virtual ~InvalidFile() throw () {}
+		virtual ~InvalidFile() noexcept {}
 	};
 
 	/// Exception when no valid format is found for a file
 	class InvalidFormat : public BaseException
 	{
 	public:
-		string file_path;
-		InvalidFormat(string message, string file_path)
+		std::string file_path;
+		InvalidFormat(std::string message, std::string file_path)
 			: BaseException(message), file_path(file_path) { }
-		virtual ~InvalidFormat() throw () {}
+		virtual ~InvalidFormat() noexcept {}
 	};
 
 	/// Exception for invalid JSON
 	class InvalidJSON : public BaseException
 	{
 	public:
-		string file_path;
-		InvalidJSON(string message, string file_path)
+		std::string file_path;
+		InvalidJSON(std::string message, std::string file_path)
 			: BaseException(message), file_path(file_path) { }
-		virtual ~InvalidJSON() throw () {}
+		virtual ~InvalidJSON() noexcept {}
 	};
 
 	/// Exception when invalid encoding options are used
 	class InvalidOptions : public BaseException
 	{
 	public:
-		string file_path;
-		InvalidOptions(string message, string file_path)
+		std::string file_path;
+		InvalidOptions(std::string message, std::string file_path)
 			: BaseException(message), file_path(file_path) { }
-		virtual ~InvalidOptions() throw () {}
+		virtual ~InvalidOptions() noexcept {}
 	};
 
 	/// Exception when invalid sample rate is detected during encoding
 	class InvalidSampleRate : public BaseException
 	{
 	public:
-		string file_path;
-		InvalidSampleRate(string message, string file_path)
+		std::string file_path;
+		InvalidSampleRate(std::string message, std::string file_path)
 			: BaseException(message), file_path(file_path) { }
-		virtual ~InvalidSampleRate() throw () {}
+		virtual ~InvalidSampleRate() noexcept {}
 	};
 
 	/// Exception for missing JSON Change key
 	class InvalidJSONKey : public BaseException
 	{
 	public:
-		string json;
-		InvalidJSONKey(string message, string json)
+		std::string json;
+		InvalidJSONKey(std::string message, std::string json)
 			: BaseException(message), json(json) { }
-		virtual ~InvalidJSONKey() throw () {}
+		virtual ~InvalidJSONKey() noexcept {}
 	};
 
 	/// Exception when no streams are found in the file
 	class NoStreamsFound : public BaseException
 	{
 	public:
-		string file_path;
-		NoStreamsFound(string message, string file_path)
+		std::string file_path;
+		NoStreamsFound(std::string message, std::string file_path)
 			: BaseException(message), file_path(file_path) { }
-		virtual ~NoStreamsFound() throw () {}
+		virtual ~NoStreamsFound() noexcept {}
 	};
 
 	/// Exception for frames that are out of bounds.
@@ -207,9 +202,9 @@ namespace openshot {
 	public:
 		int64_t FrameRequested;
 		int64_t MaxFrames;
-		OutOfBoundsFrame(string message, int64_t frame_requested, int64_t max_frames)
+		OutOfBoundsFrame(std::string message, int64_t frame_requested, int64_t max_frames)
 			: BaseException(message), FrameRequested(frame_requested), MaxFrames(max_frames) { }
-		virtual ~OutOfBoundsFrame() throw () {}
+		virtual ~OutOfBoundsFrame() noexcept {}
 	};
 
 	/// Exception for an out of bounds key-frame point.
@@ -218,59 +213,59 @@ namespace openshot {
 	public:
 		int PointRequested;
 		int MaxPoints;
-		OutOfBoundsPoint(string message, int point_requested, int max_points)
+		OutOfBoundsPoint(std::string message, int point_requested, int max_points)
 			: BaseException(message), PointRequested(point_requested), MaxPoints(max_points) { }
-		virtual ~OutOfBoundsPoint() throw () {}
+		virtual ~OutOfBoundsPoint() noexcept {}
 	};
 
 	/// Exception when memory could not be allocated
 	class OutOfMemory : public BaseException
 	{
 	public:
-		string file_path;
-		OutOfMemory(string message, string file_path)
+		std::string file_path;
+		OutOfMemory(std::string message, std::string file_path)
 			: BaseException(message), file_path(file_path) { }
-		virtual ~OutOfMemory() throw () {}
+		virtual ~OutOfMemory() noexcept {}
 	};
 
 	/// Exception when a reader is closed, and a frame is requested
 	class ReaderClosed : public BaseException
 	{
 	public:
-		string file_path;
-		ReaderClosed(string message, string file_path)
+		std::string file_path;
+		ReaderClosed(std::string message, std::string file_path)
 			: BaseException(message), file_path(file_path) { }
-		virtual ~ReaderClosed() throw () {}
+		virtual ~ReaderClosed() noexcept {}
 	};
 
 	/// Exception when resample fails
 	class ResampleError : public BaseException
 	{
 	public:
-		string file_path;
-		ResampleError(string message, string file_path)
+		std::string file_path;
+		ResampleError(std::string message, std::string file_path)
 			: BaseException(message), file_path(file_path) { }
-		virtual ~ResampleError() throw () {}
+		virtual ~ResampleError() noexcept {}
 	};
 
 	/// Exception when too many seek attempts happen
 	class TooManySeeks : public BaseException
 	{
 	public:
-		string file_path;
-		TooManySeeks(string message, string file_path)
+		std::string file_path;
+		TooManySeeks(std::string message, std::string file_path)
 			: BaseException(message), file_path(file_path) { }
-		virtual ~TooManySeeks() throw () {}
+		virtual ~TooManySeeks() noexcept {}
 	};
 
 	/// Exception when a writer is closed, and a frame is requested
 	class WriterClosed : public BaseException
 	{
 	public:
-		string file_path;
-		WriterClosed(string message, string file_path)
+		std::string file_path;
+		WriterClosed(std::string message, std::string file_path)
 			: BaseException(message), file_path(file_path) { }
-		virtual ~WriterClosed() throw () {}
+		virtual ~WriterClosed() noexcept {}
 	};
 }
 

--- a/src/CacheDisk.cpp
+++ b/src/CacheDisk.cpp
@@ -522,7 +522,7 @@ void CacheDisk::SetJson(string value) {
 		// Set all values that match
 		SetJsonValue(root);
 	}
-	catch (exception e)
+	catch (const std::exception& e)
 	{
 		// Error parsing JSON (or missing keys)
 		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)", "");

--- a/src/CacheMemory.cpp
+++ b/src/CacheMemory.cpp
@@ -377,7 +377,7 @@ void CacheMemory::SetJson(string value) {
 		// Set all values that match
 		SetJsonValue(root);
 	}
-	catch (exception e)
+	catch (const std::exception& e)
 	{
 		// Error parsing JSON (or missing keys)
 		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)", "");

--- a/src/ChunkReader.cpp
+++ b/src/ChunkReader.cpp
@@ -121,7 +121,7 @@ void ChunkReader::load_json()
 		info.audio_timebase.den = root["audio_timebase"]["den"].asInt();
 
 	}
-	catch (exception e)
+	catch (const std::exception& e)
 	{
 		// Error parsing JSON (or missing keys)
 		throw InvalidJSON("JSON could not be parsed (or is invalid).", path);
@@ -235,7 +235,7 @@ std::shared_ptr<Frame> ChunkReader::GetFrame(int64_t requested_frame)
 			local_reader = new FFmpegReader(chunk_video_path);
 			local_reader->Open(); // open reader
 
-		} catch (InvalidFile)
+		} catch (const InvalidFile& e)
 		{
 			// Invalid Chunk (possibly it is not found)
 			throw ChunkNotFound(path, requested_frame, location.number, location.frame);
@@ -298,7 +298,7 @@ void ChunkReader::SetJson(string value) {
 		// Set all values that match
 		SetJsonValue(root);
 	}
-	catch (exception e)
+	catch (const std::exception& e)
 	{
 		// Error parsing JSON (or missing keys)
 		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)", "");

--- a/src/Clip.cpp
+++ b/src/Clip.cpp
@@ -123,7 +123,7 @@ void Clip::init_reader_rotation() {
 		try {
 			float rotate_metadata = strtof(reader->info.metadata["rotate"].c_str(), 0);
 			rotation = Keyframe(rotate_metadata);
-		} catch (exception e) {}
+		} catch (const std::exception& e) {}
 	}
 	else
 		// Default no rotation
@@ -809,7 +809,7 @@ void Clip::SetJson(string value) {
 		// Set all values that match
 		SetJsonValue(root);
 	}
-	catch (exception e)
+	catch (const std::exception& e)
 	{
 		// Error parsing JSON (or missing keys)
 		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)", "");

--- a/src/Color.cpp
+++ b/src/Color.cpp
@@ -125,7 +125,7 @@ void Color::SetJson(string value) {
 		// Set all values that match
 		SetJsonValue(root);
 	}
-	catch (exception e)
+	catch (const std::exception& e)
 	{
 		// Error parsing JSON (or missing keys)
 		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)", "");

--- a/src/Coordinate.cpp
+++ b/src/Coordinate.cpp
@@ -88,7 +88,7 @@ void Coordinate::SetJson(string value) {
 		// Set all values that match
 		SetJsonValue(root);
 	}
-	catch (exception e)
+	catch (const std::exception& e)
 	{
 		// Error parsing JSON (or missing keys)
 		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)", "");

--- a/src/DecklinkReader.cpp
+++ b/src/DecklinkReader.cpp
@@ -283,7 +283,7 @@ void DecklinkReader::SetJson(string value) {
 		// Set all values that match
 		SetJsonValue(root);
 	}
-	catch (exception e)
+	catch (const std::exception& e)
 	{
 		// Error parsing JSON (or missing keys)
 		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)", "");

--- a/src/DummyReader.cpp
+++ b/src/DummyReader.cpp
@@ -161,7 +161,7 @@ void DummyReader::SetJson(string value) {
 		// Set all values that match
 		SetJsonValue(root);
 	}
-	catch (exception e)
+	catch (const std::exception& e)
 	{
 		// Error parsing JSON (or missing keys)
 		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)", "");

--- a/src/EffectBase.cpp
+++ b/src/EffectBase.cpp
@@ -117,7 +117,7 @@ void EffectBase::SetJson(string value) {
 		// Set all values that match
 		SetJsonValue(root);
 	}
-	catch (exception e)
+	catch (const std::exception& e)
 	{
 		// Error parsing JSON (or missing keys)
 		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)", "");

--- a/src/FFmpegReader.cpp
+++ b/src/FFmpegReader.cpp
@@ -2439,7 +2439,7 @@ void FFmpegReader::SetJson(string value) {
 		// Set all values that match
 		SetJsonValue(root);
 	}
-	catch (exception e) {
+	catch (const std::exception& e) {
 		// Error parsing JSON (or missing keys)
 		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)", "");
 	}

--- a/src/FrameMapper.cpp
+++ b/src/FrameMapper.cpp
@@ -712,7 +712,7 @@ void FrameMapper::SetJson(string value) {
 		// Set all values that match
 		SetJsonValue(root);
 	}
-	catch (exception e)
+	catch (const std::exception& e)
 	{
 		// Error parsing JSON (or missing keys)
 		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)", "");

--- a/src/ImageReader.cpp
+++ b/src/ImageReader.cpp
@@ -67,7 +67,7 @@ void ImageReader::Open()
 			image->backgroundColor(Magick::Color("none"));
 			MAGICK_IMAGE_ALPHA(image, true);
 		}
-		catch (Magick::Exception e) {
+		catch (const Magick::Exception& e) {
 			// raise exception
 			throw InvalidFile("File could not be opened.", path);
 		}
@@ -174,7 +174,7 @@ void ImageReader::SetJson(string value) {
 		// Set all values that match
 		SetJsonValue(root);
 	}
-	catch (exception e)
+	catch (const std::exception& e)
 	{
 		// Error parsing JSON (or missing keys)
 		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)", "");

--- a/src/KeyFrame.cpp
+++ b/src/KeyFrame.cpp
@@ -200,7 +200,7 @@ Point Keyframe::GetPreviousPoint(Point p) {
 		else
 			return Points[0];
 
-	} catch (OutOfBoundsPoint) {
+	} catch (const OutOfBoundsPoint& e) {
 		// No previous point
 		return Point(-1, -1);
 	}
@@ -384,7 +384,7 @@ void Keyframe::SetJson(string value) {
 		// Set all values that match
 		SetJsonValue(root);
 	}
-	catch (exception e)
+	catch (const std::exception& e)
 	{
 		// Error parsing JSON (or missing keys)
 		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)", "");

--- a/src/Point.cpp
+++ b/src/Point.cpp
@@ -151,7 +151,7 @@ void Point::SetJson(string value) {
 		// Set all values that match
 		SetJsonValue(root);
 	}
-	catch (exception e)
+	catch (const std::exception& e)
 	{
 		// Error parsing JSON (or missing keys)
 		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)", "");

--- a/src/Profiles.cpp
+++ b/src/Profiles.cpp
@@ -120,7 +120,7 @@ Profile::Profile(string path) {
 		}
 
 	}
-	catch (exception e)
+	catch (const std::exception& e)
 	{
 		// Error parsing profile file
 		throw InvalidFile("Profile could not be found or loaded (or is invalid).", path);
@@ -182,7 +182,7 @@ void Profile::SetJson(string value) {
 		// Set all values that match
 		SetJsonValue(root);
 	}
-	catch (exception e)
+	catch (const std::exception& e)
 	{
 		// Error parsing JSON (or missing keys)
 		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)", "");

--- a/src/QtImageReader.cpp
+++ b/src/QtImageReader.cpp
@@ -304,7 +304,7 @@ void QtImageReader::SetJson(string value) {
 		// Set all values that match
 		SetJsonValue(root);
 	}
-	catch (exception e)
+	catch (const std::exception& e)
 	{
 		// Error parsing JSON (or missing keys)
 		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)", "");

--- a/src/TextReader.cpp
+++ b/src/TextReader.cpp
@@ -235,7 +235,7 @@ void TextReader::SetJson(string value) {
 		// Set all values that match
 		SetJsonValue(root);
 	}
-	catch (exception e)
+	catch (const std::exception& e)
 	{
 		// Error parsing JSON (or missing keys)
 		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)", "");

--- a/src/Timeline.cpp
+++ b/src/Timeline.cpp
@@ -1045,7 +1045,7 @@ void Timeline::SetJson(string value) {
 		// Set all values that match
 		SetJsonValue(root);
 	}
-	catch (exception e)
+	catch (const std::exception& e)
 	{
 		// Error parsing JSON (or missing keys)
 		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)", "");
@@ -1160,7 +1160,7 @@ void Timeline::ApplyJsonDiff(string value) {
 
 		}
 	}
-	catch (exception e)
+	catch (const std::exception& e)
 	{
 		// Error parsing JSON (or missing keys)
 		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)", "");

--- a/src/WriterBase.cpp
+++ b/src/WriterBase.cpp
@@ -214,7 +214,7 @@ void WriterBase::SetJson(string value) {
 		// Set all values that match
 		SetJsonValue(root);
 	}
-	catch (exception e)
+	catch (const std::exception& e)
 	{
 		// Error parsing JSON (or missing keys)
 		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)", "");

--- a/src/effects/Bars.cpp
+++ b/src/effects/Bars.cpp
@@ -156,7 +156,7 @@ void Bars::SetJson(string value) {
 		// Set all values that match
 		SetJsonValue(root);
 	}
-	catch (exception e)
+	catch (const std::exception& e)
 	{
 		// Error parsing JSON (or missing keys)
 		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)", "");

--- a/src/effects/Blur.cpp
+++ b/src/effects/Blur.cpp
@@ -293,7 +293,7 @@ void Blur::SetJson(string value) {
 		// Set all values that match
 		SetJsonValue(root);
 	}
-	catch (exception e)
+	catch (const std::exception& e)
 	{
 		// Error parsing JSON (or missing keys)
 		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)", "");

--- a/src/effects/Brightness.cpp
+++ b/src/effects/Brightness.cpp
@@ -147,7 +147,7 @@ void Brightness::SetJson(string value) {
 		// Set all values that match
 		SetJsonValue(root);
 	}
-	catch (exception e)
+	catch (const std::exception& e)
 	{
 		// Error parsing JSON (or missing keys)
 		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)", "");

--- a/src/effects/ChromaKey.cpp
+++ b/src/effects/ChromaKey.cpp
@@ -140,7 +140,7 @@ void ChromaKey::SetJson(string value) {
 		// Set all values that match
 		SetJsonValue(root);
 	}
-	catch (exception e)
+	catch (const std::exception& e)
 	{
 		// Error parsing JSON (or missing keys)
 		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)", "");

--- a/src/effects/ColorShift.cpp
+++ b/src/effects/ColorShift.cpp
@@ -239,7 +239,7 @@ void ColorShift::SetJson(string value) {
 		// Set all values that match
 		SetJsonValue(root);
 	}
-	catch (exception e)
+	catch (const std::exception& e)
 	{
 		// Error parsing JSON (or missing keys)
 		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)", "");

--- a/src/effects/Crop.cpp
+++ b/src/effects/Crop.cpp
@@ -155,7 +155,7 @@ void Crop::SetJson(string value) {
 		// Set all values that match
 		SetJsonValue(root);
 	}
-	catch (exception e)
+	catch (const std::exception& e)
 	{
 		// Error parsing JSON (or missing keys)
 		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)", "");

--- a/src/effects/Deinterlace.cpp
+++ b/src/effects/Deinterlace.cpp
@@ -134,7 +134,7 @@ void Deinterlace::SetJson(string value) {
 		// Set all values that match
 		SetJsonValue(root);
 	}
-	catch (exception e)
+	catch (const std::exception& e)
 	{
 		// Error parsing JSON (or missing keys)
 		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)", "");

--- a/src/effects/Hue.cpp
+++ b/src/effects/Hue.cpp
@@ -141,7 +141,7 @@ void Hue::SetJson(string value) {
 		// Set all values that match
 		SetJsonValue(root);
 	}
-	catch (exception e)
+	catch (const std::exception& e)
 	{
 		// Error parsing JSON (or missing keys)
 		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)", "");

--- a/src/effects/Mask.cpp
+++ b/src/effects/Mask.cpp
@@ -194,7 +194,7 @@ void Mask::SetJson(string value) {
 		// Set all values that match
 		SetJsonValue(root);
 	}
-	catch (exception e)
+	catch (const std::exception& e)
 	{
 		// Error parsing JSON (or missing keys)
 		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)", "");

--- a/src/effects/Negate.cpp
+++ b/src/effects/Negate.cpp
@@ -95,7 +95,7 @@ void Negate::SetJson(string value) {
 		// Set all values that match
 		SetJsonValue(root);
 	}
-	catch (exception e)
+	catch (const std::exception& e)
 	{
 		// Error parsing JSON (or missing keys)
 		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)", "");

--- a/src/effects/Pixelate.cpp
+++ b/src/effects/Pixelate.cpp
@@ -152,7 +152,7 @@ void Pixelate::SetJson(string value) {
 		// Set all values that match
 		SetJsonValue(root);
 	}
-	catch (exception e)
+	catch (const std::exception& e)
 	{
 		// Error parsing JSON (or missing keys)
 		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)", "");

--- a/src/effects/Saturation.cpp
+++ b/src/effects/Saturation.cpp
@@ -152,7 +152,7 @@ void Saturation::SetJson(string value) {
 		// Set all values that match
 		SetJsonValue(root);
 	}
-	catch (exception e)
+	catch (const std::exception& e)
 	{
 		// Error parsing JSON (or missing keys)
 		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)", "");

--- a/src/effects/Shift.cpp
+++ b/src/effects/Shift.cpp
@@ -172,7 +172,7 @@ void Shift::SetJson(string value) {
 		// Set all values that match
 		SetJsonValue(root);
 	}
-	catch (exception e)
+	catch (const std::exception& e)
 	{
 		// Error parsing JSON (or missing keys)
 		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)", "");

--- a/src/effects/Wave.cpp
+++ b/src/effects/Wave.cpp
@@ -155,7 +155,7 @@ void Wave::SetJson(string value) {
 		// Set all values that match
 		SetJsonValue(root);
 	}
-	catch (exception e)
+	catch (const std::exception& e)
 	{
 		// Error parsing JSON (or missing keys)
 		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)", "");

--- a/tests/Clip_Tests.cpp
+++ b/tests/Clip_Tests.cpp
@@ -128,7 +128,7 @@ TEST(Clip_Properties)
 		CHECK_EQUAL(true, root["alpha"]["keyframe"].asBool());
 
 	}
-	catch (exception e)
+	catch (const std::exception& e)
 	{
 		// Error parsing JSON (or missing keys)
 		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)", "");
@@ -153,7 +153,7 @@ TEST(Clip_Properties)
 		CHECK_EQUAL(false, root["alpha"]["keyframe"].asBool());
 
 	}
-	catch (exception e)
+	catch (const std::exception& e)
 	{
 		// Error parsing JSON (or missing keys)
 		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)", "");
@@ -177,7 +177,7 @@ TEST(Clip_Properties)
 		CHECK_EQUAL(false, root["alpha"]["keyframe"].asBool());
 
 	}
-	catch (exception e)
+	catch (const std::exception& e)
 	{
 		// Error parsing JSON (or missing keys)
 		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)", "");
@@ -202,7 +202,7 @@ TEST(Clip_Properties)
 		CHECK_EQUAL(true, root["alpha"]["keyframe"].asBool());
 
 	}
-	catch (exception e)
+	catch (const std::exception& e)
 	{
 		// Error parsing JSON (or missing keys)
 		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)", "");


### PR DESCRIPTION
Another source of screaming from `g++ -Wall`, best practices in C++11 call for exceptions to be [thrown by value, caught by reference](https://stackoverflow.com/a/2522311/200794) wherever practical. This change replaces all instances of `catch (exception e)` and similar with the preferred `catch (const std::exception& e)`, which saves us from unnecessarily copying the exception class, and eliminates the [slicing](https://www.viva64.com/en/w/v746/) that would otherwise occur due to the use of `std::exception`'s copy constructor on the duplication.

And some more cleanup in the `Exceptions.h` header, to make `-Wall` happy...er.
* Several exception classes had a `file_path` member variable, despite those exceptions never accepting a `file_path` in their constructor. Removed the unused class member.
* Replaced `throw ()` in declarations with `noexcept`, as `throw ()` is [deprecated in c++11](https://en.cppreference.com/w/cpp/language/noexcept_spec).
* Removed `using namespace std;` from the header and added `std::` prefixes where needed (mostly `std::string`)

