### PR TITLE
CMake: Rename LIBOPENSHOT_AUDIO to OpenShotAudio

### DIFF
--- a/cmake/Modules/FindOpenShotAudio.cmake
+++ b/cmake/Modules/FindOpenShotAudio.cmake
@@ -1,9 +1,9 @@
 # - Try to find JUCE-based OpenShot Audio Library
 # libopenshot-audio;
 # Once done this will define
-#  LIBOPENSHOT_AUDIO_FOUND - System has libjuce.so
-#  LIBOPENSHOT_AUDIO_INCLUDE_DIRS - The juce.h include directories
-#  LIBOPENSHOT_AUDIO_LIBRARIES - The libraries needed to use juce
+#  OpenShotAudio_FOUND - System has libjuce.so
+#  OpenShotAudio_INCLUDE_DIRS - The juce.h include directories
+#  OpenShotAudio_LIBRARIES - The libraries needed to use juce
 
 if("$ENV{LIBOPENSHOT_AUDIO_DIR}" AND NOT "${OpenShotAudio_FIND_QUIETLY}")
     message(STATUS "Looking for OpenShotAudio in: $ENV{LIBOPENSHOT_AUDIO_DIR}")
@@ -11,12 +11,13 @@ endif()
 
 # Find the libopenshot-audio header files (check env/cache vars first)
 find_path(
-  LIBOPENSHOT_AUDIO_INCLUDE_DIR
+  OpenShotAudio_INCLUDE_DIR
   JuceHeader.h
   HINTS
     ENV LIBOPENSHOT_AUDIO_DIR
   PATHS
     ${LIBOPENSHOT_AUDIO_DIR}
+    ${OpenShotAudio_DIR}
   PATH_SUFFIXES
     include/libopenshot-audio
     libopenshot-audio
@@ -26,12 +27,13 @@ find_path(
 
 # Find the libopenshot-audio header files (fallback to std. paths)
 find_path(
-  LIBOPENSHOT_AUDIO_INCLUDE_DIR
+  OpenShotAudio_INCLUDE_DIR
   JuceHeader.h
   HINTS
     ENV LIBOPENSHOT_AUDIO_DIR
   PATHS
     ${LIBOPENSHOT_AUDIO_DIR}
+    ${OpenShotAudio_DIR}
   PATH_SUFFIXES
     include/libopenshot-audio
     libopenshot-audio
@@ -40,7 +42,7 @@ find_path(
 
 # Find libopenshot-audio.so / libopenshot-audio.dll (check env/cache vars first)
 find_library(
-  LIBOPENSHOT_AUDIO_LIBRARY
+  OpenShotAudio_LIBRARY
   NAMES
     libopenshot-audio
     openshot-audio
@@ -48,6 +50,7 @@ find_library(
     ENV LIBOPENSHOT_AUDIO_DIR
   PATHS
     ${LIBOPENSHOT_AUDIO_DIR}
+    ${OpenShotAudio_DIR}
   PATH_SUFFIXES
     lib/libopenshot-audio
     libopenshot-audio
@@ -57,7 +60,7 @@ find_library(
 
 # Find libopenshot-audio.so / libopenshot-audio.dll (fallback)
 find_library(
-  LIBOPENSHOT_AUDIO_LIBRARY
+  OpenShotAudio_LIBRARY
   NAMES
     libopenshot-audio
     openshot-audio
@@ -65,39 +68,40 @@ find_library(
     ENV LIBOPENSHOT_AUDIO_DIR
   PATHS
     ${LIBOPENSHOT_AUDIO_DIR}
+    ${OpenShotAudio_DIR}
   PATH_SUFFIXES
     lib/libopenshot-audio
     libopenshot-audio
     lib
 )
 
-set(LIBOPENSHOT_AUDIO_LIBRARIES "${LIBOPENSHOT_AUDIO_LIBRARY}")
-set(LIBOPENSHOT_AUDIO_LIBRARY "${LIBOPENSHOT_AUDIO_LIBRARIES}")
-set(LIBOPENSHOT_AUDIO_INCLUDE_DIRS "${LIBOPENSHOT_AUDIO_INCLUDE_DIR}")
+set(OpenShotAudio_LIBRARIES "${OpenShotAudio_LIBRARY}")
+set(OpenShotAudio_LIBRARY "${OpenShotAudio_LIBRARIES}")
+set(OpenShotAudio_INCLUDE_DIRS "${OpenShotAudio_INCLUDE_DIR}")
 
-if(LIBOPENSHOT_AUDIO_INCLUDE_DIR AND EXISTS "${LIBOPENSHOT_AUDIO_INCLUDE_DIR}/JuceHeader.h")
-  file(STRINGS "${LIBOPENSHOT_AUDIO_INCLUDE_DIR}/JuceHeader.h" libosa_version_str
+if(OpenShotAudio_INCLUDE_DIR AND EXISTS "${OpenShotAudio_INCLUDE_DIR}/JuceHeader.h")
+  file(STRINGS "${OpenShotAudio_INCLUDE_DIR}/JuceHeader.h" libosa_version_str
        REGEX "versionString.*=.*\"[^\"]+\"")
   if(libosa_version_str MATCHES "versionString.*=.*\"([^\"]+)\"")
-    set(LIBOPENSHOT_AUDIO_VERSION_STRING ${CMAKE_MATCH_1})
+    set(OpenShotAudio_VERSION_STRING ${CMAKE_MATCH_1})
   endif()
   unset(libosa_version_str)
   string(REGEX REPLACE "^([0-9]+\.[0-9]+\.[0-9]+).*$" "\\1"
-         LIBOPENSHOT_AUDIO_VERSION "${LIBOPENSHOT_AUDIO_VERSION_STRING}")
+         OpenShotAudio_VERSION "${OpenShotAudio_VERSION_STRING}")
 endif()
 
 # If we couldn't parse M.N.B version, don't keep any of it
-if(NOT LIBOPENSHOT_AUDIO_VERSION)
-  unset(LIBOPENSHOT_AUDIO_VERSION)
-  unset(LIBOPENSHOT_AUDIO_VERSION_STRING)
+if(NOT OpenShotAudio_VERSION)
+  unset(OpenShotAudio_VERSION)
+  unset(OpenShotAudio_VERSION_STRING)
 endif()
 
 # Determine compatibility with requested version in find_package()
-if(OpenShotAudio_FIND_VERSION AND LIBOPENSHOT_AUDIO_VERSION)
-  if("${OpenShotAudio_FIND_VERSION}" STREQUAL "${LIBOPENSHOT_AUDIO_VERSION}")
+if(OpenShotAudio_FIND_VERSION AND OpenShotAudio_VERSION)
+  if("${OpenShotAudio_FIND_VERSION}" STREQUAL "${OpenShotAudio_VERSION}")
     set(OpenShotAudio_VERSION_EXACT TRUE)
   endif()
-  if("${OpenShotAudio_FIND_VERSION}" VERSION_GREATER "${LIBOPENSHOT_AUDIO_VERSION}")
+  if("${OpenShotAudio_FIND_VERSION}" VERSION_GREATER "${OpenShotAudio_VERSION}")
     set(OpenShotAudio_VERSION_COMPATIBLE FALSE)
   else()
     set(OpenShotAudio_VERSION_COMPATIBLE TRUE)
@@ -109,8 +113,8 @@ include(FindPackageHandleStandardArgs)
 # if all listed variables are TRUE
 find_package_handle_standard_args(OpenShotAudio
   REQUIRED_VARS
-    LIBOPENSHOT_AUDIO_LIBRARY
-    LIBOPENSHOT_AUDIO_INCLUDE_DIRS
+    OpenShotAudio_LIBRARY
+    OpenShotAudio_INCLUDE_DIRS
   VERSION_VAR
-    LIBOPENSHOT_AUDIO_VERSION_STRING
+    OpenShotAudio_VERSION_STRING
 )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -115,7 +115,7 @@ ENDIF (AVRESAMPLE_FOUND)
 FIND_PACKAGE(OpenShotAudio 0.1.8 REQUIRED)
 
 # Include Juce headers (needed for compile)
-include_directories(${LIBOPENSHOT_AUDIO_INCLUDE_DIRS})
+include_directories(${OpenShotAudio_INCLUDE_DIRS})
 
 ################# QT5 ###################
 # Find QT5 libraries
@@ -308,7 +308,7 @@ set_target_properties(openshot
 
 ###############  LINK LIBRARY  #################
 SET ( REQUIRED_LIBRARIES
-		${LIBOPENSHOT_AUDIO_LIBRARIES}
+		${OpenShotAudio_LIBRARIES}
 		${QT_LIBRARIES}
 		${PROFILER}
 		${JSONCPP_LIBRARY}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -115,7 +115,7 @@ ENDIF (AVRESAMPLE_FOUND)
 FIND_PACKAGE(OpenShotAudio 0.1.8 REQUIRED)
 
 # Include Juce headers (needed for compile)
-include_directories(${LIBOPENSHOT_AUDIO_INCLUDE_DIRS})
+include_directories(${OpenShotAudio_INCLUDE_DIRS})
 
 ################# QT5 ###################
 # Find QT5 libraries


### PR DESCRIPTION
The `freeze.py` script in openshot-qt still contains a lot of hardcoded paths for things like library `.so` files, that only apply on the project build servers (if even there).

To generalize those better, I had the thought that we could leverage CMake's `--find-package` commandline mode even from the non-CMake `openshot-qt` project. For example:
```
$ cd /path/to/repo/libopenshot
$ cmake -DCMAKE_MODULE_PATH=cmake/Modules --find-package -DNAME=FFmpeg \
-DCOMPILER_ID=GNU -DLANGUAGE=CXX -DMODE=LINK 

/lib64/libavcodec.so /lib64/libavformat.so /lib64/libavutil.so
```
However, that mode _requires_ that the variable names used to store the results of the Find module match its name. When I rewrote `FindOpenShotAudio.cmake`, I retained the `LIBOPENSHOT_AUDIO_` variable names for convenience. But, that won't work for `--find-package`. 

So, this PR renames `LIBOPENSHOT_AUDIO_INCLUDE_DIRS`, `LIBOPENSHOT_AUDIO_LIBRARY`, etc. to `OpenShotAudio_INCLUDE_DIRS`, `OpenShotAudio_LIBRARY`, and so on.

With this change, we can use `--find-package` to locate `libopenshot-audio.so`, and if we were to write a similar find module for `libopenshot.so`, that would work the same way:
```
$ cd /path/to/repo/libopenshot
$ cmake -DCMAKE_MODULE_PATH=cmake/Modules --find-package -DNAME=OpenShotAudio \
-DCOMPILER_ID=GNU -DLANGUAGE=CXX -DMODE=LINK

/usr/lib64/libopenshot-audio.so 
```

For backwards-compatibility / convenience, the `LIBOPENSHOT_AUDIO_DIR` environment variable and CMake variable are both still respected, along with a new CMake variable `OpenShotAudio_DIR` which can (should) be used instead.