### PR TITLE
Exclude all build* files/directories @ root level

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
-build/
-build/*
+/build*
 *.DS_Store
 .pydevproject
 .settings


### PR DESCRIPTION
I tend to create multiple build paths at the root of the project, for testing various configurations. So I'll  have all of `build/`, `build-somebranch/`, `build-otherbranch/`, etc. sitting around. The current `.gitignore` will only ignore a directory named exactly `build`.

This PR updates the `.gitignore` for the repo to exclude `/build*`, meaning _anything_ with a name that starts with `build`, if it's located at the root of the repository tree.