### PR TITLE
Fix crash during seeking at the start of the file

### DIFF
--- a/src/FFmpegReader.cpp
+++ b/src/FFmpegReader.cpp
@@ -921,6 +921,11 @@ std::shared_ptr<Frame> FFmpegReader::ReadStream(int64_t requested_frame) {
 						continue;
 					}
 
+					// Packet may become NULL on Close inside Seek if CheckSeek returns false
+					if (!packet)
+						// Jump to the next iteration of this loop
+						continue;
+
 					// Get the AVFrame from the current packet
 					frame_finished = GetAVFrame();
 
@@ -956,6 +961,11 @@ std::shared_ptr<Frame> FFmpegReader::ReadStream(int64_t requested_frame) {
 						// Jump to the next iteration of this loop
 						continue;
 					}
+
+					// Packet may become NULL on Close inside Seek if CheckSeek returns false
+					if (!packet)
+						// Jump to the next iteration of this loop
+						continue;
 
 					// Update PTS / Frame Offset (if any)
 					UpdatePTSOffset(false);


### PR DESCRIPTION
Attempt to fix the crash that was detected during investigation of the https://github.com/OpenShot/openshot-qt/issues/2828

This change doesn't fixes the desync issue mentioned in the report. It aims only at the crash resolve.