### PR TITLE
Use std::stoll to convert JSON values

### DIFF
--- a/include/CacheBase.h
+++ b/include/CacheBase.h
@@ -32,6 +32,7 @@
 #define OPENSHOT_CACHE_BASE_H
 
 #include <memory>
+#include <cstdlib>
 #include "Frame.h"
 #include "Exceptions.h"
 #include "Json.h"

--- a/include/ChunkReader.h
+++ b/include/ChunkReader.h
@@ -39,7 +39,7 @@
 #include <omp.h>
 #include <QtCore/qdir.h>
 #include <stdio.h>
-#include <stdlib.h>
+#include <cstdlib>
 #include <memory>
 #include "Json.h"
 #include "CacheMemory.h"

--- a/include/ReaderBase.h
+++ b/include/ReaderBase.h
@@ -34,7 +34,7 @@
 #include <iostream>
 #include <iomanip>
 #include <memory>
-#include <stdlib.h>
+#include <cstdlib>
 #include <sstream>
 #include "CacheMemory.h"
 #include "ChannelLayouts.h"

--- a/src/CacheBase.cpp
+++ b/src/CacheBase.cpp
@@ -71,5 +71,5 @@ void CacheBase::SetJsonValue(Json::Value root) {
 
 	// Set data from Json (if key is found)
 	if (!root["max_bytes"].isNull())
-		max_bytes = atoll(root["max_bytes"].asString().c_str());
+		max_bytes = std::stoll(root["max_bytes"].asString());
 }

--- a/src/ChunkReader.cpp
+++ b/src/ChunkReader.cpp
@@ -94,7 +94,7 @@ void ChunkReader::load_json()
 		info.has_video = root["has_video"].asBool();
 		info.has_audio = root["has_audio"].asBool();
 		info.duration = root["duration"].asDouble();
-		info.file_size = atoll(root["file_size"].asString().c_str());
+		info.file_size = std::stoll(root["file_size"].asString());
 		info.height = root["height"].asInt();
 		info.width = root["width"].asInt();
 		info.pixel_format = root["pixel_format"].asInt();
@@ -106,7 +106,7 @@ void ChunkReader::load_json()
 		info.display_ratio.num = root["display_ratio"]["num"].asInt();
 		info.display_ratio.den = root["display_ratio"]["den"].asInt();
 		info.vcodec = root["vcodec"].asString();
-		info.video_length = atoll(root["video_length"].asString().c_str());
+		info.video_length = std::stoll(root["video_length"].asString());
 		info.video_stream_index = root["video_stream_index"].asInt();
 		info.video_timebase.num = root["video_timebase"]["num"].asInt();
 		info.video_timebase.den = root["video_timebase"]["den"].asInt();
@@ -316,7 +316,7 @@ void ChunkReader::SetJsonValue(Json::Value root) {
 	if (!root["path"].isNull())
 		path = root["path"].asString();
 	if (!root["chunk_size"].isNull())
-		chunk_size = atoll(root["chunk_size"].asString().c_str());
+		chunk_size = std::stoll(root["chunk_size"].asString());
 	if (!root["chunk_version"].isNull())
 		version = (ChunkVersion) root["chunk_version"].asInt();
 

--- a/src/ReaderBase.cpp
+++ b/src/ReaderBase.cpp
@@ -181,7 +181,7 @@ void ReaderBase::SetJsonValue(Json::Value root) {
 	if (!root["duration"].isNull())
 		info.duration = root["duration"].asDouble();
 	if (!root["file_size"].isNull())
-		info.file_size = atoll(root["file_size"].asString().c_str());
+		info.file_size = std::stoll(root["file_size"].asString());
 	if (!root["height"].isNull())
 		info.height = root["height"].asInt();
 	if (!root["width"].isNull())
@@ -211,7 +211,7 @@ void ReaderBase::SetJsonValue(Json::Value root) {
 	if (!root["vcodec"].isNull())
 		info.vcodec = root["vcodec"].asString();
 	if (!root["video_length"].isNull())
-		info.video_length = atoll(root["video_length"].asString().c_str());
+		info.video_length = std::stoll(root["video_length"].asString());
 	if (!root["video_stream_index"].isNull())
 		info.video_stream_index = root["video_stream_index"].asInt();
 	if (!root["video_timebase"].isNull() && root["video_timebase"].isObject()) {


### PR DESCRIPTION
The code to convert JSON values from string to numeric types was using the old C `atoll()` function from `stdlib.h` for type-conversion. But C++11 has `std::stoll()` to convert directly from `std::string`, instead of going through C byte strings.

This PR switches from `#include <stdlib.h>` to `#include <cstdlib>`, and rewrites the conversions to use `std::stoll()`.