### PR TITLE
Remove mentions of nonexistent InitFileInfo()

### DIFF
--- a/include/ReaderBase.h
+++ b/include/ReaderBase.h
@@ -57,8 +57,7 @@ namespace openshot
 	 * @brief This struct contains info about a media file, such as height, width, frames per second, etc...
 	 *
 	 * Each derived class of ReaderBase is responsible for updating this struct to reflect accurate information
-	 * about the streams. Derived classes of ReaderBase should call the InitFileInfo() method to initialize the
-	 * default values of this struct.
+	 * about the streams.
 	 */
 	struct ReaderInfo
 	{
@@ -95,7 +94,7 @@ namespace openshot
 	 *
 	 * Readers are types of classes that read video, audio, and image files, and
 	 * return openshot::Frame objects. The only requirements for a 'reader', are to
-	 * derive from this base class, implement the GetFrame method, and call the InitFileInfo() method.
+	 * derive from this base class, implement the GetFrame method, and populate ReaderInfo.
 	 */
 	class ReaderBase
 	{

--- a/src/EffectBase.cpp
+++ b/src/EffectBase.cpp
@@ -32,7 +32,7 @@
 
 using namespace openshot;
 
-// Initialize the values of the FileInfo struct
+// Initialize the values of the EffectInfo struct
 void EffectBase::InitEffectInfo()
 {
 	// Init clip settings

--- a/tests/ReaderBase_Tests.cpp
+++ b/tests/ReaderBase_Tests.cpp
@@ -59,7 +59,6 @@ TEST(ReaderBase_Derived_Class)
 	TestReader t1;
 
 	// Check some of the default values of the FileInfo struct on the base class
-	// If InitFileInfo() is not called in the derived class, these checks would fail.
 	CHECK_EQUAL(false, t1.info.has_audio);
 	CHECK_EQUAL(false, t1.info.has_audio);
 	CHECK_CLOSE(0.0f, t1.info.duration, 0.00001);


### PR DESCRIPTION
Various documentation comments gave instructions about how this or that class _must call_ `InitFileInfo()` — except, no such method exists.

(There is an `InitEffectInfo()`, also changed one comment to correctly reference it by the proper name.)