### PR TITLE
Fix include path list, for subdirectories

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,9 +74,9 @@ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/include/OpenShotVersion.h
 
 ############### Set up include paths #################
 list(APPEND OPENSHOT_INCLUDE_DIRS
-    include
-    include/effects
-    include/Qt
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/effects
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/Qt
     ${CMAKE_CURRENT_BINARY_DIR}/include )
 
 #### Enable C++11 (for std::shared_ptr support)


### PR DESCRIPTION
The include paths listed in `OPENSHOT_INCLUDE_DIRS` by the root `CMakeLists.txt` all need to be absolute, so that `src/CMakeLists.txt` and the rest don't interpret them relative to _their_ current directory.