### PR TITLE
Fix truncated output filenames in FFmpegWriter

### DIFF
--- a/include/FFmpegUtilities.h
+++ b/include/FFmpegUtilities.h
@@ -149,6 +149,7 @@
 		#define AV_REGISTER_ALL
 		#define AVCODEC_REGISTER_ALL
 		#define AV_FILENAME url
+		#define AV_SET_FILENAME(oc, f) oc->AV_FILENAME = av_strdup(f)
 		#define MY_INPUT_BUFFER_PADDING_SIZE AV_INPUT_BUFFER_PADDING_SIZE
 		#define AV_ALLOCATE_FRAME() av_frame_alloc()
 		#define AV_ALLOCATE_IMAGE(av_frame, pix_fmt, width, height) av_image_alloc(av_frame->data, av_frame->linesize, width, height, pix_fmt, 1)
@@ -184,6 +185,7 @@
 		#define AV_REGISTER_ALL av_register_all();
 		#define AVCODEC_REGISTER_ALL	avcodec_register_all();
 		#define AV_FILENAME filename
+		#define AV_SET_FILENAME(oc, f) snprintf(oc->AV_FILENAME, sizeof(oc->AV_FILENAME), "%s", f)
 		#define MY_INPUT_BUFFER_PADDING_SIZE FF_INPUT_BUFFER_PADDING_SIZE
 		#define AV_ALLOCATE_FRAME() av_frame_alloc()
 		#define AV_ALLOCATE_IMAGE(av_frame, pix_fmt, width, height) av_image_alloc(av_frame->data, av_frame->linesize, width, height, pix_fmt, 1)
@@ -222,6 +224,7 @@
 		#define AV_REGISTER_ALL av_register_all();
 		#define AVCODEC_REGISTER_ALL	avcodec_register_all();
 		#define AV_FILENAME filename
+		#define AV_SET_FILENAME(oc, f) snprintf(oc->AV_FILENAME, sizeof(oc->AV_FILENAME), "%s", f)
 		#define MY_INPUT_BUFFER_PADDING_SIZE FF_INPUT_BUFFER_PADDING_SIZE
 		#define AV_ALLOCATE_FRAME() av_frame_alloc()
 		#define AV_ALLOCATE_IMAGE(av_frame, pix_fmt, width, height) avpicture_alloc((AVPicture *) av_frame, pix_fmt, width, height)
@@ -252,6 +255,7 @@
 		#define AV_REGISTER_ALL av_register_all();
 		#define AVCODEC_REGISTER_ALL	avcodec_register_all();
 		#define AV_FILENAME filename
+		#define AV_SET_FILENAME(oc, f) snprintf(oc->AV_FILENAME, sizeof(oc->AV_FILENAME), "%s", f)
 		#define MY_INPUT_BUFFER_PADDING_SIZE FF_INPUT_BUFFER_PADDING_SIZE
 		#define AV_ALLOCATE_FRAME() avcodec_alloc_frame()
 		#define AV_ALLOCATE_IMAGE(av_frame, pix_fmt, width, height) avpicture_alloc((AVPicture *) av_frame, pix_fmt, width, height)

--- a/src/FFmpegWriter.cpp
+++ b/src/FFmpegWriter.cpp
@@ -525,9 +525,7 @@ void FFmpegWriter::WriteHeader() {
 	}
 
 	// Force the output filename (which doesn't always happen for some reason)
-	snprintf(oc->AV_FILENAME, sizeof(oc->AV_FILENAME), "%s", path.c_str());
-
-	// Write the stream header, if any
+	AV_SET_FILENAME(oc, path.c_str());
 
 	// Add general metadata (if any)
 	for (std::map<string, string>::iterator iter = info.metadata.begin(); iter != info.metadata.end(); ++iter) {
@@ -543,6 +541,7 @@ void FFmpegWriter::WriteHeader() {
 	if (is_mp4 || is_mov)
 		av_dict_copy(&dict, mux_dict, 0);
 
+	// Write the stream header
 	if (avformat_write_header(oc, &dict) != 0) {
 		throw InvalidFile("Could not write header to file.", path);
 	};


### PR DESCRIPTION
This was causing unexpected problems with the `faststart` muxing option, because FFmpeg has to reopen the file to perform the second pass.

Fixes Openshot/openshot-qt#2921