### PR TITLE
Some minor fixes made while testing hwaccel

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -372,6 +372,14 @@ target_link_libraries(openshot ${REQUIRED_LIBRARIES})
 # Create test executable
 add_executable(openshot-example examples/Example.cpp)
 
+# Define path to test input files
+SET(TEST_MEDIA_PATH "${PROJECT_SOURCE_DIR}/src/examples/")
+IF (WIN32)
+        STRING(REPLACE "/" "\\\\" TEST_MEDIA_PATH TEST_MEDIA_PATH)
+ENDIF(WIN32)
+target_compile_definitions(openshot-example PRIVATE
+	-DTEST_MEDIA_PATH="${TEST_MEDIA_PATH}" )
+
 # Link test executable to the new library
 target_link_libraries(openshot-example openshot)
 

--- a/src/FFmpegReader.cpp
+++ b/src/FFmpegReader.cpp
@@ -309,7 +309,7 @@ void FFmpegReader::Open() {
 					char *adapter_ptr = NULL;
 					int adapter_num;
 					adapter_num = openshot::Settings::Instance()->HW_DE_DEVICE_SET;
-					fprintf(stderr, "\n\nDecodiing Device Nr: %d\n", adapter_num);
+					fprintf(stderr, "Hardware decoding device number: %d\n", adapter_num);
 
 					// Set hardware pix format (callback)
 					pCodecCtx->get_format = get_hw_dec_format;

--- a/src/FFmpegWriter.cpp
+++ b/src/FFmpegWriter.cpp
@@ -172,7 +172,7 @@ void FFmpegWriter::SetVideoOptions(bool has_video, string codec, Fraction fps, i
 		AVCodec *new_codec;
 		// Check if the codec selected is a hardware accelerated codec
 #if IS_FFMPEG_3_2
-		#if defined(__linux__)
+	#if defined(__linux__)
 		if ( (strcmp(codec.c_str(),"h264_vaapi") == 0)) {
 			new_codec = avcodec_find_encoder_by_name(codec.c_str());
 			hw_en_on = 1;
@@ -194,7 +194,7 @@ void FFmpegWriter::SetVideoOptions(bool has_video, string codec, Fraction fps, i
 				hw_en_supported = 0;
 			}
 		}
-#elif defined(_WIN32)
+	#elif defined(_WIN32)
 		if ( (strcmp(codec.c_str(),"h264_dxva2") == 0)) {
 			new_codec = avcodec_find_encoder_by_name(codec.c_str());
 			hw_en_on = 1;
@@ -216,7 +216,7 @@ void FFmpegWriter::SetVideoOptions(bool has_video, string codec, Fraction fps, i
 				hw_en_supported = 0;
 			}
 		}
-#elif defined(__APPLE__)
+	#elif defined(__APPLE__)
 		if ( (strcmp(codec.c_str(),"h264_videotoolbox") == 0)) {
 			new_codec = avcodec_find_encoder_by_name(codec.c_str());
 			hw_en_on = 1;
@@ -229,9 +229,9 @@ void FFmpegWriter::SetVideoOptions(bool has_video, string codec, Fraction fps, i
 			hw_en_on = 0;
 			hw_en_supported = 0;
 		}
-#else  // is FFmpeg 3 but not linux
+	#else  // is FFmpeg 3 but not linux
 		new_codec = avcodec_find_encoder_by_name(codec.c_str());
-#endif //__linux__
+	#endif //__linux__
 #else // not ffmpeg 3
 		new_codec = avcodec_find_encoder_by_name(codec.c_str());
 #endif //IS_FFMPEG_3_2

--- a/src/examples/Example.cpp
+++ b/src/examples/Example.cpp
@@ -39,9 +39,9 @@ using namespace openshot;
 
 int main(int argc, char* argv[]) {
 
-	Settings *s = Settings::Instance();
-	s->HARDWARE_DECODER = 2; // 1 VA-API, 2 NVDEC
-	s->HW_DE_DEVICE_SET = 0;
+    Settings *s = Settings::Instance();
+    s->HARDWARE_DECODER = 2; // 1 VA-API, 2 NVDEC, 6 VDPAU
+    s->HW_DE_DEVICE_SET = 0;
 
     std::string input_filepath = TEST_MEDIA_PATH;
     input_filepath += "sintel_trailer-720p.mp4";
@@ -83,7 +83,7 @@ int main(int argc, char* argv[]) {
     // Close timeline
     r9.Close();
 
-	cout << "Completed successfully!" << endl;
+    cout << "Completed successfully!" << endl;
 
     return 0;
 }

--- a/src/examples/Example.cpp
+++ b/src/examples/Example.cpp
@@ -43,12 +43,15 @@ int main(int argc, char* argv[]) {
 	s->HARDWARE_DECODER = 2; // 1 VA-API, 2 NVDEC
 	s->HW_DE_DEVICE_SET = 0;
 
-    FFmpegReader r9("/home/jonathan/Videos/sintel_trailer-720p.mp4");
+    std::string input_filepath = TEST_MEDIA_PATH;
+    input_filepath += "sintel_trailer-720p.mp4";
+
+    FFmpegReader r9(input_filepath);
     r9.Open();
     r9.DisplayInfo();
 
     /* WRITER ---------------- */
-    FFmpegWriter w9("/home/jonathan/metadata.mp4");
+    FFmpegWriter w9("metadata.mp4");
 
     // Set options
     w9.SetAudioOptions(true, "libmp3lame", r9.info.sample_rate, r9.info.channels, r9.info.channel_layout, 128000);


### PR DESCRIPTION
(And mostly unrelated to hardware acceleration.)

- Clean up some misleading indentation in FFmpegWriter
- Replace this FFmpegReader message (printed on stdout):
   ```
   
   
   Decodiing Device Nr: 2
   ```
  With this:
   ```
   Hardware decoding device number: 2
   ```
- Eliminate the hardcoded `/home/jonathan/` source-file path in `Example.cpp` by adding a definition of `TEST_MEDIA_PATH` to `src/CMakeListst.txt`, same as `tests/CMakeLists.txt`, and using that as the path to the input file.