### PR TITLE
FFmpegReader: Detect interlaced video on file open

### DIFF
--- a/src/FFmpegReader.cpp
+++ b/src/FFmpegReader.cpp
@@ -729,6 +729,31 @@ void FFmpegReader::UpdateVideoInfo() {
 	info.display_ratio.num = size.num;
 	info.display_ratio.den = size.den;
 
+	// Get scan type and order from codec context/params
+	if (!check_interlace) {
+		check_interlace = true;
+		AVFieldOrder field_order = AV_GET_CODEC_ATTRIBUTES(pStream, pCodecCtx)->field_order;
+		switch(field_order) {
+			case AV_FIELD_PROGRESSIVE:
+				info.interlaced_frame = false;
+				break;
+			case AV_FIELD_TT:
+			case AV_FIELD_TB:
+				info.interlaced_frame = true;
+				info.top_field_first = true;
+				break;
+			case AV_FIELD_BT:
+			case AV_FIELD_BB:
+				info.interlaced_frame = true;
+				info.top_field_first = false;
+				break;
+			case AV_FIELD_UNKNOWN:
+				// Check again later?
+				check_interlace = false;
+				break;
+		}
+	}
+
 	// Set the video timebase
 	info.video_timebase.num = pStream->time_base.num;
 	info.video_timebase.den = pStream->time_base.den;
@@ -1078,14 +1103,14 @@ bool FFmpegReader::GetAVFrame() {
 			ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::GetAVFrame (Packet not sent)");
 		}
 		else {
-				AVFrame *next_frame2;
-				if (hw_de_on && hw_de_supported) {
-					next_frame2 = AV_ALLOCATE_FRAME();
-				}
-				else
-				{
-					next_frame2 = next_frame;
-				}
+			AVFrame *next_frame2;
+			if (hw_de_on && hw_de_supported) {
+				next_frame2 = AV_ALLOCATE_FRAME();
+			}
+			else
+			{
+				next_frame2 = next_frame;
+			}
 			pFrame = AV_ALLOCATE_FRAME();
 			while (ret >= 0) {
 				ret =  avcodec_receive_frame(pCodecCtx, next_frame2);
@@ -1119,11 +1144,6 @@ bool FFmpegReader::GetAVFrame() {
 					av_image_alloc(pFrame->data, pFrame->linesize, info.width, info.height, (AVPixelFormat)(pStream->codecpar->format), 1);
 					av_image_copy(pFrame->data, pFrame->linesize, (const uint8_t**)next_frame->data, next_frame->linesize,
 												(AVPixelFormat)(pStream->codecpar->format), info.width, info.height);
-					if (!check_interlace)	{
-						check_interlace = true;
-						info.interlaced_frame = next_frame->interlaced_frame;
-						info.top_field_first = next_frame->top_field_first;
-					}
 				}
 			}
 			if (hw_de_on && hw_de_supported) {
@@ -1143,13 +1163,6 @@ bool FFmpegReader::GetAVFrame() {
 			avpicture_alloc((AVPicture *) pFrame, pCodecCtx->pix_fmt, info.width, info.height);
 			av_picture_copy((AVPicture *) pFrame, (AVPicture *) next_frame, pCodecCtx->pix_fmt, info.width,
 							info.height);
-
-			// Detect interlaced frame (only once)
-			if (!check_interlace) {
-				check_interlace = true;
-				info.interlaced_frame = next_frame->interlaced_frame;
-				info.top_field_first = next_frame->top_field_first;
-			}
 		}
 #endif
 	}

--- a/src/FFmpegReader.cpp
+++ b/src/FFmpegReader.cpp
@@ -752,6 +752,8 @@ void FFmpegReader::UpdateVideoInfo() {
 				check_interlace = false;
 				break;
 		}
+		// check_interlace will prevent these checks being repeated,
+		// unless it was cleared because we got an AV_FIELD_UNKNOWN response.
 	}
 
 	// Set the video timebase


### PR DESCRIPTION
Move interlace detection to `UpdateVideoInfo()` so it'll be done before we read any frames, and use the `field_order` member of the codec attributes (an `AVFieldOrder` enum) as the data source.

In my limited testing, this seems to fix interlace detection in at least simple cases. I have an interlaced MPG file (a VHS capture), which FFmpegReader now properly reports as interlaced immediately after `Open()`. 

With the _old_ code, interlacing **was** being detected, but only _after_ reading the file (because `GetFrame()` was examining the input frame on read to determine scan parameters). This would explain the issues with `File Properties` in OpenShot not displaying correct data for interlaced files.

I do have a _different_ interlaced file which fails to detect as interlaced, even though MediaInfo does correctly detect it. However, it seems FFmpeg _genuinely_ cannot detect the scan type of that file, as `field_order` always comes back as `AV_FIELD_UNKNOWN` (before and after reading), and even command-line `ffprobe` has no clue.

Mediainfo:
```
Format                                   : AVC
Format/Info                              : Advanced Video Codec
Format profile                           : High@L6.2
Format settings                          : CABAC / 4 Ref Frames
Format settings, CABAC                   : Yes
Format settings, Reference frames        : 4 frames
Codec ID                                 : avc1
Codec ID/Info                            : Advanced Video Coding
Duration                                 : 7 s 920 ms
Bit rate                                 : 1 684 kb/s
Width                                    : 1 920 pixels
Height                                   : 2 160 pixels
Display aspect ratio                     : 16:9
Frame rate mode                          : Constant
Frame rate                               : 12.500 FPS
Color space                              : YUV
Chroma subsampling                       : 4:2:0
Bit depth                                : 8 bits
Scan type                                : MBAFF
Scan type, store method                  : Interleaved fields
Scan order                               : Top Field First
```

`ffprobe`:
```
  Metadata:
    major_brand     : isom
    minor_version   : 512
    compatible_brands: isomiso2avc1mp41
    encoder         : Lavf58.20.100
  Duration: 00:00:07.92, start: 0.000000, bitrate: 1693 kb/s
    Stream #0:0(und): Video: h264 (High) (avc1 / 0x31637661), yuv420p, 1920x2160 [SAR 2:1 DAR 16:9], 1684 kb/s, 12.50 fps, 12.50 tbr, 12800 tbn, 25 tbc (default)
```

Compare that to `ffprobe` on my properly-detecting MPG capture:
```
  Duration: 00:04:01.18, start: 0.224400, bitrate: 9557 kb/s
    Stream #0:0[0xa0]: Audio: pcm_dvd, 48000 Hz, 2 channels, s16, 1536 kb/s
    Stream #0:1[0x1e0]: Video: mpeg2video (Main), yuv420p(tv, top first), 720x480 [SAR 8:9 DAR 4:3], 29.97 fps, 29.97 tbr, 90k tbn, 59.94 tbc
```

Note the lack of field-order information after `yuv420p`, on the "bad" file.

So, interlace detection still isn't perfect, but:
1. The old code also failed to detect interlacing with that file (even after reading)
2. Which means the detection situation is unchanged, in this case: the new code works no worse than before
3. The lack of detection appears to be FFmpeg's bug, anyway

(...That being said, I don't discount the possibility that there could be _other_ files for which detection from the context's `field_order` doesn't work properly, but the old detection in `GetFrame()` did.)

Addresses OpenShot/openshot-qt#2922