### PR TITLE
Rename AV_GET_CODEC_TYPE to AVSTREAM_GET_CODEC_TYPE

### DIFF
--- a/include/FFmpegUtilities.h
+++ b/include/FFmpegUtilities.h
@@ -284,5 +284,7 @@
 		#define AV_COPY_PARAMS_FROM_CONTEXT(av_stream, av_codec)
 	#endif
 
+	// Deprecated macro aliases, will be removed in a future release
+	#define AV_GET_CODEC_TYPE(av_stream) _Pragma ("GCC warning \"AV_GET_CODEC_TYPE is deprecated, use AVSTREAM_GET_CODEC_TYPE\"") AVSTREAM_GET_CODEC_TYPE(av_stream)
 
 #endif

--- a/include/FFmpegUtilities.h
+++ b/include/FFmpegUtilities.h
@@ -157,7 +157,7 @@
     	#define AV_FREE_FRAME(av_frame) av_frame_free(av_frame)
 		#define AV_FREE_PACKET(av_packet) av_packet_unref(av_packet)
 		#define AV_FREE_CONTEXT(av_context) avcodec_free_context(&av_context)
-		#define AV_GET_CODEC_TYPE(av_stream) av_stream->codecpar->codec_type
+		#define AVSTREAM_GET_CODEC_TYPE(av_stream) av_stream->codecpar->codec_type
 		#define AV_FIND_DECODER_CODEC_ID(av_stream) av_stream->codecpar->codec_id
 		auto AV_GET_CODEC_CONTEXT = [](AVStream* av_stream, AVCodec* av_codec) { \
 			AVCodecContext *context = avcodec_alloc_context3(av_codec); \
@@ -193,7 +193,7 @@
     	#define AV_FREE_FRAME(av_frame) av_frame_free(av_frame)
 		#define AV_FREE_PACKET(av_packet) av_packet_unref(av_packet)
 		#define AV_FREE_CONTEXT(av_context) avcodec_free_context(&av_context)
-		#define AV_GET_CODEC_TYPE(av_stream) av_stream->codecpar->codec_type
+		#define AVSTREAM_GET_CODEC_TYPE(av_stream) av_stream->codecpar->codec_type
 		#define AV_FIND_DECODER_CODEC_ID(av_stream) av_stream->codecpar->codec_id
 		auto AV_GET_CODEC_CONTEXT = [](AVStream* av_stream, AVCodec* av_codec) { \
 			AVCodecContext *context = avcodec_alloc_context3(av_codec); \
@@ -232,7 +232,7 @@
     	#define AV_FREE_FRAME(av_frame) av_frame_free(av_frame)
 		#define AV_FREE_PACKET(av_packet) av_packet_unref(av_packet)
 		#define AV_FREE_CONTEXT(av_context) avcodec_close(av_context)
-		#define AV_GET_CODEC_TYPE(av_stream) av_stream->codec->codec_type
+		#define AVSTREAM_GET_CODEC_TYPE(av_stream) av_stream->codec->codec_type
 		#define AV_FIND_DECODER_CODEC_ID(av_stream) av_stream->codec->codec_id
 		#define AV_GET_CODEC_CONTEXT(av_stream, av_codec) av_stream->codec
 		#define AV_GET_CODEC_PAR_CONTEXT(av_stream, av_codec) av_stream->codec
@@ -263,7 +263,7 @@
 		#define AV_FREE_FRAME(av_frame) avcodec_free_frame(av_frame)
 		#define AV_FREE_PACKET(av_packet) av_free_packet(av_packet)
 		#define AV_FREE_CONTEXT(av_context) avcodec_close(av_context)
-		#define AV_GET_CODEC_TYPE(av_stream) av_stream->codec->codec_type
+		#define AVSTREAM_GET_CODEC_TYPE(av_stream) av_stream->codec->codec_type
 		#define AV_FIND_DECODER_CODEC_ID(av_stream) av_stream->codec->codec_id
 		#define AV_GET_CODEC_CONTEXT(av_stream, av_codec) av_stream->codec
 		#define AV_GET_CODEC_PAR_CONTEXT(av_stream, av_codec) av_stream->codec

--- a/src/FFmpegReader.cpp
+++ b/src/FFmpegReader.cpp
@@ -255,11 +255,11 @@ void FFmpegReader::Open() {
 		// Loop through each stream, and identify the video and audio stream index
 		for (unsigned int i = 0; i < pFormatCtx->nb_streams; i++) {
 			// Is this a video stream?
-			if (AV_GET_CODEC_TYPE(pFormatCtx->streams[i]) == AVMEDIA_TYPE_VIDEO && videoStream < 0) {
+			if (AVSTREAM_GET_CODEC_TYPE(pFormatCtx->streams[i]) == AVMEDIA_TYPE_VIDEO && videoStream < 0) {
 				videoStream = i;
 			}
 			// Is this an audio stream?
-			if (AV_GET_CODEC_TYPE(pFormatCtx->streams[i]) == AVMEDIA_TYPE_AUDIO && audioStream < 0) {
+			if (AVSTREAM_GET_CODEC_TYPE(pFormatCtx->streams[i]) == AVMEDIA_TYPE_AUDIO && audioStream < 0) {
 				audioStream = i;
 			}
 		}

--- a/src/FFmpegWriter.cpp
+++ b/src/FFmpegWriter.cpp
@@ -737,10 +737,10 @@ void FFmpegWriter::WriteTrailer() {
 
 // Flush encoders
 void FFmpegWriter::flush_encoders() {
-	if (info.has_audio && audio_codec && AV_GET_CODEC_TYPE(audio_st) == AVMEDIA_TYPE_AUDIO && AV_GET_CODEC_ATTRIBUTES(audio_st, audio_codec)->frame_size <= 1)
+	if (info.has_audio && audio_codec && AVSTREAM_GET_CODEC_TYPE(audio_st) == AVMEDIA_TYPE_AUDIO && AV_GET_CODEC_ATTRIBUTES(audio_st, audio_codec)->frame_size <= 1)
 		return;
 #if (LIBAVFORMAT_VERSION_MAJOR < 58)
-	if (info.has_video && video_codec && AV_GET_CODEC_TYPE(video_st) == AVMEDIA_TYPE_VIDEO && (oc->oformat->flags & AVFMT_RAWPICTURE) && AV_FIND_DECODER_CODEC_ID(video_st) == AV_CODEC_ID_RAWVIDEO)
+	if (info.has_video && video_codec && AVSTREAM_GET_CODEC_TYPE(video_st) == AVMEDIA_TYPE_VIDEO && (oc->oformat->flags & AVFMT_RAWPICTURE) && AV_FIND_DECODER_CODEC_ID(video_st) == AV_CODEC_ID_RAWVIDEO)
 		return;
 #endif
 


### PR DESCRIPTION
There are a lot of ways to access `codec_type` in FFmpeg, and the macro is only useful for the path that goes through `AVStream`. (It's necessary due to `AVStream::codec` being replaced with `AVStream::codecpar` at some point in FFmpeg's evolution.)

Fixes #299