### PR TITLE
Raise SWIG version requirement to 3.0

### DIFF
--- a/src/bindings/python/CMakeLists.txt
+++ b/src/bindings/python/CMakeLists.txt
@@ -26,7 +26,7 @@
 
 
 ############### SWIG PYTHON BINDINGS ################
-FIND_PACKAGE(SWIG 2.0 REQUIRED)
+FIND_PACKAGE(SWIG 3.0 REQUIRED)
 INCLUDE(${SWIG_USE_FILE})
 
 ### Enable some legacy SWIG behaviors, in newer CMAKEs

--- a/src/bindings/ruby/CMakeLists.txt
+++ b/src/bindings/ruby/CMakeLists.txt
@@ -28,7 +28,7 @@
 include_directories(${OPENSHOT_INCLUDE_DIRS})
 
 ############### RUBY BINDINGS ################
-FIND_PACKAGE(SWIG 2.0 REQUIRED)
+FIND_PACKAGE(SWIG 3.0 REQUIRED)
 INCLUDE(${SWIG_USE_FILE})
 
 ### Enable some legacy SWIG behaviors, in newer CMAKEs


### PR DESCRIPTION
@jonoomph discovered in #265 that SWIG 2.0 doesn't speak our dialect of C++11, which he fixed by upgrading to SWIG 3.0.8. So, bump the minimum SWIG version that CMake checks for.