### PR TITLE
Install documentation into DOCDIR/API, if built

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,3 +99,12 @@ add_subdirectory(tests)
 ################### DOCUMENTATION ###################
 # Find Doxygen (used for documentation)
 include(cmake/Modules/UseDoxygen.cmake)
+
+# Install docs, if the user builds them with `make doc`
+install(CODE "MESSAGE(\"Checking for documentation files to install...\")")
+install(CODE "MESSAGE(\"(Compile with 'make doc' command, requires Doxygen)\")")
+
+install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/doc/html/
+        DESTINATION ${CMAKE_INSTALL_DOCDIR}/API
+        MESSAGE_NEVER # Don't spew about file copies
+        OPTIONAL )    # No error if the docs aren't found


### PR DESCRIPTION
This adds the same documentation install logic used in libopenshot-audio (since OpenShot/libopenshot-audio#56, plus the modifications in OpenShot/libopenshot-audio#59), so that running `make install` AFTER `make doc` will pick up the generated Doxygen output an install it into `${CMAKE_INSTALL_DOCDIR}/API`, which is `${CMAKE_INSTALL_PREFIX}/share/doc/libopenshot/API` on most systems.