### PR TITLE
Bindings: Apply #defines for optional libs

### DIFF
--- a/src/bindings/python/CMakeLists.txt
+++ b/src/bindings/python/CMakeLists.txt
@@ -48,7 +48,6 @@ if (PYTHONLIBS_FOUND AND PYTHONINTERP_FOUND)
 	### Enable C++ support in SWIG
 	set_property(SOURCE openshot.i PROPERTY CPLUSPLUS ON)
 	set_property(SOURCE openshot.i PROPERTY SWIG_MODULE_NAME openshot)
-	SET(CMAKE_SWIG_FLAGS "")
 
 	### Suppress a ton of warnings in the generated SWIG C++ code
 	set(SWIG_CXX_FLAGS "-Wno-unused-variable -Wno-unused-function -Wno-deprecated-copy -Wno-class-memaccess -Wno-cast-function-type \

--- a/src/bindings/ruby/CMakeLists.txt
+++ b/src/bindings/ruby/CMakeLists.txt
@@ -50,7 +50,6 @@ IF (RUBY_FOUND)
 	set_property(SOURCE openshot.i PROPERTY CPLUSPLUS ON)
 	set_property(SOURCE openshot.i PROPERTY SWIG_MODULE_NAME openshot)
 
-	SET(CMAKE_SWIG_FLAGS "")
 	### Suppress a ton of warnings in the generated SWIG C++ code
 	set(SWIG_CXX_FLAGS "-Wno-unused-variable -Wno-unused-function -Wno-deprecated-copy -Wno-class-memaccess -Wno-cast-function-type \
 -Wno-unused-parameter -Wno-catch-value -Wno-sign-compare -Wno-ignored-qualifiers")


### PR DESCRIPTION
The resetting of `CMAKE_SWIG_FLAGS` to the empty string, in the bindings' CMakeLists.txt files, was clearing away the definitions for things like `USE_IMAGEMAGICK` and `USE_BLACKMAGIC`. This caused the bindings to be built _without_ those classes even if they're available in the library.

(And it's been like that for _three and a half **years**_.)