### PR TITLE
SWIG: Warnings cleanup

### DIFF
--- a/include/Frame.h
+++ b/include/Frame.h
@@ -65,9 +65,6 @@
 	#include "MagickUtilities.h"
 #endif
 
-#pragma SWIG nowarn=362
-using namespace std;
-
 namespace openshot
 {
 	/**
@@ -131,7 +128,7 @@ namespace openshot
 		int width;
 		int height;
 		int sample_rate;
-		string color;
+		std::string color;
 		int64_t max_audio_sample; ///< The max audio sample count added to this frame
 
 		/// Constrain a color value from 0 to 255
@@ -147,13 +144,13 @@ namespace openshot
 		Frame();
 
 		/// Constructor - image only (48kHz audio silence)
-		Frame(int64_t number, int width, int height, string color);
+		Frame(int64_t number, int width, int height, std::string color);
 
 		/// Constructor - audio only (300x200 blank image)
 		Frame(int64_t number, int samples, int channels);
 
 		/// Constructor - image & audio
-		Frame(int64_t number, int width, int height, string color, int samples, int channels);
+		Frame(int64_t number, int width, int height, std::string color, int samples, int channels);
 
 		/// Copy constructor
 		Frame ( const Frame &other );
@@ -165,7 +162,7 @@ namespace openshot
 		virtual ~Frame();
 
 		/// Add (or replace) pixel data to the frame (based on a solid color)
-		void AddColor(int new_width, int new_height, string new_color);
+		void AddColor(int new_width, int new_height, std::string new_color);
 
 		/// Add (or replace) pixel data to the frame
 		void AddImage(int new_width, int new_height, int bytes_per_pixel, QImage::Format type, const unsigned char *pixels_);
@@ -283,7 +280,7 @@ namespace openshot
 		void SampleRate(int orig_sample_rate) { sample_rate = orig_sample_rate; };
 
 		/// Save the frame image to the specified path.  The image format can be BMP, JPG, JPEG, PNG, PPM, XBM, XPM
-		void Save(string path, float scale, string format="PNG", int quality=100);
+		void Save(std::string path, float scale, std::string format="PNG", int quality=100);
 
 		/// Set frame number
 		void SetFrameNumber(int64_t number);
@@ -293,8 +290,8 @@ namespace openshot
 
 		/// Thumbnail the frame image with tons of options to the specified path.  The image format is determined from the extension (i.e. image.PNG, image.JPEG).
 		/// This method allows for masks, overlays, background color, and much more accurate resizing (including padding and centering)
-		void Thumbnail(string path, int new_width, int new_height, string mask_path, string overlay_path,
-				string background_color, bool ignore_aspect, string format="png", int quality=100, float rotate=0.0);
+		void Thumbnail(std::string path, int new_width, int new_height, std::string mask_path, std::string overlay_path,
+				std::string background_color, bool ignore_aspect, std::string format="png", int quality=100, float rotate=0.0);
 
 		/// Play audio samples for this frame
 		void Play();

--- a/src/bindings/python/CMakeLists.txt
+++ b/src/bindings/python/CMakeLists.txt
@@ -50,6 +50,12 @@ if (PYTHONLIBS_FOUND AND PYTHONINTERP_FOUND)
 	set_property(SOURCE openshot.i PROPERTY SWIG_MODULE_NAME openshot)
 	SET(CMAKE_SWIG_FLAGS "")
 
+	### Suppress a ton of warnings in the generated SWIG C++ code
+	set(SWIG_CXX_FLAGS "-Wno-unused-variable -Wno-unused-function -Wno-deprecated-copy -Wno-class-memaccess -Wno-cast-function-type \
+-Wno-unused-parameter -Wno-catch-value -Wno-sign-compare -Wno-ignored-qualifiers")
+	separate_arguments(sw_flags UNIX_COMMAND ${SWIG_CXX_FLAGS})
+	set_property(SOURCE openshot.i PROPERTY GENERATED_COMPILE_OPTIONS ${sw_flags})
+
 	### Add the SWIG interface file (which defines all the SWIG methods)
 	if (CMAKE_VERSION VERSION_LESS 3.8.0)
 		swig_add_module(pyopenshot python openshot.i)
@@ -65,7 +71,7 @@ if (PYTHONLIBS_FOUND AND PYTHONINTERP_FOUND)
 	target_link_libraries(${SWIG_MODULE_pyopenshot_REAL_NAME}
 	                      ${PYTHON_LIBRARIES} openshot)
 
-    ### Check if the following Debian-friendly python module path exists
+	### Check if the following Debian-friendly python module path exists
 	SET(PYTHON_MODULE_PATH "${CMAKE_INSTALL_PREFIX}/lib/python${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}/site-packages")
 	if (NOT EXISTS ${PYTHON_MODULE_PATH})
 

--- a/src/bindings/python/openshot.i
+++ b/src/bindings/python/openshot.i
@@ -27,6 +27,9 @@
 
 %module openshot
 
+/* Suppress warnings about ignored operator= */
+%warnfilter(362);
+
 /* Enable inline documentation */
 %feature("autodoc", "1");
 

--- a/src/bindings/ruby/CMakeLists.txt
+++ b/src/bindings/ruby/CMakeLists.txt
@@ -51,6 +51,11 @@ IF (RUBY_FOUND)
 	set_property(SOURCE openshot.i PROPERTY SWIG_MODULE_NAME openshot)
 
 	SET(CMAKE_SWIG_FLAGS "")
+	### Suppress a ton of warnings in the generated SWIG C++ code
+	set(SWIG_CXX_FLAGS "-Wno-unused-variable -Wno-unused-function -Wno-deprecated-copy -Wno-class-memaccess -Wno-cast-function-type \
+-Wno-unused-parameter -Wno-catch-value -Wno-sign-compare -Wno-ignored-qualifiers")
+	separate_arguments(sw_flags UNIX_COMMAND ${SWIG_CXX_FLAGS})
+	set_property(SOURCE openshot.i PROPERTY GENERATED_COMPILE_OPTIONS ${sw_flags})
 
 	### Add the SWIG interface file (which defines all the SWIG methods)
 	if (CMAKE_VERSION VERSION_LESS 3.8.0)

--- a/src/bindings/ruby/openshot.i
+++ b/src/bindings/ruby/openshot.i
@@ -27,6 +27,9 @@
 
 %module openshot
 
+/* Suppress warnings about ignored operator= */
+%warnfilter(362);
+
 /* Enable inline documentation */
 %feature("autodoc", "1");
 


### PR DESCRIPTION
This PR contains a bunch of changes to the SWIG generation, to make it possible to run with `CMAKE_CXX_FLAGS="-Wall -Wextra"` (and not be bombarded by errors from the generated code).

* Remove a SWIG pragma from `Frame.h` (gcc warns on it)
* Place the equivalent `%warnfilter` in the `openshot.i` files
* Populate `openshot.i` `PROPERTY` `GENERATED_COMPILE_OPTIONS` with flags to disable warning spew in generated SWIG code, if `-Wall` is used

(Also, remove 'using namespace std' from `Frame.h`, and add `std::` prefixes to necessary types.)