### PR TITLE
Clean up allocated memory in JSON code

### DIFF
--- a/src/CacheDisk.cpp
+++ b/src/CacheDisk.cpp
@@ -495,6 +495,8 @@ Json::Value CacheDisk::JsonValue() {
 	string errors;
 	bool success = reader->parse( json_ranges.c_str(),
 	                 json_ranges.c_str() + json_ranges.size(), &ranges, &errors );
+	delete reader;
+
 	if (success)
 		root["ranges"] = ranges;
 
@@ -512,7 +514,9 @@ void CacheDisk::SetJson(string value) {
 
 	string errors;
 	bool success = reader->parse( value.c_str(),
-                 value.c_str() + value.size(), &root, &errors );
+	               value.c_str() + value.size(), &root, &errors );
+ 	delete reader;
+
 	if (!success)
 		// Raise exception
 		throw InvalidJSON("JSON could not be parsed (or is invalid)", "");

--- a/src/CacheMemory.cpp
+++ b/src/CacheMemory.cpp
@@ -345,10 +345,11 @@ Json::Value CacheMemory::JsonValue() {
 	Json::Value ranges;
 	Json::CharReaderBuilder rbuilder;
 	Json::CharReader* reader(rbuilder.newCharReader());
-	
+
 	string errors;
 	bool success = reader->parse( json_ranges.c_str(),
 	                 json_ranges.c_str() + json_ranges.size(), &ranges, &errors );
+	delete reader;
 
 	if (success)
 		root["ranges"] = ranges;
@@ -368,6 +369,7 @@ void CacheMemory::SetJson(string value) {
 	string errors;
 	bool success = reader->parse( value.c_str(),
                  value.c_str() + value.size(), &root, &errors );
+	delete reader;
 	if (!success)
 		// Raise exception
 		throw InvalidJSON("JSON could not be parsed (or is invalid)", "");

--- a/src/ChunkReader.cpp
+++ b/src/ChunkReader.cpp
@@ -285,10 +285,11 @@ void ChunkReader::SetJson(string value) {
 	Json::Value root;
 	Json::CharReaderBuilder rbuilder;
 	Json::CharReader* reader(rbuilder.newCharReader());
-	
+
 	string errors;
 	bool success = reader->parse( value.c_str(),
 	                 value.c_str() + value.size(), &root, &errors );
+	delete reader;
 	if (!success)
 		// Raise exception
 		throw InvalidJSON("JSON could not be parsed (or is invalid)", "");

--- a/src/Clip.cpp
+++ b/src/Clip.cpp
@@ -796,10 +796,12 @@ void Clip::SetJson(string value) {
 	Json::Value root;
 	Json::CharReaderBuilder rbuilder;
 	Json::CharReader* reader(rbuilder.newCharReader());
-	
+
 	string errors;
 	bool success = reader->parse( value.c_str(),
                  value.c_str() + value.size(), &root, &errors );
+	delete reader;
+
 	if (!success)
 		// Raise exception
 		throw InvalidJSON("JSON could not be parsed (or is invalid)", "");

--- a/src/Color.cpp
+++ b/src/Color.cpp
@@ -116,6 +116,8 @@ void Color::SetJson(string value) {
 	string errors;
 	bool success = reader->parse( value.c_str(),
 	                 value.c_str() + value.size(), &root, &errors );
+	 delete reader;
+
 	if (!success)
 		// Raise exception
 		throw InvalidJSON("JSON could not be parsed (or is invalid)", "");

--- a/src/Coordinate.cpp
+++ b/src/Coordinate.cpp
@@ -77,8 +77,10 @@ void Coordinate::SetJson(string value) {
 	Json::CharReader* reader(rbuilder.newCharReader());
 
 	string errors;
-	bool success = reader->parse( value.c_str(), 
+	bool success = reader->parse( value.c_str(),
                  value.c_str() + value.size(), &root, &errors );
+	delete reader;
+
 	if (!success)
 		// Raise exception
 		throw InvalidJSON("JSON could not be parsed (or is invalid)", "");

--- a/src/DecklinkReader.cpp
+++ b/src/DecklinkReader.cpp
@@ -272,8 +272,10 @@ void DecklinkReader::SetJson(string value) {
 	Json::CharReader* reader(rbuilder.newCharReader());
 
 	string errors;
-	bool success = reader->parse( value.c_str(), 
+	bool success = reader->parse( value.c_str(),
                  value.c_str() + value.size(), &root, &errors );
+	delete reader;
+
 	if (!success)
 		// Raise exception
 		throw InvalidJSON("JSON could not be parsed (or is invalid)", "");

--- a/src/DummyReader.cpp
+++ b/src/DummyReader.cpp
@@ -150,8 +150,10 @@ void DummyReader::SetJson(string value) {
 	Json::CharReader* reader(rbuilder.newCharReader());
 
 	string errors;
-	bool success = reader->parse( value.c_str(), 
+	bool success = reader->parse( value.c_str(),
                  value.c_str() + value.size(), &root, &errors );
+	delete reader;
+
 	if (!success)
 		// Raise exception
 		throw InvalidJSON("JSON could not be parsed (or is invalid)", "");

--- a/src/EffectBase.cpp
+++ b/src/EffectBase.cpp
@@ -106,8 +106,10 @@ void EffectBase::SetJson(string value) {
 	Json::CharReader* reader(rbuilder.newCharReader());
 
 	string errors;
-	bool success = reader->parse( value.c_str(), 
+	bool success = reader->parse( value.c_str(),
                  value.c_str() + value.size(), &root, &errors );
+	delete reader;
+
 	if (!success)
 		// Raise exception
 		throw InvalidJSON("JSON could not be parsed (or is invalid)", "");

--- a/src/FFmpegReader.cpp
+++ b/src/FFmpegReader.cpp
@@ -2431,6 +2431,8 @@ void FFmpegReader::SetJson(string value) {
 	string errors;
 	bool success = reader->parse(value.c_str(), value.c_str() + value.size(),
 	                 &root, &errors);
+	delete reader;
+
 	if (!success)
 		// Raise exception
 		throw InvalidJSON("JSON could not be parsed (or is invalid)", "");

--- a/src/FrameMapper.cpp
+++ b/src/FrameMapper.cpp
@@ -701,8 +701,10 @@ void FrameMapper::SetJson(string value) {
 	Json::CharReader* reader(rbuilder.newCharReader());
 
 	string errors;
-	bool success = reader->parse( value.c_str(), 
+	bool success = reader->parse( value.c_str(),
                  value.c_str() + value.size(), &root, &errors );
+	delete reader;
+
 	if (!success)
 		// Raise exception
 		throw InvalidJSON("JSON could not be parsed (or is invalid)", "");

--- a/src/ImageReader.cpp
+++ b/src/ImageReader.cpp
@@ -165,6 +165,8 @@ void ImageReader::SetJson(string value) {
 	string errors;
 	bool success = reader->parse( value.c_str(),
                  value.c_str() + value.size(), &root, &errors );
+	delete reader;
+
 	if (!success)
 		// Raise exception
 		throw InvalidJSON("JSON could not be parsed (or is invalid)", "");

--- a/src/KeyFrame.cpp
+++ b/src/KeyFrame.cpp
@@ -373,8 +373,10 @@ void Keyframe::SetJson(string value) {
 	Json::CharReader* reader(rbuilder.newCharReader());
 
 	string errors;
-	bool success = reader->parse( value.c_str(), 
+	bool success = reader->parse( value.c_str(),
                  value.c_str() + value.size(), &root, &errors );
+	delete reader;
+
 	if (!success)
 		// Raise exception
 		throw InvalidJSON("JSON could not be parsed (or is invalid)", "");

--- a/src/Point.cpp
+++ b/src/Point.cpp
@@ -140,8 +140,10 @@ void Point::SetJson(string value) {
 	Json::CharReader* reader(rbuilder.newCharReader());
 
 	string errors;
-	bool success = reader->parse( value.c_str(), 
+	bool success = reader->parse( value.c_str(),
                  value.c_str() + value.size(), &root, &errors );
+	delete reader;
+
 	if (!success)
 		// Raise exception
 		throw InvalidJSON("JSON could not be parsed (or is invalid)", "");

--- a/src/Profiles.cpp
+++ b/src/Profiles.cpp
@@ -171,8 +171,10 @@ void Profile::SetJson(string value) {
 	Json::CharReader* reader(rbuilder.newCharReader());
 
 	string errors;
-	bool success = reader->parse( value.c_str(), 
+	bool success = reader->parse( value.c_str(),
                  value.c_str() + value.size(), &root, &errors );
+	delete reader;
+
 	if (!success)
 		// Raise exception
 		throw InvalidJSON("JSON could not be parsed (or is invalid)", "");

--- a/src/QtImageReader.cpp
+++ b/src/QtImageReader.cpp
@@ -304,8 +304,10 @@ void QtImageReader::SetJson(string value) {
 	Json::CharReader* reader(rbuilder.newCharReader());
 
 	string errors;
-	bool success = reader->parse( value.c_str(), 
+	bool success = reader->parse( value.c_str(),
                  value.c_str() + value.size(), &root, &errors );
+	delete reader;
+
 	if (!success)
 		// Raise exception
 		throw InvalidJSON("JSON could not be parsed (or is invalid)", "");

--- a/src/TextReader.cpp
+++ b/src/TextReader.cpp
@@ -224,8 +224,10 @@ void TextReader::SetJson(string value) {
 	Json::CharReader* reader(rbuilder.newCharReader());
 
 	string errors;
-	bool success = reader->parse( value.c_str(), 
+	bool success = reader->parse( value.c_str(),
                  value.c_str() + value.size(), &root, &errors );
+	delete reader;
+
 	if (!success)
 		// Raise exception
 		throw InvalidJSON("JSON could not be parsed (or is invalid)", "");

--- a/src/Timeline.cpp
+++ b/src/Timeline.cpp
@@ -1034,8 +1034,10 @@ void Timeline::SetJson(string value) {
 	Json::CharReader* reader(rbuilder.newCharReader());
 
 	string errors;
-	bool success = reader->parse( value.c_str(), 
+	bool success = reader->parse( value.c_str(),
                  value.c_str() + value.size(), &root, &errors );
+	delete reader;
+
 	if (!success)
 		// Raise exception
 		throw InvalidJSON("JSON could not be parsed (or is invalid)", "");
@@ -1131,8 +1133,10 @@ void Timeline::ApplyJsonDiff(string value) {
 	Json::CharReader* reader(rbuilder.newCharReader());
 
 	string errors;
-	bool success = reader->parse( value.c_str(), 
+	bool success = reader->parse( value.c_str(),
                  value.c_str() + value.size(), &root, &errors );
+	delete reader;
+
 	if (!success || !root.isArray())
 		// Raise exception
 		throw InvalidJSON("JSON could not be parsed (or is invalid).", "");

--- a/src/WriterBase.cpp
+++ b/src/WriterBase.cpp
@@ -203,8 +203,10 @@ void WriterBase::SetJson(string value) {
 	Json::CharReader* reader(rbuilder.newCharReader());
 
 	string errors;
-	bool success = reader->parse( value.c_str(), 
+	bool success = reader->parse( value.c_str(),
                  value.c_str() + value.size(), &root, &errors );
+	delete reader;
+
 	if (!success)
 		// Raise exception
 		throw InvalidJSON("JSON could not be parsed (or is invalid)", "");

--- a/src/effects/Bars.cpp
+++ b/src/effects/Bars.cpp
@@ -145,8 +145,10 @@ void Bars::SetJson(string value) {
 	Json::CharReader* reader(rbuilder.newCharReader());
 
 	string errors;
-	bool success = reader->parse( value.c_str(), 
+	bool success = reader->parse( value.c_str(),
                  value.c_str() + value.size(), &root, &errors );
+	delete reader;
+
 	if (!success)
 		// Raise exception
 		throw InvalidJSON("JSON could not be parsed (or is invalid)", "");
@@ -207,4 +209,3 @@ string Bars::PropertiesJSON(int64_t requested_frame) {
 	// Return formatted string
 	return root.toStyledString();
 }
-

--- a/src/effects/Blur.cpp
+++ b/src/effects/Blur.cpp
@@ -282,8 +282,10 @@ void Blur::SetJson(string value) {
 	Json::CharReader* reader(rbuilder.newCharReader());
 
 	string errors;
-	bool success = reader->parse( value.c_str(), 
+	bool success = reader->parse( value.c_str(),
                  value.c_str() + value.size(), &root, &errors );
+	delete reader;
+
 	if (!success)
 		// Raise exception
 		throw InvalidJSON("JSON could not be parsed (or is invalid)", "");
@@ -338,4 +340,3 @@ string Blur::PropertiesJSON(int64_t requested_frame) {
 	// Return formatted string
 	return root.toStyledString();
 }
-

--- a/src/effects/Brightness.cpp
+++ b/src/effects/Brightness.cpp
@@ -136,8 +136,10 @@ void Brightness::SetJson(string value) {
 	Json::CharReader* reader(rbuilder.newCharReader());
 
 	string errors;
-	bool success = reader->parse( value.c_str(), 
+	bool success = reader->parse( value.c_str(),
                  value.c_str() + value.size(), &root, &errors );
+	delete reader;
+
 	if (!success)
 		// Raise exception
 		throw InvalidJSON("JSON could not be parsed (or is invalid)", "");
@@ -186,4 +188,3 @@ string Brightness::PropertiesJSON(int64_t requested_frame) {
 	// Return formatted string
 	return root.toStyledString();
 }
-

--- a/src/effects/ChromaKey.cpp
+++ b/src/effects/ChromaKey.cpp
@@ -129,8 +129,10 @@ void ChromaKey::SetJson(string value) {
 	Json::CharReader* reader(rbuilder.newCharReader());
 
 	string errors;
-	bool success = reader->parse( value.c_str(), 
+	bool success = reader->parse( value.c_str(),
                  value.c_str() + value.size(), &root, &errors );
+	delete reader;
+
 	if (!success)
 		// Raise exception
 		throw InvalidJSON("JSON could not be parsed (or is invalid)", "");

--- a/src/effects/ColorShift.cpp
+++ b/src/effects/ColorShift.cpp
@@ -228,8 +228,10 @@ void ColorShift::SetJson(string value) {
 	Json::CharReader* reader(rbuilder.newCharReader());
 
 	string errors;
-	bool success = reader->parse( value.c_str(), 
+	bool success = reader->parse( value.c_str(),
                  value.c_str() + value.size(), &root, &errors );
+	delete reader;
+
 	if (!success)
 		// Raise exception
 		throw InvalidJSON("JSON could not be parsed (or is invalid)", "");
@@ -296,4 +298,3 @@ string ColorShift::PropertiesJSON(int64_t requested_frame) {
 	// Return formatted string
 	return root.toStyledString();
 }
-

--- a/src/effects/Crop.cpp
+++ b/src/effects/Crop.cpp
@@ -146,6 +146,8 @@ void Crop::SetJson(string value) {
 	string errors;
 	bool success = reader->parse( value.c_str(),
 	                 value.c_str() + value.size(), &root, &errors );
+	delete reader;
+
 	if (!success)
 		// Raise exception
 		throw InvalidJSON("JSON could not be parsed (or is invalid)", "");

--- a/src/effects/Deinterlace.cpp
+++ b/src/effects/Deinterlace.cpp
@@ -123,8 +123,10 @@ void Deinterlace::SetJson(string value) {
 	Json::CharReader* reader(rbuilder.newCharReader());
 
 	string errors;
-	bool success = reader->parse( value.c_str(), 
+	bool success = reader->parse( value.c_str(),
                  value.c_str() + value.size(), &root, &errors );
+	delete reader;
+
 	if (!success)
 		// Raise exception
 		throw InvalidJSON("JSON could not be parsed (or is invalid)", "");

--- a/src/effects/Hue.cpp
+++ b/src/effects/Hue.cpp
@@ -130,8 +130,10 @@ void Hue::SetJson(string value) {
 	Json::CharReader* reader(rbuilder.newCharReader());
 
 	string errors;
-	bool success = reader->parse( value.c_str(), 
+	bool success = reader->parse( value.c_str(),
                  value.c_str() + value.size(), &root, &errors );
+	delete reader;
+
 	if (!success)
 		// Raise exception
 		throw InvalidJSON("JSON could not be parsed (or is invalid)", "");
@@ -177,4 +179,3 @@ string Hue::PropertiesJSON(int64_t requested_frame) {
 	// Return formatted string
 	return root.toStyledString();
 }
-

--- a/src/effects/Mask.cpp
+++ b/src/effects/Mask.cpp
@@ -183,8 +183,10 @@ void Mask::SetJson(string value) {
 	Json::CharReader* reader(rbuilder.newCharReader());
 
 	string errors;
-	bool success = reader->parse( value.c_str(), 
+	bool success = reader->parse( value.c_str(),
                  value.c_str() + value.size(), &root, &errors );
+	delete reader;
+
 	if (!success)
 		// Raise exception
 		throw InvalidJSON("JSON could not be parsed (or is invalid)", "");

--- a/src/effects/Negate.cpp
+++ b/src/effects/Negate.cpp
@@ -84,8 +84,10 @@ void Negate::SetJson(string value) {
 	Json::CharReader* reader(rbuilder.newCharReader());
 
 	string errors;
-	bool success = reader->parse( value.c_str(), 
+	bool success = reader->parse( value.c_str(),
                  value.c_str() + value.size(), &root, &errors );
+	delete reader;
+
 	if (!success)
 		// Raise exception
 		throw InvalidJSON("JSON could not be parsed (or is invalid)", "");

--- a/src/effects/Pixelate.cpp
+++ b/src/effects/Pixelate.cpp
@@ -141,8 +141,10 @@ void Pixelate::SetJson(string value) {
 	Json::CharReader* reader(rbuilder.newCharReader());
 
 	string errors;
-	bool success = reader->parse( value.c_str(), 
+	bool success = reader->parse( value.c_str(),
                  value.c_str() + value.size(), &root, &errors );
+	delete reader;
+
 	if (!success)
 		// Raise exception
 		throw InvalidJSON("JSON could not be parsed (or is invalid)", "");
@@ -200,4 +202,3 @@ string Pixelate::PropertiesJSON(int64_t requested_frame) {
 	// Return formatted string
 	return root.toStyledString();
 }
-

--- a/src/effects/Saturation.cpp
+++ b/src/effects/Saturation.cpp
@@ -141,8 +141,10 @@ void Saturation::SetJson(string value) {
 	Json::CharReader* reader(rbuilder.newCharReader());
 
 	string errors;
-	bool success = reader->parse( value.c_str(), 
+	bool success = reader->parse( value.c_str(),
                  value.c_str() + value.size(), &root, &errors );
+	delete reader;
+
 	if (!success)
 		// Raise exception
 		throw InvalidJSON("JSON could not be parsed (or is invalid)", "");
@@ -188,4 +190,3 @@ string Saturation::PropertiesJSON(int64_t requested_frame) {
 	// Return formatted string
 	return root.toStyledString();
 }
-

--- a/src/effects/Shift.cpp
+++ b/src/effects/Shift.cpp
@@ -161,8 +161,10 @@ void Shift::SetJson(string value) {
 	Json::CharReader* reader(rbuilder.newCharReader());
 
 	string errors;
-	bool success = reader->parse( value.c_str(), 
+	bool success = reader->parse( value.c_str(),
                  value.c_str() + value.size(), &root, &errors );
+	delete reader;
+
 	if (!success)
 		// Raise exception
 		throw InvalidJSON("JSON could not be parsed (or is invalid)", "");
@@ -211,4 +213,3 @@ string Shift::PropertiesJSON(int64_t requested_frame) {
 	// Return formatted string
 	return root.toStyledString();
 }
-

--- a/src/effects/Wave.cpp
+++ b/src/effects/Wave.cpp
@@ -144,8 +144,10 @@ void Wave::SetJson(string value) {
 	Json::CharReader* reader(rbuilder.newCharReader());
 
 	string errors;
-	bool success = reader->parse( value.c_str(), 
+	bool success = reader->parse( value.c_str(),
                  value.c_str() + value.size(), &root, &errors );
+	delete reader;
+
 	if (!success)
 		// Raise exception
 		throw InvalidJSON("JSON could not be parsed (or is invalid)", "");
@@ -203,4 +205,3 @@ string Wave::PropertiesJSON(int64_t requested_frame) {
 	// Return formatted string
 	return root.toStyledString();
 }
-

--- a/tests/Clip_Tests.cpp
+++ b/tests/Clip_Tests.cpp
@@ -117,6 +117,7 @@ TEST(Clip_Properties)
 	string errors;
 	bool success = reader->parse( properties.c_str(),
 	                 properties.c_str() + properties.size(), &root, &errors );
+
 	if (!success)
 		// Raise exception
 		throw InvalidJSON("JSON could not be parsed (or is invalid)", "");
@@ -208,6 +209,9 @@ TEST(Clip_Properties)
 		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)", "");
 	}
 
+
+	// Free up the reader we allocated
+	delete reader;
 }
 
 TEST(Clip_Effects)


### PR DESCRIPTION
It was pointed out that I was being sloppy, in the updated JSON code, and not freeing any of the `Json::CharReader` objects that get allocated all over the place now. This created very, _very_ small memory leaks (less than 2 Kb per allocation) that nevertheless could add up over time.

Running `valgrind` on just the `tests/openshot-test` executable previously (meaning, since the JsonCPP upgrade, but before this PR) would flag 61 instances of a `Json` function leaking memory. After this change, those are **all** eliminated, and leaked memory as reported by valgrind is reduced by nearly 7 Kb. (Hey, I said they were **SMALL** leaks.)

Fixes #271 reported by @laochen.