### PR TITLE
QtImageReader: Safer ReSVG file extension checks

### DIFF
--- a/include/QtImageReader.h
+++ b/include/QtImageReader.h
@@ -67,7 +67,7 @@ namespace openshot
 	class QtImageReader : public ReaderBase
 	{
 	private:
-		string path;
+		QString path;
 		std::shared_ptr<QImage> image;			///> Original image (full quality)
 		std::shared_ptr<QImage> cached_image;	///> Scaled for performance
 		bool is_open;	///> Is Reader opened

--- a/src/QtImageReader.cpp
+++ b/src/QtImageReader.cpp
@@ -44,14 +44,14 @@
 
 using namespace openshot;
 
-QtImageReader::QtImageReader(string path) : path(path), is_open(false)
+QtImageReader::QtImageReader(string path) : path{QString::fromStdString(path)}, is_open(false)
 {
 	// Open and Close the reader, to populate its attributes (such as height, width, etc...)
 	Open();
 	Close();
 }
 
-QtImageReader::QtImageReader(string path, bool inspect_reader) : path(path), is_open(false)
+QtImageReader::QtImageReader(string path, bool inspect_reader) : path{QString::fromStdString(path)}, is_open(false)
 {
 	// Open and Close the reader, to populate its attributes (such as height, width, etc...)
 	if (inspect_reader) {
@@ -77,12 +77,12 @@ void QtImageReader::Open()
 		// If defined and found in CMake, utilize the libresvg for parsing
 		// SVG files and rasterizing them to QImages.
 		// Only use resvg for files ending in '.svg' or '.svgz'
-		if (path.find(".svg") != std::string::npos || path.find(".svgz") != std::string::npos) {
+		if (path.toLower().endsWith(".svg") || path.toLower().endsWith(".svgz")) {
 
-			ResvgRenderer renderer(QString::fromStdString(path));
+			ResvgRenderer renderer(path);
 			if (!renderer.isValid()) {
 				// Attempt to open file (old method using Qt5 limited SVG parsing)
-				success = image->load(QString::fromStdString(path));
+				success = image->load(path);
 				if (success) {
 					image = std::shared_ptr<QImage>(new QImage(image->convertToFormat(QImage::Format_RGBA8888)));
 				}
@@ -98,20 +98,20 @@ void QtImageReader::Open()
 
 		} else {
 			// Attempt to open file (old method)
-			success = image->load(QString::fromStdString(path));
+			success = image->load(path);
 			if (success)
 				image = std::shared_ptr<QImage>(new QImage(image->convertToFormat(QImage::Format_RGBA8888)));
 		}
 #else
 		// Attempt to open file using Qt's build in image processing capabilities
-		success = image->load(QString::fromStdString(path));
+		success = image->load(path);
 		if (success)
 			image = std::shared_ptr<QImage>(new QImage(image->convertToFormat(QImage::Format_RGBA8888)));
 #endif
 
 		if (!success)
 			// raise exception
-			throw InvalidFile("File could not be opened.", path);
+			throw InvalidFile("File could not be opened.", path.toStdString());
 
 		// Update image properties
 		info.has_audio = false;
@@ -171,7 +171,7 @@ std::shared_ptr<Frame> QtImageReader::GetFrame(int64_t requested_frame)
 {
 	// Check for open reader (or throw exception)
 	if (!is_open)
-		throw ReaderClosed("The Image is closed.  Call Open() before calling this method.", path);
+		throw ReaderClosed("The Image is closed.  Call Open() before calling this method.", path.toStdString());
 
 	// Create a scoped lock, allowing only a single thread to run the following code at one time
 	const GenericScopedLock<CriticalSection> lock(getFrameCriticalSection);
@@ -228,8 +228,8 @@ std::shared_ptr<Frame> QtImageReader::GetFrame(int64_t requested_frame)
 		// If defined and found in CMake, utilize the libresvg for parsing
 		// SVG files and rasterizing them to QImages.
 		// Only use resvg for files ending in '.svg' or '.svgz'
-		if (path.find(".svg") != std::string::npos || path.find(".svgz") != std::string::npos) {
-			ResvgRenderer renderer(QString::fromStdString(path));
+		if (path.toLower().endsWith(".svg") || path.toLower().endsWith(".svgz")) {
+			ResvgRenderer renderer(path);
 			if (renderer.isValid()) {
 				// Scale SVG size to keep aspect ratio, and fill the max_size as best as possible
 				QSize svg_size(renderer.defaultSize().width(), renderer.defaultSize().height());
@@ -289,7 +289,7 @@ Json::Value QtImageReader::JsonValue() {
 	// Create root json object
 	Json::Value root = ReaderBase::JsonValue(); // get parent properties
 	root["type"] = "QtImageReader";
-	root["path"] = path;
+	root["path"] = path.toStdString();
 
 	// return JsonValue
 	return root;
@@ -332,7 +332,7 @@ void QtImageReader::SetJsonValue(Json::Value root) {
 
 	// Set data from Json (if key is found)
 	if (!root["path"].isNull())
-		path = root["path"].asString();
+		path = QString::fromStdString(root["path"].asString());
 
 	// Re-Open path, and re-init everything (if needed)
 	if (is_open)


### PR DESCRIPTION
This changes the type of the private `path` variable to QString internally (which we were converting it to for a bunch of operations anyway), and uses QString's more robust string-manipulation and
-comparison methods to ensure that only filenames that _end in_ an `.svg`/`.svgz` extension (case-insensitively) are recognized as SVG files.

Previously, a filename such as "Title.svg.png" would be interpreted as an SVG file.

The change in the `path` type is purely internal, all of the class's interfaces remain the same, and accept `std::string path`. We simply convert it to/from QString at opposite places in the code, now.