### PR TITLE
FindOpenShotAudio version reporting/validation, other fixes

### DIFF
--- a/cmake/Modules/FindOpenShotAudio.cmake
+++ b/cmake/Modules/FindOpenShotAudio.cmake
@@ -5,8 +5,6 @@
 #  LIBOPENSHOT_AUDIO_INCLUDE_DIRS - The juce.h include directories
 #  LIBOPENSHOT_AUDIO_LIBRARIES - The libraries needed to use juce
 
-include(GNUInstallDirs)
-
 if("$ENV{LIBOPENSHOT_AUDIO_DIR}" AND NOT "${OpenShotAudio_FIND_QUIETLY}")
     message(STATUS "Looking for OpenShotAudio in: $ENV{LIBOPENSHOT_AUDIO_DIR}")
 endif()

--- a/cmake/Modules/FindOpenShotAudio.cmake
+++ b/cmake/Modules/FindOpenShotAudio.cmake
@@ -5,34 +5,114 @@
 #  LIBOPENSHOT_AUDIO_INCLUDE_DIRS - The juce.h include directories
 #  LIBOPENSHOT_AUDIO_LIBRARIES - The libraries needed to use juce
 
-message("$ENV{LIBOPENSHOT_AUDIO_DIR}")
+include(GNUInstallDirs)
 
-# Find the libopenshot-audio header files
-find_path(LIBOPENSHOT_AUDIO_INCLUDE_DIR JuceHeader.h
-			PATHS $ENV{LIBOPENSHOT_AUDIO_DIR}/include/libopenshot-audio/
-			/usr/include/libopenshot-audio/
-			/usr/local/include/libopenshot-audio/ )
+if("$ENV{LIBOPENSHOT_AUDIO_DIR}" AND NOT "${OpenShotAudio_FIND_QUIETLY}")
+    message(STATUS "Looking for OpenShotAudio in: $ENV{LIBOPENSHOT_AUDIO_DIR}")
+endif()
 
-# Find the libopenshot-audio.so (check env var first)
-find_library(LIBOPENSHOT_AUDIO_LIBRARY
-		NAMES libopenshot-audio openshot-audio
-		PATHS $ENV{LIBOPENSHOT_AUDIO_DIR}/lib/ NO_DEFAULT_PATH)
+# Find the libopenshot-audio header files (check env/cache vars first)
+find_path(
+  LIBOPENSHOT_AUDIO_INCLUDE_DIR
+  JuceHeader.h
+  HINTS
+    ENV LIBOPENSHOT_AUDIO_DIR
+  PATHS
+    ${LIBOPENSHOT_AUDIO_DIR}
+  PATH_SUFFIXES
+    include/libopenshot-audio
+    libopenshot-audio
+    include
+  NO_DEFAULT_PATH
+)
 
-# Find the libopenshot-audio.so / libopenshot-audio.dll library (fallback)
-find_library(LIBOPENSHOT_AUDIO_LIBRARY
-			NAMES libopenshot-audio openshot-audio
-			HINTS $ENV{LIBOPENSHOT_AUDIO_DIR}/lib/
-			/usr/lib/
-			/usr/lib/libopenshot-audio/
-			/usr/local/lib/ )
+# Find the libopenshot-audio header files (fallback to std. paths)
+find_path(
+  LIBOPENSHOT_AUDIO_INCLUDE_DIR
+  JuceHeader.h
+  HINTS
+    ENV LIBOPENSHOT_AUDIO_DIR
+  PATHS
+    ${LIBOPENSHOT_AUDIO_DIR}
+  PATH_SUFFIXES
+    include/libopenshot-audio
+    libopenshot-audio
+    include
+)
 
-set(LIBOPENSHOT_AUDIO_LIBRARIES ${LIBOPENSHOT_AUDIO_LIBRARY})
-set(LIBOPENSHOT_AUDIO_LIBRARY ${LIBOPENSHOT_AUDIO_LIBRARIES})
+# Find libopenshot-audio.so / libopenshot-audio.dll (check env/cache vars first)
+find_library(
+  LIBOPENSHOT_AUDIO_LIBRARY
+  NAMES
+    libopenshot-audio
+    openshot-audio
+  HINTS
+    ENV LIBOPENSHOT_AUDIO_DIR
+  PATHS
+    ${LIBOPENSHOT_AUDIO_DIR}
+  PATH_SUFFIXES
+    lib/libopenshot-audio
+    libopenshot-audio
+    lib
+  NO_DEFAULT_PATH
+)
 
-set(LIBOPENSHOT_AUDIO_INCLUDE_DIRS ${LIBOPENSHOT_AUDIO_INCLUDE_DIR} )
+# Find libopenshot-audio.so / libopenshot-audio.dll (fallback)
+find_library(
+  LIBOPENSHOT_AUDIO_LIBRARY
+  NAMES
+    libopenshot-audio
+    openshot-audio
+  HINTS
+    ENV LIBOPENSHOT_AUDIO_DIR
+  PATHS
+    ${LIBOPENSHOT_AUDIO_DIR}
+  PATH_SUFFIXES
+    lib/libopenshot-audio
+    libopenshot-audio
+    lib
+)
+
+set(LIBOPENSHOT_AUDIO_LIBRARIES "${LIBOPENSHOT_AUDIO_LIBRARY}")
+set(LIBOPENSHOT_AUDIO_LIBRARY "${LIBOPENSHOT_AUDIO_LIBRARIES}")
+set(LIBOPENSHOT_AUDIO_INCLUDE_DIRS "${LIBOPENSHOT_AUDIO_INCLUDE_DIR}")
+
+if(LIBOPENSHOT_AUDIO_INCLUDE_DIR AND EXISTS "${LIBOPENSHOT_AUDIO_INCLUDE_DIR}/JuceHeader.h")
+  file(STRINGS "${LIBOPENSHOT_AUDIO_INCLUDE_DIR}/JuceHeader.h" libosa_version_str
+       REGEX "versionString.*=.*\"[^\"]+\"")
+  if(libosa_version_str MATCHES "versionString.*=.*\"([^\"]+)\"")
+    set(LIBOPENSHOT_AUDIO_VERSION_STRING ${CMAKE_MATCH_1})
+  endif()
+  unset(libosa_version_str)
+  string(REGEX REPLACE "^([0-9]+\.[0-9]+\.[0-9]+).*$" "\\1"
+         LIBOPENSHOT_AUDIO_VERSION "${LIBOPENSHOT_AUDIO_VERSION_STRING}")
+endif()
+
+# If we couldn't parse M.N.B version, don't keep any of it
+if(NOT LIBOPENSHOT_AUDIO_VERSION)
+  unset(LIBOPENSHOT_AUDIO_VERSION)
+  unset(LIBOPENSHOT_AUDIO_VERSION_STRING)
+endif()
+
+# Determine compatibility with requested version in find_package()
+if(OpenShotAudio_FIND_VERSION AND LIBOPENSHOT_AUDIO_VERSION)
+  if("${OpenShotAudio_FIND_VERSION}" STREQUAL "${LIBOPENSHOT_AUDIO_VERSION}")
+    set(OpenShotAudio_VERSION_EXACT TRUE)
+  endif()
+  if("${OpenShotAudio_FIND_VERSION}" VERSION_GREATER "${LIBOPENSHOT_AUDIO_VERSION}")
+    set(OpenShotAudio_VERSION_COMPATIBLE FALSE)
+  else()
+    set(OpenShotAudio_VERSION_COMPATIBLE TRUE)
+  endif()
+endif()
 
 include(FindPackageHandleStandardArgs)
 # handle the QUIETLY and REQUIRED arguments and set LIBOPENSHOT_AUDIO_FOUND to TRUE
 # if all listed variables are TRUE
-find_package_handle_standard_args(LIBOPENSHOT_AUDIO  DEFAULT_MSG
-                                  LIBOPENSHOT_AUDIO_LIBRARY LIBOPENSHOT_AUDIO_INCLUDE_DIR)
+find_package_handle_standard_args(OpenShotAudio
+  REQUIRED_VARS
+    LIBOPENSHOT_AUDIO_LIBRARY
+    LIBOPENSHOT_AUDIO_INCLUDE_DIRS
+  VERSION_VAR
+    LIBOPENSHOT_AUDIO_VERSION_STRING
+)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -112,7 +112,7 @@ ENDIF (AVRESAMPLE_FOUND)
 
 ################# LIBOPENSHOT-AUDIO ###################
 # Find JUCE-based openshot Audio libraries
-FIND_PACKAGE(OpenShotAudio REQUIRED)
+FIND_PACKAGE(OpenShotAudio 0.1.8 REQUIRED)
 
 # Include Juce headers (needed for compile)
 include_directories(${LIBOPENSHOT_AUDIO_INCLUDE_DIRS})

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -112,7 +112,7 @@ ENDIF (AVRESAMPLE_FOUND)
 
 ################# LIBOPENSHOT-AUDIO ###################
 # Find JUCE-based openshot Audio libraries
-FIND_PACKAGE(OpenShotAudio REQUIRED)
+FIND_PACKAGE(OpenShotAudio 0.1.8 REQUIRED)
 
 # Include Juce headers (needed for compile)
 include_directories(${LIBOPENSHOT_AUDIO_INCLUDE_DIRS})


### PR DESCRIPTION
This PR is an overhaul of `FindOpenShotAudio.cmake` with things I needed for my local testing, but it should be more useful overall (fingers crossed that it works everywhere it's supposed to).

The major changes are:

1. **Version checking!** `find_package(OpenShotAudio 0.1.8 REQUIRED)` will now check that the version is at least `0.1.8`, and abort (because of the `REQUIRED`) if not.
    The version is parsed from the `JuceHeader.h` file, and it would be _best_ with a merge of my PR OpenShot/libopenshot-audio#60, to generate that header during build. But, since we've had "0.1.8" hardcoded in there for a long time, it's fine even right now.

    Other features:
    - Supports `EXACT` (but only for M.N.B, e.g. `0.1.8-dev1` matches `0.1.8` EXACT)
    - Outputs the following: (see below for examples)
      - Version requested, if set
      - Version found, if successfully parsed from header
      - Compatibility status, if version set on both ends

2. Accept `LIBOPENSHOT_AUDIO_DIR` cache variable, in addition to the environment variable. (This allows `cmake -DLIBOPENSHOT_AUDIO_DIR=...` to set the path, instead of having to export an environment variable.) The environment variable will still be given preference, if set.

3. Do the same two-stage search for **both** headers and libs.
   (Avoids this situation...)
   - `LIBOPENSHOT_AUDIO_INCLUDE_DIRS=/usr/include/libopenshot-audio`
   - `LIBOPENSHOT_AUDIO_LIBRARY=/home/ferd/build/`

(A lot of this logic was largely inspired by CMake's `FindPythonLibs.cmake`)

Examples of the version-checking in action:
```cmake
# 1. With "0.1.8-dev1" set in header file
find_package(OpenShotAudio REQUIRED) # Success

# 2. With "0.1.8-dev2" set in header file
find_package(OpenShotAudio 0.1.8 REQUIRED) # Success

# 3. With no parseable string in header file
find_package(OpenShotAudio 0.1.8 REQUIRED) # Success

# F1. With "0.1.8-dev3" set in header file
find_package(OpenShotAudio 0.1.7 EXACT REQUIRED) # FAIL

# F2. With "0.1.8-dev1" set in header file
find_package(OpenShotAudio 0.1.9 REQUIRED) # FAIL
```

#### Successful checks
1. `find_package(OpenShotAudio REQUIRED)` with "0.1.8-dev1" set in header file
```
-- Found OpenShotAudio: /usr/lib/libopenshot-audio.so (found version "0.1.8-dev1") 
```
2. `find_package(OpenShotAudio 0.1.8 REQUIRED)` with "0.1.8-dev2" set in header file
```
-- Found OpenShotAudio: /usr/lib/libopenshot-audio.so (found suitable version "0.1.8-dev2",
 minimum required is "0.1.8") 
```
3. `find_package(OpenShotAudio 0.1.8 REQUIRED)` with no parseable string in header file
```
-- Found OpenShotAudio: /usr/lib/libopenshot-audio.so (Required is at least version "0.1.8") 
```
#### Failures
1. `find_package(OpenShotAudio 0.1.7 EXACT REQUIRED)` with "0.1.8-dev3" set in header file
```
CMake Error at /usr/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:137 (message):
  Could NOT find OpenShotAudio: Found unsuitable version "0.1.8-dev3", but
  required is exact version "0.1.7" (found /usr/lib/libopenshot-audio.so)
Call Stack (most recent call first):
  /usr/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:376 (_FPHSA_FAILURE_MESSAGE)
  cmake/Modules/FindOpenShotAudio.cmake:112 (find_package_handle_standard_args)
  src/CMakeLists.txt:115 (FIND_PACKAGE)


-- Configuring incomplete, errors occurred!
```

2. `find_package(OpenShotAudio 0.1.9 REQUIRED)` with "0.1.8-dev1" set in header file
```
CMake Error at /usr/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:137 (message):
  Could NOT find OpenShotAudio: Found unsuitable version "0.1.8-dev1", but
  required is at least "0.1.9" (found /usr/lib/libopenshot-audio.so)
Call Stack (most recent call first):
  /usr/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:376 (_FPHSA_FAILURE_MESSAGE)
  cmake/Modules/FindOpenShotAudio.cmake:112 (find_package_handle_standard_args)
  src/CMakeLists.txt:115 (FIND_PACKAGE)


-- Configuring incomplete, errors occurred!
```