### PR TITLE
Python install path: remove site-packages detection

### DIFF
--- a/src/bindings/python/CMakeLists.txt
+++ b/src/bindings/python/CMakeLists.txt
@@ -72,26 +72,21 @@ if (PYTHONLIBS_FOUND AND PYTHONINTERP_FOUND)
 	                      ${PYTHON_LIBRARIES} openshot)
 
 	### Check if the following Debian-friendly python module path exists
-	SET(PYTHON_MODULE_PATH "${CMAKE_INSTALL_PREFIX}/lib/python${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}/site-packages")
+	SET(PYTHON_MODULE_PATH "${CMAKE_INSTALL_PREFIX}/lib/python${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}/dist-packages")
 	if (NOT EXISTS ${PYTHON_MODULE_PATH})
 
-		### Check if another Debian-friendly python module path exists
-		SET(PYTHON_MODULE_PATH "${CMAKE_INSTALL_PREFIX}/lib/python${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}/dist-packages")
-		if (NOT EXISTS ${PYTHON_MODULE_PATH})
-
-			### Calculate the python module path (using distutils)
-			execute_process ( COMMAND ${PYTHON_EXECUTABLE} -c "\
+		### Calculate the python module path (using distutils)
+		execute_process ( COMMAND ${PYTHON_EXECUTABLE} -c "\
 from distutils.sysconfig import get_python_lib; \
 print( get_python_lib( plat_specific=True, prefix='${CMAKE_INSTALL_PREFIX}' ) )"
-				OUTPUT_VARIABLE _ABS_PYTHON_MODULE_PATH
-				OUTPUT_STRIP_TRAILING_WHITESPACE )
+			OUTPUT_VARIABLE _ABS_PYTHON_MODULE_PATH
+			OUTPUT_STRIP_TRAILING_WHITESPACE )
 
-			GET_FILENAME_COMPONENT(_ABS_PYTHON_MODULE_PATH
-					"${_ABS_PYTHON_MODULE_PATH}" ABSOLUTE)
-			FILE(RELATIVE_PATH _REL_PYTHON_MODULE_PATH
-					${CMAKE_INSTALL_PREFIX} ${_ABS_PYTHON_MODULE_PATH})
-			SET(PYTHON_MODULE_PATH ${_ABS_PYTHON_MODULE_PATH})
-		endif()
+		GET_FILENAME_COMPONENT(_ABS_PYTHON_MODULE_PATH
+				"${_ABS_PYTHON_MODULE_PATH}" ABSOLUTE)
+		FILE(RELATIVE_PATH _REL_PYTHON_MODULE_PATH
+				${CMAKE_INSTALL_PREFIX} ${_ABS_PYTHON_MODULE_PATH})
+		SET(PYTHON_MODULE_PATH ${_ABS_PYTHON_MODULE_PATH})
 	endif()
 	message("PYTHON_MODULE_PATH: ${PYTHON_MODULE_PATH}")
 


### PR DESCRIPTION
This is a hail-mary _attempt_ to fix Python install-path logic for non-Debian systems, without breaking things for the Debian folks. Because currently, the Debian special-casing is causing the **wrong** install path to be chosen on Fedora and other `lib64`-using systems, a regression from previous behavior (up to and including 2.4.4-release) where the proper `/usr/lib64/...` path was correctly chosen.

The path `${CMAKE_INSTALL_PREFIX}/lib/pythonM.N/site-packages` is not Debian-specific, and will exist on too many systems where it should _not_ be assumed to be the correct install path.