### PR TITLE
Exceptions: Make (most) file_path args optional

### DIFF
--- a/include/Exceptions.h
+++ b/include/Exceptions.h
@@ -111,7 +111,7 @@ namespace openshot {
 	{
 	public:
 		std::string file_path;
-		InvalidChannels(std::string message, std::string file_path)
+		InvalidChannels(std::string message, std::string file_path="")
 			: BaseException(message), file_path(file_path) { }
 		virtual ~InvalidChannels() noexcept {}
 	};
@@ -121,7 +121,7 @@ namespace openshot {
 	{
 	public:
 		std::string file_path;
-		InvalidCodec(std::string message, std::string file_path)
+		InvalidCodec(std::string message, std::string file_path="")
 			: BaseException(message), file_path(file_path) { }
 		virtual ~InvalidCodec() noexcept {}
 	};
@@ -141,7 +141,7 @@ namespace openshot {
 	{
 	public:
 		std::string file_path;
-		InvalidFormat(std::string message, std::string file_path)
+		InvalidFormat(std::string message, std::string file_path="")
 			: BaseException(message), file_path(file_path) { }
 		virtual ~InvalidFormat() noexcept {}
 	};
@@ -151,7 +151,7 @@ namespace openshot {
 	{
 	public:
 		std::string file_path;
-		InvalidJSON(std::string message, std::string file_path)
+		InvalidJSON(std::string message, std::string file_path="")
 			: BaseException(message), file_path(file_path) { }
 		virtual ~InvalidJSON() noexcept {}
 	};
@@ -161,7 +161,7 @@ namespace openshot {
 	{
 	public:
 		std::string file_path;
-		InvalidOptions(std::string message, std::string file_path)
+		InvalidOptions(std::string message, std::string file_path="")
 			: BaseException(message), file_path(file_path) { }
 		virtual ~InvalidOptions() noexcept {}
 	};
@@ -171,7 +171,7 @@ namespace openshot {
 	{
 	public:
 		std::string file_path;
-		InvalidSampleRate(std::string message, std::string file_path)
+		InvalidSampleRate(std::string message, std::string file_path="")
 			: BaseException(message), file_path(file_path) { }
 		virtual ~InvalidSampleRate() noexcept {}
 	};
@@ -191,7 +191,7 @@ namespace openshot {
 	{
 	public:
 		std::string file_path;
-		NoStreamsFound(std::string message, std::string file_path)
+		NoStreamsFound(std::string message, std::string file_path="")
 			: BaseException(message), file_path(file_path) { }
 		virtual ~NoStreamsFound() noexcept {}
 	};
@@ -223,7 +223,7 @@ namespace openshot {
 	{
 	public:
 		std::string file_path;
-		OutOfMemory(std::string message, std::string file_path)
+		OutOfMemory(std::string message, std::string file_path="")
 			: BaseException(message), file_path(file_path) { }
 		virtual ~OutOfMemory() noexcept {}
 	};
@@ -233,7 +233,7 @@ namespace openshot {
 	{
 	public:
 		std::string file_path;
-		ReaderClosed(std::string message, std::string file_path)
+		ReaderClosed(std::string message, std::string file_path="")
 			: BaseException(message), file_path(file_path) { }
 		virtual ~ReaderClosed() noexcept {}
 	};
@@ -243,7 +243,7 @@ namespace openshot {
 	{
 	public:
 		std::string file_path;
-		ResampleError(std::string message, std::string file_path)
+		ResampleError(std::string message, std::string file_path="")
 			: BaseException(message), file_path(file_path) { }
 		virtual ~ResampleError() noexcept {}
 	};
@@ -253,7 +253,7 @@ namespace openshot {
 	{
 	public:
 		std::string file_path;
-		TooManySeeks(std::string message, std::string file_path)
+		TooManySeeks(std::string message, std::string file_path="")
 			: BaseException(message), file_path(file_path) { }
 		virtual ~TooManySeeks() noexcept {}
 	};
@@ -263,7 +263,7 @@ namespace openshot {
 	{
 	public:
 		std::string file_path;
-		WriterClosed(std::string message, std::string file_path)
+		WriterClosed(std::string message, std::string file_path="")
 			: BaseException(message), file_path(file_path) { }
 		virtual ~WriterClosed() noexcept {}
 	};

--- a/include/Exceptions.h
+++ b/include/Exceptions.h
@@ -61,6 +61,14 @@ namespace openshot {
 		int64_t frame_number;
 		int64_t chunk_number;
 		int64_t chunk_frame;
+		/**
+		 * @brief Constructor
+		 *
+		 * @param message A message to accompany the exception
+		 * @param frame_number The frame number being processed
+		 * @param chunk_number The chunk requested
+		 * @param chunk_frame The chunk frame
+		 */
 		ChunkNotFound(std::string message, int64_t frame_number, int64_t chunk_number, int64_t chunk_frame)
 			: BaseException(message), frame_number(frame_number), chunk_number(chunk_number), chunk_frame(chunk_frame) { }
 		virtual ~ChunkNotFound() noexcept {}
@@ -71,6 +79,11 @@ namespace openshot {
 	class DecklinkError : public BaseException
 	{
 	public:
+		/**
+		 * @brief Constructor
+		 *
+		 * @param message A message to accompany the exception
+		 */
 		DecklinkError(std::string message)
 			: BaseException(message) { }
 		virtual ~DecklinkError() noexcept {}
@@ -81,6 +94,12 @@ namespace openshot {
 	{
 	public:
 		int64_t frame_number;
+		/**
+		 * @brief Constructor
+		 *
+		 * @param message A message to accompany the exception
+		 * @param frame_number The frame number being processed
+		 */
 		ErrorDecodingAudio(std::string message, int64_t frame_number)
 			: BaseException(message), frame_number(frame_number) { }
 		virtual ~ErrorDecodingAudio() noexcept {}
@@ -91,6 +110,12 @@ namespace openshot {
 	{
 	public:
 		int64_t frame_number;
+		/**
+		 * @brief Constructor
+		 *
+		 * @param message A message to accompany the exception
+		 * @param frame_number The frame number being processed
+		 */
 		ErrorEncodingAudio(std::string message, int64_t frame_number)
 			: BaseException(message), frame_number(frame_number) { }
 		virtual ~ErrorEncodingAudio() noexcept {}
@@ -101,6 +126,12 @@ namespace openshot {
 	{
 	public:
 		int64_t frame_number;
+		/**
+		 * @brief Constructor
+		 *
+		 * @param message A message to accompany the exception
+		 * @param frame_number The frame number being processed
+		 */
 		ErrorEncodingVideo(std::string message, int64_t frame_number)
 			: BaseException(message), frame_number(frame_number) { }
 		virtual ~ErrorEncodingVideo() noexcept {}
@@ -111,6 +142,12 @@ namespace openshot {
 	{
 	public:
 		std::string file_path;
+		/**
+		 * @brief Constructor
+		 *
+		 * @param message A message to accompany the exception
+		 * @param file_path (optional) The input file being processed
+		 */
 		InvalidChannels(std::string message, std::string file_path="")
 			: BaseException(message), file_path(file_path) { }
 		virtual ~InvalidChannels() noexcept {}
@@ -121,6 +158,12 @@ namespace openshot {
 	{
 	public:
 		std::string file_path;
+		/**
+		 * @brief Constructor
+		 *
+		 * @param message A message to accompany the exception
+		 * @param file_path (optional) The input file being processed
+		 */
 		InvalidCodec(std::string message, std::string file_path="")
 			: BaseException(message), file_path(file_path) { }
 		virtual ~InvalidCodec() noexcept {}
@@ -131,6 +174,12 @@ namespace openshot {
 	{
 	public:
 		std::string file_path;
+		/**
+		 * @brief Constructor
+		 *
+		 * @param message A message to accompany the exception
+		 * @param file_path The input file being processed
+		 */
 		InvalidFile(std::string message, std::string file_path)
 			: BaseException(message), file_path(file_path) { }
 		virtual ~InvalidFile() noexcept {}
@@ -141,6 +190,12 @@ namespace openshot {
 	{
 	public:
 		std::string file_path;
+		/**
+		 * @brief Constructor
+		 *
+		 * @param message A message to accompany the exception
+		 * @param file_path (optional) The input file being processed
+		 */
 		InvalidFormat(std::string message, std::string file_path="")
 			: BaseException(message), file_path(file_path) { }
 		virtual ~InvalidFormat() noexcept {}
@@ -151,6 +206,12 @@ namespace openshot {
 	{
 	public:
 		std::string file_path;
+		/**
+		 * @brief Constructor
+		 *
+		 * @param message A message to accompany the exception
+		 * @param file_path (optional) The input file being processed
+		 */
 		InvalidJSON(std::string message, std::string file_path="")
 			: BaseException(message), file_path(file_path) { }
 		virtual ~InvalidJSON() noexcept {}
@@ -161,6 +222,12 @@ namespace openshot {
 	{
 	public:
 		std::string file_path;
+		/**
+		 * @brief Constructor
+		 *
+		 * @param message A message to accompany the exception
+		 * @param file_path (optional) The input file being processed
+		 */
 		InvalidOptions(std::string message, std::string file_path="")
 			: BaseException(message), file_path(file_path) { }
 		virtual ~InvalidOptions() noexcept {}
@@ -171,6 +238,12 @@ namespace openshot {
 	{
 	public:
 		std::string file_path;
+		/**
+		 * @brief Constructor
+		 *
+		 * @param message A message to accompany the exception
+		 * @param file_path (optional) The input file being processed
+		 */
 		InvalidSampleRate(std::string message, std::string file_path="")
 			: BaseException(message), file_path(file_path) { }
 		virtual ~InvalidSampleRate() noexcept {}
@@ -181,6 +254,12 @@ namespace openshot {
 	{
 	public:
 		std::string json;
+		/**
+		 * @brief Constructor
+		 *
+		 * @param message A message to accompany the exception
+		 * @param json The json data being processed
+		 */
 		InvalidJSONKey(std::string message, std::string json)
 			: BaseException(message), json(json) { }
 		virtual ~InvalidJSONKey() noexcept {}
@@ -191,6 +270,12 @@ namespace openshot {
 	{
 	public:
 		std::string file_path;
+		/**
+		 * @brief Constructor
+		 *
+		 * @param message A message to accompany the exception
+		 * @param file_path (optional) The input file being processed
+		 */
 		NoStreamsFound(std::string message, std::string file_path="")
 			: BaseException(message), file_path(file_path) { }
 		virtual ~NoStreamsFound() noexcept {}
@@ -202,6 +287,13 @@ namespace openshot {
 	public:
 		int64_t FrameRequested;
 		int64_t MaxFrames;
+		/**
+		 * @brief Constructor
+		 *
+		 * @param message A message to accompany the exception
+		 * @param frame_requested The out-of-bounds frame number requested
+		 * @param max_frames The maximum available frame number
+		 */
 		OutOfBoundsFrame(std::string message, int64_t frame_requested, int64_t max_frames)
 			: BaseException(message), FrameRequested(frame_requested), MaxFrames(max_frames) { }
 		virtual ~OutOfBoundsFrame() noexcept {}
@@ -213,6 +305,13 @@ namespace openshot {
 	public:
 		int PointRequested;
 		int MaxPoints;
+		/**
+		 * @brief Constructor
+		 *
+		 * @param message A message to accompany the exception
+		 * @param point_requested The out-of-bounds point requested
+		 * @param max_points The maximum available point value
+		 */
 		OutOfBoundsPoint(std::string message, int point_requested, int max_points)
 			: BaseException(message), PointRequested(point_requested), MaxPoints(max_points) { }
 		virtual ~OutOfBoundsPoint() noexcept {}
@@ -223,6 +322,12 @@ namespace openshot {
 	{
 	public:
 		std::string file_path;
+		/**
+		 * @brief Constructor
+		 *
+		 * @param message A message to accompany the exception
+		 * @param file_path (optional) The input file being processed
+		 */
 		OutOfMemory(std::string message, std::string file_path="")
 			: BaseException(message), file_path(file_path) { }
 		virtual ~OutOfMemory() noexcept {}
@@ -233,6 +338,12 @@ namespace openshot {
 	{
 	public:
 		std::string file_path;
+		/**
+		 * @brief Constructor
+		 *
+		 * @param message A message to accompany the exception
+		 * @param file_path (optional) The input file being processed
+		 */
 		ReaderClosed(std::string message, std::string file_path="")
 			: BaseException(message), file_path(file_path) { }
 		virtual ~ReaderClosed() noexcept {}
@@ -243,6 +354,12 @@ namespace openshot {
 	{
 	public:
 		std::string file_path;
+		/**
+		 * @brief Constructor
+		 *
+		 * @param message A message to accompany the exception
+		 * @param file_path (optional) The input file being processed
+		 */
 		ResampleError(std::string message, std::string file_path="")
 			: BaseException(message), file_path(file_path) { }
 		virtual ~ResampleError() noexcept {}
@@ -253,6 +370,12 @@ namespace openshot {
 	{
 	public:
 		std::string file_path;
+		/**
+		 * @brief Constructor
+		 *
+		 * @param message A message to accompany the exception
+		 * @param file_path (optional) The input file being processed
+		 */
 		TooManySeeks(std::string message, std::string file_path="")
 			: BaseException(message), file_path(file_path) { }
 		virtual ~TooManySeeks() noexcept {}
@@ -263,6 +386,12 @@ namespace openshot {
 	{
 	public:
 		std::string file_path;
+		/**
+		 * @brief Constructor
+		 *
+		 * @param message A message to accompany the exception
+		 * @param file_path (optional) The output file being written
+		 */
 		WriterClosed(std::string message, std::string file_path="")
 			: BaseException(message), file_path(file_path) { }
 		virtual ~WriterClosed() noexcept {}

--- a/src/CacheDisk.cpp
+++ b/src/CacheDisk.cpp
@@ -519,7 +519,7 @@ void CacheDisk::SetJson(string value) {
 
 	if (!success)
 		// Raise exception
-		throw InvalidJSON("JSON could not be parsed (or is invalid)", "");
+		throw InvalidJSON("JSON could not be parsed (or is invalid)");
 
 	try
 	{
@@ -529,7 +529,7 @@ void CacheDisk::SetJson(string value) {
 	catch (const std::exception& e)
 	{
 		// Error parsing JSON (or missing keys)
-		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)", "");
+		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)");
 	}
 }
 

--- a/src/CacheMemory.cpp
+++ b/src/CacheMemory.cpp
@@ -372,7 +372,7 @@ void CacheMemory::SetJson(string value) {
 	delete reader;
 	if (!success)
 		// Raise exception
-		throw InvalidJSON("JSON could not be parsed (or is invalid)", "");
+		throw InvalidJSON("JSON could not be parsed (or is invalid)");
 
 	try
 	{
@@ -382,7 +382,7 @@ void CacheMemory::SetJson(string value) {
 	catch (const std::exception& e)
 	{
 		// Error parsing JSON (or missing keys)
-		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)", "");
+		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)");
 	}
 }
 

--- a/src/ChunkReader.cpp
+++ b/src/ChunkReader.cpp
@@ -292,7 +292,7 @@ void ChunkReader::SetJson(string value) {
 	delete reader;
 	if (!success)
 		// Raise exception
-		throw InvalidJSON("JSON could not be parsed (or is invalid)", "");
+		throw InvalidJSON("JSON could not be parsed (or is invalid)");
 
 	try
 	{
@@ -302,7 +302,7 @@ void ChunkReader::SetJson(string value) {
 	catch (const std::exception& e)
 	{
 		// Error parsing JSON (or missing keys)
-		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)", "");
+		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)");
 	}
 }
 

--- a/src/Clip.cpp
+++ b/src/Clip.cpp
@@ -235,7 +235,7 @@ ReaderBase* Clip::Reader()
 		return reader;
 	else
 		// Throw error if reader not initialized
-		throw ReaderClosed("No Reader has been initialized for this Clip.  Call Reader(*reader) before calling this method.", "");
+		throw ReaderClosed("No Reader has been initialized for this Clip.  Call Reader(*reader) before calling this method.");
 }
 
 // Open the internal reader
@@ -252,7 +252,7 @@ void Clip::Open()
 	}
 	else
 		// Throw error if reader not initialized
-		throw ReaderClosed("No Reader has been initialized for this Clip.  Call Reader(*reader) before calling this method.", "");
+		throw ReaderClosed("No Reader has been initialized for this Clip.  Call Reader(*reader) before calling this method.");
 }
 
 // Close the internal reader
@@ -266,7 +266,7 @@ void Clip::Close()
 	}
 	else
 		// Throw error if reader not initialized
-		throw ReaderClosed("No Reader has been initialized for this Clip.  Call Reader(*reader) before calling this method.", "");
+		throw ReaderClosed("No Reader has been initialized for this Clip.  Call Reader(*reader) before calling this method.");
 }
 
 // Get end position of clip (trim end of video), which can be affected by the time curve.
@@ -282,7 +282,7 @@ float Clip::End()
 			fps = reader->info.fps.ToFloat();
 		else
 			// Throw error if reader not initialized
-			throw ReaderClosed("No Reader has been initialized for this Clip.  Call Reader(*reader) before calling this method.", "");
+			throw ReaderClosed("No Reader has been initialized for this Clip.  Call Reader(*reader) before calling this method.");
 
 		return float(time.GetLength()) / fps;
 	}
@@ -350,7 +350,7 @@ std::shared_ptr<Frame> Clip::GetFrame(int64_t requested_frame)
 	}
 	else
 		// Throw error if reader not initialized
-		throw ReaderClosed("No Reader has been initialized for this Clip.  Call Reader(*reader) before calling this method.", "");
+		throw ReaderClosed("No Reader has been initialized for this Clip.  Call Reader(*reader) before calling this method.");
 }
 
 // Get file extension
@@ -394,7 +394,7 @@ void Clip::get_time_mapped_frame(std::shared_ptr<Frame> frame, int64_t frame_num
 	// Check for valid reader
 	if (!reader)
 		// Throw error if reader not initialized
-		throw ReaderClosed("No Reader has been initialized for this Clip.  Call Reader(*reader) before calling this method.", "");
+		throw ReaderClosed("No Reader has been initialized for this Clip.  Call Reader(*reader) before calling this method.");
 
 	// Check for a valid time map curve
 	if (time.Values.size() > 1)
@@ -812,7 +812,7 @@ void Clip::SetJson(string value) {
 
 	if (!success)
 		// Raise exception
-		throw InvalidJSON("JSON could not be parsed (or is invalid)", "");
+		throw InvalidJSON("JSON could not be parsed (or is invalid)");
 
 	try
 	{
@@ -822,7 +822,7 @@ void Clip::SetJson(string value) {
 	catch (const std::exception& e)
 	{
 		// Error parsing JSON (or missing keys)
-		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)", "");
+		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)");
 	}
 }
 

--- a/src/Color.cpp
+++ b/src/Color.cpp
@@ -120,7 +120,7 @@ void Color::SetJson(string value) {
 
 	if (!success)
 		// Raise exception
-		throw InvalidJSON("JSON could not be parsed (or is invalid)", "");
+		throw InvalidJSON("JSON could not be parsed (or is invalid)");
 
 	try
 	{
@@ -130,7 +130,7 @@ void Color::SetJson(string value) {
 	catch (const std::exception& e)
 	{
 		// Error parsing JSON (or missing keys)
-		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)", "");
+		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)");
 	}
 }
 

--- a/src/Coordinate.cpp
+++ b/src/Coordinate.cpp
@@ -83,7 +83,7 @@ void Coordinate::SetJson(string value) {
 
 	if (!success)
 		// Raise exception
-		throw InvalidJSON("JSON could not be parsed (or is invalid)", "");
+		throw InvalidJSON("JSON could not be parsed (or is invalid)");
 
 	try
 	{
@@ -93,7 +93,7 @@ void Coordinate::SetJson(string value) {
 	catch (const std::exception& e)
 	{
 		// Error parsing JSON (or missing keys)
-		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)", "");
+		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)");
 	}
 }
 

--- a/src/DecklinkReader.cpp
+++ b/src/DecklinkReader.cpp
@@ -278,7 +278,7 @@ void DecklinkReader::SetJson(string value) {
 
 	if (!success)
 		// Raise exception
-		throw InvalidJSON("JSON could not be parsed (or is invalid)", "");
+		throw InvalidJSON("JSON could not be parsed (or is invalid)");
 
 	try
 	{
@@ -288,7 +288,7 @@ void DecklinkReader::SetJson(string value) {
 	catch (const std::exception& e)
 	{
 		// Error parsing JSON (or missing keys)
-		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)", "");
+		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)");
 	}
 }
 

--- a/src/DecklinkWriter.cpp
+++ b/src/DecklinkWriter.cpp
@@ -234,7 +234,7 @@ void DecklinkWriter::WriteFrame(std::shared_ptr<Frame> frame)
 {
 	// Check for open reader (or throw exception)
 	if (!is_open)
-		throw WriterClosed("The DecklinkWriter is closed.  Call Open() before calling this method.", "");
+		throw WriterClosed("The DecklinkWriter is closed.  Call Open() before calling this method.");
 
 	delegate->WriteFrame(frame);
 }

--- a/src/DummyReader.cpp
+++ b/src/DummyReader.cpp
@@ -156,7 +156,7 @@ void DummyReader::SetJson(string value) {
 
 	if (!success)
 		// Raise exception
-		throw InvalidJSON("JSON could not be parsed (or is invalid)", "");
+		throw InvalidJSON("JSON could not be parsed (or is invalid)");
 
 	try
 	{
@@ -166,7 +166,7 @@ void DummyReader::SetJson(string value) {
 	catch (const std::exception& e)
 	{
 		// Error parsing JSON (or missing keys)
-		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)", "");
+		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)");
 	}
 }
 

--- a/src/EffectBase.cpp
+++ b/src/EffectBase.cpp
@@ -112,7 +112,7 @@ void EffectBase::SetJson(string value) {
 
 	if (!success)
 		// Raise exception
-		throw InvalidJSON("JSON could not be parsed (or is invalid)", "");
+		throw InvalidJSON("JSON could not be parsed (or is invalid)");
 
 	try
 	{
@@ -122,7 +122,7 @@ void EffectBase::SetJson(string value) {
 	catch (const std::exception& e)
 	{
 		// Error parsing JSON (or missing keys)
-		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)", "");
+		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)");
 	}
 }
 

--- a/src/FFmpegReader.cpp
+++ b/src/FFmpegReader.cpp
@@ -2445,7 +2445,7 @@ void FFmpegReader::SetJson(string value) {
 
 	if (!success)
 		// Raise exception
-		throw InvalidJSON("JSON could not be parsed (or is invalid)", "");
+		throw InvalidJSON("JSON could not be parsed (or is invalid)");
 
 	try {
 		// Set all values that match
@@ -2453,7 +2453,7 @@ void FFmpegReader::SetJson(string value) {
 	}
 	catch (const std::exception& e) {
 		// Error parsing JSON (or missing keys)
-		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)", "");
+		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)");
 	}
 }
 

--- a/src/FrameMapper.cpp
+++ b/src/FrameMapper.cpp
@@ -75,7 +75,7 @@ ReaderBase* FrameMapper::Reader()
         return reader;
     else
         // Throw error if reader not initialized
-        throw ReaderClosed("No Reader has been initialized for FrameMapper.  Call Reader(*reader) before calling this method.", "");
+        throw ReaderClosed("No Reader has been initialized for FrameMapper.  Call Reader(*reader) before calling this method.");
 }
 
 void FrameMapper::AddField(int64_t frame)
@@ -707,7 +707,7 @@ void FrameMapper::SetJson(string value) {
 
 	if (!success)
 		// Raise exception
-		throw InvalidJSON("JSON could not be parsed (or is invalid)", "");
+		throw InvalidJSON("JSON could not be parsed (or is invalid)");
 
 	try
 	{
@@ -717,7 +717,7 @@ void FrameMapper::SetJson(string value) {
 	catch (const std::exception& e)
 	{
 		// Error parsing JSON (or missing keys)
-		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)", "");
+		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)");
 	}
 }
 

--- a/src/ImageReader.cpp
+++ b/src/ImageReader.cpp
@@ -169,7 +169,7 @@ void ImageReader::SetJson(string value) {
 
 	if (!success)
 		// Raise exception
-		throw InvalidJSON("JSON could not be parsed (or is invalid)", "");
+		throw InvalidJSON("JSON could not be parsed (or is invalid)");
 
 	try
 	{
@@ -179,7 +179,7 @@ void ImageReader::SetJson(string value) {
 	catch (const std::exception& e)
 	{
 		// Error parsing JSON (or missing keys)
-		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)", "");
+		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)");
 	}
 }
 

--- a/src/KeyFrame.cpp
+++ b/src/KeyFrame.cpp
@@ -379,7 +379,7 @@ void Keyframe::SetJson(string value) {
 
 	if (!success)
 		// Raise exception
-		throw InvalidJSON("JSON could not be parsed (or is invalid)", "");
+		throw InvalidJSON("JSON could not be parsed (or is invalid)");
 
 	try
 	{
@@ -389,7 +389,7 @@ void Keyframe::SetJson(string value) {
 	catch (const std::exception& e)
 	{
 		// Error parsing JSON (or missing keys)
-		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)", "");
+		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)");
 	}
 }
 

--- a/src/Point.cpp
+++ b/src/Point.cpp
@@ -146,7 +146,7 @@ void Point::SetJson(string value) {
 
 	if (!success)
 		// Raise exception
-		throw InvalidJSON("JSON could not be parsed (or is invalid)", "");
+		throw InvalidJSON("JSON could not be parsed (or is invalid)");
 
 	try
 	{
@@ -156,7 +156,7 @@ void Point::SetJson(string value) {
 	catch (const std::exception& e)
 	{
 		// Error parsing JSON (or missing keys)
-		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)", "");
+		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)");
 	}
 }
 

--- a/src/Profiles.cpp
+++ b/src/Profiles.cpp
@@ -177,7 +177,7 @@ void Profile::SetJson(string value) {
 
 	if (!success)
 		// Raise exception
-		throw InvalidJSON("JSON could not be parsed (or is invalid)", "");
+		throw InvalidJSON("JSON could not be parsed (or is invalid)");
 
 	try
 	{
@@ -187,7 +187,7 @@ void Profile::SetJson(string value) {
 	catch (const std::exception& e)
 	{
 		// Error parsing JSON (or missing keys)
-		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)", "");
+		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)");
 	}
 }
 

--- a/src/QtImageReader.cpp
+++ b/src/QtImageReader.cpp
@@ -310,7 +310,7 @@ void QtImageReader::SetJson(string value) {
 
 	if (!success)
 		// Raise exception
-		throw InvalidJSON("JSON could not be parsed (or is invalid)", "");
+		throw InvalidJSON("JSON could not be parsed (or is invalid)");
 
 	try
 	{
@@ -320,7 +320,7 @@ void QtImageReader::SetJson(string value) {
 	catch (const std::exception& e)
 	{
 		// Error parsing JSON (or missing keys)
-		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)", "");
+		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)");
 	}
 }
 

--- a/src/TextReader.cpp
+++ b/src/TextReader.cpp
@@ -230,7 +230,7 @@ void TextReader::SetJson(string value) {
 
 	if (!success)
 		// Raise exception
-		throw InvalidJSON("JSON could not be parsed (or is invalid)", "");
+		throw InvalidJSON("JSON could not be parsed (or is invalid)");
 
 	try
 	{
@@ -240,7 +240,7 @@ void TextReader::SetJson(string value) {
 	catch (const std::exception& e)
 	{
 		// Error parsing JSON (or missing keys)
-		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)", "");
+		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)");
 	}
 }
 

--- a/src/Timeline.cpp
+++ b/src/Timeline.cpp
@@ -746,7 +746,7 @@ std::shared_ptr<Frame> Timeline::GetFrame(int64_t requested_frame)
 
 		// Check for open reader (or throw exception)
 		if (!is_open)
-			throw ReaderClosed("The Timeline is closed.  Call Open() before calling this method.", "");
+			throw ReaderClosed("The Timeline is closed.  Call Open() before calling this method.");
 
 		// Check cache again (due to locking)
 		#pragma omp critical (T_GetFrame)
@@ -1040,7 +1040,7 @@ void Timeline::SetJson(string value) {
 
 	if (!success)
 		// Raise exception
-		throw InvalidJSON("JSON could not be parsed (or is invalid)", "");
+		throw InvalidJSON("JSON could not be parsed (or is invalid)");
 
 	try
 	{
@@ -1050,7 +1050,7 @@ void Timeline::SetJson(string value) {
 	catch (const std::exception& e)
 	{
 		// Error parsing JSON (or missing keys)
-		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)", "");
+		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)");
 	}
 }
 
@@ -1139,7 +1139,7 @@ void Timeline::ApplyJsonDiff(string value) {
 
 	if (!success || !root.isArray())
 		// Raise exception
-		throw InvalidJSON("JSON could not be parsed (or is invalid).", "");
+		throw InvalidJSON("JSON could not be parsed (or is invalid).");
 
 	try
 	{
@@ -1167,7 +1167,7 @@ void Timeline::ApplyJsonDiff(string value) {
 	catch (const std::exception& e)
 	{
 		// Error parsing JSON (or missing keys)
-		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)", "");
+		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)");
 	}
 }
 

--- a/src/WriterBase.cpp
+++ b/src/WriterBase.cpp
@@ -209,7 +209,7 @@ void WriterBase::SetJson(string value) {
 
 	if (!success)
 		// Raise exception
-		throw InvalidJSON("JSON could not be parsed (or is invalid)", "");
+		throw InvalidJSON("JSON could not be parsed (or is invalid)");
 
 	try
 	{
@@ -219,7 +219,7 @@ void WriterBase::SetJson(string value) {
 	catch (const std::exception& e)
 	{
 		// Error parsing JSON (or missing keys)
-		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)", "");
+		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)");
 	}
 }
 

--- a/src/effects/Bars.cpp
+++ b/src/effects/Bars.cpp
@@ -151,7 +151,7 @@ void Bars::SetJson(string value) {
 
 	if (!success)
 		// Raise exception
-		throw InvalidJSON("JSON could not be parsed (or is invalid)", "");
+		throw InvalidJSON("JSON could not be parsed (or is invalid)");
 
 	try
 	{
@@ -161,7 +161,7 @@ void Bars::SetJson(string value) {
 	catch (const std::exception& e)
 	{
 		// Error parsing JSON (or missing keys)
-		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)", "");
+		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)");
 	}
 }
 

--- a/src/effects/Blur.cpp
+++ b/src/effects/Blur.cpp
@@ -288,7 +288,7 @@ void Blur::SetJson(string value) {
 
 	if (!success)
 		// Raise exception
-		throw InvalidJSON("JSON could not be parsed (or is invalid)", "");
+		throw InvalidJSON("JSON could not be parsed (or is invalid)");
 
 	try
 	{
@@ -298,7 +298,7 @@ void Blur::SetJson(string value) {
 	catch (const std::exception& e)
 	{
 		// Error parsing JSON (or missing keys)
-		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)", "");
+		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)");
 	}
 }
 

--- a/src/effects/Brightness.cpp
+++ b/src/effects/Brightness.cpp
@@ -142,7 +142,7 @@ void Brightness::SetJson(string value) {
 
 	if (!success)
 		// Raise exception
-		throw InvalidJSON("JSON could not be parsed (or is invalid)", "");
+		throw InvalidJSON("JSON could not be parsed (or is invalid)");
 
 	try
 	{
@@ -152,7 +152,7 @@ void Brightness::SetJson(string value) {
 	catch (const std::exception& e)
 	{
 		// Error parsing JSON (or missing keys)
-		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)", "");
+		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)");
 	}
 }
 

--- a/src/effects/ChromaKey.cpp
+++ b/src/effects/ChromaKey.cpp
@@ -135,7 +135,7 @@ void ChromaKey::SetJson(string value) {
 
 	if (!success)
 		// Raise exception
-		throw InvalidJSON("JSON could not be parsed (or is invalid)", "");
+		throw InvalidJSON("JSON could not be parsed (or is invalid)");
 
 	try
 	{
@@ -145,7 +145,7 @@ void ChromaKey::SetJson(string value) {
 	catch (const std::exception& e)
 	{
 		// Error parsing JSON (or missing keys)
-		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)", "");
+		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)");
 	}
 }
 

--- a/src/effects/ColorShift.cpp
+++ b/src/effects/ColorShift.cpp
@@ -234,7 +234,7 @@ void ColorShift::SetJson(string value) {
 
 	if (!success)
 		// Raise exception
-		throw InvalidJSON("JSON could not be parsed (or is invalid)", "");
+		throw InvalidJSON("JSON could not be parsed (or is invalid)");
 
 	try
 	{
@@ -244,7 +244,7 @@ void ColorShift::SetJson(string value) {
 	catch (const std::exception& e)
 	{
 		// Error parsing JSON (or missing keys)
-		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)", "");
+		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)");
 	}
 }
 

--- a/src/effects/Crop.cpp
+++ b/src/effects/Crop.cpp
@@ -150,7 +150,7 @@ void Crop::SetJson(string value) {
 
 	if (!success)
 		// Raise exception
-		throw InvalidJSON("JSON could not be parsed (or is invalid)", "");
+		throw InvalidJSON("JSON could not be parsed (or is invalid)");
 
 	try
 	{
@@ -160,7 +160,7 @@ void Crop::SetJson(string value) {
 	catch (const std::exception& e)
 	{
 		// Error parsing JSON (or missing keys)
-		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)", "");
+		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)");
 	}
 }
 

--- a/src/effects/Deinterlace.cpp
+++ b/src/effects/Deinterlace.cpp
@@ -129,7 +129,7 @@ void Deinterlace::SetJson(string value) {
 
 	if (!success)
 		// Raise exception
-		throw InvalidJSON("JSON could not be parsed (or is invalid)", "");
+		throw InvalidJSON("JSON could not be parsed (or is invalid)");
 
 	try
 	{
@@ -139,7 +139,7 @@ void Deinterlace::SetJson(string value) {
 	catch (const std::exception& e)
 	{
 		// Error parsing JSON (or missing keys)
-		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)", "");
+		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)");
 	}
 }
 

--- a/src/effects/Hue.cpp
+++ b/src/effects/Hue.cpp
@@ -136,7 +136,7 @@ void Hue::SetJson(string value) {
 
 	if (!success)
 		// Raise exception
-		throw InvalidJSON("JSON could not be parsed (or is invalid)", "");
+		throw InvalidJSON("JSON could not be parsed (or is invalid)");
 
 	try
 	{
@@ -146,7 +146,7 @@ void Hue::SetJson(string value) {
 	catch (const std::exception& e)
 	{
 		// Error parsing JSON (or missing keys)
-		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)", "");
+		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)");
 	}
 }
 

--- a/src/effects/Mask.cpp
+++ b/src/effects/Mask.cpp
@@ -189,7 +189,7 @@ void Mask::SetJson(string value) {
 
 	if (!success)
 		// Raise exception
-		throw InvalidJSON("JSON could not be parsed (or is invalid)", "");
+		throw InvalidJSON("JSON could not be parsed (or is invalid)");
 
 	try
 	{
@@ -199,7 +199,7 @@ void Mask::SetJson(string value) {
 	catch (const std::exception& e)
 	{
 		// Error parsing JSON (or missing keys)
-		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)", "");
+		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)");
 	}
 }
 

--- a/src/effects/Negate.cpp
+++ b/src/effects/Negate.cpp
@@ -90,7 +90,7 @@ void Negate::SetJson(string value) {
 
 	if (!success)
 		// Raise exception
-		throw InvalidJSON("JSON could not be parsed (or is invalid)", "");
+		throw InvalidJSON("JSON could not be parsed (or is invalid)");
 
 	try
 	{
@@ -100,7 +100,7 @@ void Negate::SetJson(string value) {
 	catch (const std::exception& e)
 	{
 		// Error parsing JSON (or missing keys)
-		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)", "");
+		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)");
 	}
 }
 

--- a/src/effects/Pixelate.cpp
+++ b/src/effects/Pixelate.cpp
@@ -147,7 +147,7 @@ void Pixelate::SetJson(string value) {
 
 	if (!success)
 		// Raise exception
-		throw InvalidJSON("JSON could not be parsed (or is invalid)", "");
+		throw InvalidJSON("JSON could not be parsed (or is invalid)");
 
 	try
 	{
@@ -157,7 +157,7 @@ void Pixelate::SetJson(string value) {
 	catch (const std::exception& e)
 	{
 		// Error parsing JSON (or missing keys)
-		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)", "");
+		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)");
 	}
 }
 

--- a/src/effects/Saturation.cpp
+++ b/src/effects/Saturation.cpp
@@ -147,7 +147,7 @@ void Saturation::SetJson(string value) {
 
 	if (!success)
 		// Raise exception
-		throw InvalidJSON("JSON could not be parsed (or is invalid)", "");
+		throw InvalidJSON("JSON could not be parsed (or is invalid)");
 
 	try
 	{
@@ -157,7 +157,7 @@ void Saturation::SetJson(string value) {
 	catch (const std::exception& e)
 	{
 		// Error parsing JSON (or missing keys)
-		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)", "");
+		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)");
 	}
 }
 

--- a/src/effects/Shift.cpp
+++ b/src/effects/Shift.cpp
@@ -167,7 +167,7 @@ void Shift::SetJson(string value) {
 
 	if (!success)
 		// Raise exception
-		throw InvalidJSON("JSON could not be parsed (or is invalid)", "");
+		throw InvalidJSON("JSON could not be parsed (or is invalid)");
 
 	try
 	{
@@ -177,7 +177,7 @@ void Shift::SetJson(string value) {
 	catch (const std::exception& e)
 	{
 		// Error parsing JSON (or missing keys)
-		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)", "");
+		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)");
 	}
 }
 

--- a/src/effects/Wave.cpp
+++ b/src/effects/Wave.cpp
@@ -150,7 +150,7 @@ void Wave::SetJson(string value) {
 
 	if (!success)
 		// Raise exception
-		throw InvalidJSON("JSON could not be parsed (or is invalid)", "");
+		throw InvalidJSON("JSON could not be parsed (or is invalid)");
 
 	try
 	{
@@ -160,7 +160,7 @@ void Wave::SetJson(string value) {
 	catch (const std::exception& e)
 	{
 		// Error parsing JSON (or missing keys)
-		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)", "");
+		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)");
 	}
 }
 

--- a/tests/Clip_Tests.cpp
+++ b/tests/Clip_Tests.cpp
@@ -120,7 +120,7 @@ TEST(Clip_Properties)
 
 	if (!success)
 		// Raise exception
-		throw InvalidJSON("JSON could not be parsed (or is invalid)", "");
+		throw InvalidJSON("JSON could not be parsed (or is invalid)");
 
 	try
 	{
@@ -132,7 +132,7 @@ TEST(Clip_Properties)
 	catch (const std::exception& e)
 	{
 		// Error parsing JSON (or missing keys)
-		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)", "");
+		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)");
 	}
 
 
@@ -145,7 +145,7 @@ TEST(Clip_Properties)
 	            properties.c_str() + properties.size(), &root, &errors );
 	if (!success)
 		// Raise exception
-		throw InvalidJSON("JSON could not be parsed (or is invalid)", "");
+		throw InvalidJSON("JSON could not be parsed (or is invalid)");
 
 	try
 	{
@@ -157,7 +157,7 @@ TEST(Clip_Properties)
 	catch (const std::exception& e)
 	{
 		// Error parsing JSON (or missing keys)
-		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)", "");
+		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)");
 	}
 
 
@@ -170,7 +170,7 @@ TEST(Clip_Properties)
 				properties.c_str() + properties.size(), &root, &errors );
 	if (!success)
 		// Raise exception
-		throw InvalidJSON("JSON could not be parsed (or is invalid)", "");
+		throw InvalidJSON("JSON could not be parsed (or is invalid)");
 
 	try
 	{
@@ -181,7 +181,7 @@ TEST(Clip_Properties)
 	catch (const std::exception& e)
 	{
 		// Error parsing JSON (or missing keys)
-		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)", "");
+		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)");
 	}
 
 
@@ -194,7 +194,7 @@ TEST(Clip_Properties)
 	            properties.c_str() + properties.size(), &root, &errors );
 	if (!success)
 		// Raise exception
-		throw InvalidJSON("JSON could not be parsed (or is invalid)", "");
+		throw InvalidJSON("JSON could not be parsed (or is invalid)");
 
 	try
 	{
@@ -206,7 +206,7 @@ TEST(Clip_Properties)
 	catch (const std::exception& e)
 	{
 		// Error parsing JSON (or missing keys)
-		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)", "");
+		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)");
 	}
 
 


### PR DESCRIPTION
It's official: "Don't make programmers write awkward code" is now a trilogy! (The first two thrilling installments: #266 , OpenShot/openshot-qt#2853.) That's right, it now has _seven_ Executive Producer credits, four of whom are just the overpaid stars of the franchise. We'll probably kill one of them off this time, only to bring them back two PRs later.

This sequel concerns the libopenshot exceptions, with a fix very analogous to our first installment (but less impactful or widespread).

### Don't make programmers write awkward code

Many of libopenshot's exception classes take a `file_path` argument, to denote the input/output file in use when the exception occurred. Which is fine, if your exception involves a file path. But, not every exception does, as many are encountered by classes that don't operate exclusively on disk files. So you get code like this:

https://github.com/OpenShot/libopenshot/blob/5e1e8ce601952db3160000998e54454cc2da77cd/src/effects/Blur.cpp#L289-L291

https://github.com/OpenShot/libopenshot/blob/5e1e8ce601952db3160000998e54454cc2da77cd/src/Clip.cpp#L392-L397

#### Once again, a job for the compiler

Just like in #266, filling in empty strings for optional arguments is a job better left to the compiler than the programmer. So, I added a default arg of `""` to every exception that takes a `file_path` argument, _except_ when it was something like the `InvalidFile` exception. For that one, a `file_path` really _should_ be required!

Then I replaced every instance of `throw _____("...", "");` in the codebase with `throw _____("...");` and committed the change. (The only exceptions involved were the two above, as it turns out. Only `InvalidJSON` and `ReaderClosed` are ever _actually_ called with an empty `file_path` string, as it turns out. But, now the rest _can_ be if it's ever needed.)
