### PR TITLE
Fix resvg rendering issues for common transitions

### DIFF
--- a/src/QtImageReader.cpp
+++ b/src/QtImageReader.cpp
@@ -229,10 +229,15 @@ std::shared_ptr<Frame> QtImageReader::GetFrame(int64_t requested_frame)
 			path.find(".svgz") != std::string::npos) {
 			ResvgRenderer renderer(QString::fromStdString(path));
 			if (renderer.isValid()) {
+				// Scale SVG size to keep aspect ratio, and fill the max_size as best as possible
+				QSize svg_size(renderer.defaultSize().width(), renderer.defaultSize().height());
+				svg_size.scale(max_width, max_height, Qt::KeepAspectRatio);
 
-				cached_image = std::shared_ptr<QImage>(new QImage(QSize(max_width, max_height), QImage::Format_RGBA8888));
+				// Create empty QImage
+				cached_image = std::shared_ptr<QImage>(new QImage(QSize(svg_size.width(), svg_size.height()), QImage::Format_RGBA8888));
 				cached_image->fill(Qt::transparent);
 
+				// Render SVG into QImage
 				QPainter p(cached_image.get());
 				renderer.render(&p);
 				p.end();

--- a/src/QtImageReader.cpp
+++ b/src/QtImageReader.cpp
@@ -77,12 +77,15 @@ void QtImageReader::Open()
 		// If defined and found in CMake, utilize the libresvg for parsing
 		// SVG files and rasterizing them to QImages.
 		// Only use resvg for files ending in '.svg' or '.svgz'
-		if (path.find(".svg") != std::string::npos ||
-				path.find(".svgz") != std::string::npos) {
+		if (path.find(".svg") != std::string::npos || path.find(".svgz") != std::string::npos) {
 
 			ResvgRenderer renderer(QString::fromStdString(path));
 			if (!renderer.isValid()) {
-				success = false;
+				// Attempt to open file (old method using Qt5 limited SVG parsing)
+				success = image->load(QString::fromStdString(path));
+				if (success) {
+					image = std::shared_ptr<QImage>(new QImage(image->convertToFormat(QImage::Format_RGBA8888)));
+				}
 			} else {
 
 				image = std::shared_ptr<QImage>(new QImage(renderer.defaultSize(), QImage::Format_RGBA8888));
@@ -225,8 +228,7 @@ std::shared_ptr<Frame> QtImageReader::GetFrame(int64_t requested_frame)
 		// If defined and found in CMake, utilize the libresvg for parsing
 		// SVG files and rasterizing them to QImages.
 		// Only use resvg for files ending in '.svg' or '.svgz'
-		if (path.find(".svg") != std::string::npos ||
-			path.find(".svgz") != std::string::npos) {
+		if (path.find(".svg") != std::string::npos || path.find(".svgz") != std::string::npos) {
 			ResvgRenderer renderer(QString::fromStdString(path));
 			if (renderer.isValid()) {
 				// Scale SVG size to keep aspect ratio, and fill the max_size as best as possible
@@ -241,6 +243,10 @@ std::shared_ptr<Frame> QtImageReader::GetFrame(int64_t requested_frame)
 				QPainter p(cached_image.get());
 				renderer.render(&p);
 				p.end();
+			} else {
+				// Resize current rasterized SVG (since we failed to parse original SVG file with resvg)
+				cached_image = std::shared_ptr<QImage>(new QImage(image->scaled(max_width, max_height, Qt::KeepAspectRatio, Qt::SmoothTransformation)));
+				cached_image = std::shared_ptr<QImage>(new QImage(cached_image->convertToFormat(QImage::Format_RGBA8888)));
 			}
 		} else {
 			// We need to resize the original image to a smaller image (for performance reasons)


### PR DESCRIPTION
When using Resvg to render SVG files to pixels, we were accidentally rendering transparency into our original aspect ratio, and thus, common/SVG-based transitions appeared to be letter boxed. This is essentially a regression caused by our implementation of Resvg.

There are times during preview (at smaller resolutions) when transitions appear to be 1 pixel offset, caused by some aliasing. I'm not sure if this is specifically an resvg problem, or something larger related to source aspect ratios / Qt scaling / etc... Some discussion has taken place on this issue here: https://github.com/RazrFalcon/resvg/issues/153. 