### PR TITLE
Fix return type mismatch

### DIFF
--- a/include/PlayerBase.h
+++ b/include/PlayerBase.h
@@ -81,7 +81,7 @@ namespace openshot
 		virtual void Pause() = 0;
 
 		/// Get the current frame number being played
-		virtual int Position() = 0;
+		virtual int64_t Position() = 0;
 
 		/// Seek to a specific frame in the player
 		virtual void Seek(int64_t new_frame) = 0;

--- a/include/QtPlayer.h
+++ b/include/QtPlayer.h
@@ -81,7 +81,7 @@ namespace openshot
 	void Pause();
 	
 	/// Get the current frame number being played
-	int Position();
+	int64_t Position();
 	
 	/// Seek to a specific frame in the player
 	void Seek(int64_t new_frame);

--- a/src/QtPlayer.cpp
+++ b/src/QtPlayer.cpp
@@ -127,7 +127,7 @@ void QtPlayer::Pause()
     Speed(0);
 }
 
-int QtPlayer::Position()
+int64_t QtPlayer::Position()
 {
     return p->video_position;
 }


### PR DESCRIPTION
`video_position` of the class `PlayerPrivate` declared as `int64_t` inside the _include/Qt/PlayerPrivate.h_

Note: The `ClipBase` class has its own `Position()` method that returns `float` (used in the Timeline operations, the latter has number of internal limits that is not affected by this PR).