### PR TITLE
Example.py: Remove useless `import sys`

### DIFF
--- a/src/examples/Example.py
+++ b/src/examples/Example.py
@@ -30,7 +30,6 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with OpenShot Library. If not, see <http://www.gnu.org/licenses/>.
 
-import sys
 
 # This can be run against an uninstalled build of libopenshot, just set the
 # environment variable PYTHONPATH to the location of the Python bindings.


### PR DESCRIPTION
Codacy pointed out that there's absolutely no reason to be
importing the sys module in this code.