### PR TITLE
PlayerDemo: declare keyPressEvent() override

### DIFF
--- a/include/Qt/PlayerDemo.h
+++ b/include/Qt/PlayerDemo.h
@@ -57,7 +57,7 @@ public:
     ~PlayerDemo();
 
 protected:
-    override void keyPressEvent(QKeyEvent *event);
+    void keyPressEvent(QKeyEvent *event) Q_DECL_OVERRIDE;
     void closeEvent(QCloseEvent *event) Q_DECL_OVERRIDE;
 
 private slots:

--- a/include/Qt/PlayerDemo.h
+++ b/include/Qt/PlayerDemo.h
@@ -57,7 +57,7 @@ public:
     ~PlayerDemo();
 
 protected:
-    void keyPressEvent(QKeyEvent *event);
+    override void keyPressEvent(QKeyEvent *event);
     void closeEvent(QCloseEvent *event) Q_DECL_OVERRIDE;
 
 private slots:


### PR DESCRIPTION
keyPressEvent() overrides that of QWidget(), and ought be declared `override`.