### PR TITLE
WIP: Remove not used code

### DIFF
--- a/src/FFmpegWriter.cpp
+++ b/src/FFmpegWriter.cpp
@@ -2032,11 +2032,6 @@ void FFmpegWriter::OutputStreamInfo() {
 
 // Init a collection of software rescalers (thread safe)
 void FFmpegWriter::InitScalers(int source_width, int source_height) {
-	int scale_mode = SWS_FAST_BILINEAR;
-	if (openshot::Settings::Instance()->HIGH_QUALITY_SCALING) {
-		scale_mode = SWS_LANCZOS;
-	}
-
 	// Init software rescalers vector (many of them, one for each thread)
 	for (int x = 0; x < num_of_rescalers; x++) {
 		// Init the software scaler from FFMpeg


### PR DESCRIPTION
Custom scale_mode is never used during writing.

The option intended to be used in chroma downscale during writing,
and Lanczos has no advantages over Bilinear for this task (size is
reduces twice horizontally and vertically or isn't changes at all).