### PR TITLE
Travis updates (Bionic, Qt 5.12, config)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,53 +1,88 @@
-dist: xenial
-sudo: required
+language: cpp
+
+# This section uses a rather esoteric (and tricky!) feature of YAML,
+# &aliases and *anchors, to build package lists out of sublists without
+# repeating their contents. Basically, '&name' creates an alias for the
+# given data, which can then be referenced using the anchor '*name'.
+addons:
+  apt:
+    packages: &p_common  # Packages common to all Ubuntu builds
+    - cmake
+    - swig
+    - libopenshot-audio-dev
+    - libmagick++-dev
+    - libunittest++-dev
+    - libzmq3-dev
+    - qtbase5-dev
+    - qtmultimedia5-dev
+    - doxygen
+    - graphviz
+    packages: &ff_common  # Common set of FFmpeg packages
+    - *p_common
+    - libfdk-aac-dev
+    - libavcodec-dev
+    - libavformat-dev
+    - libavdevice-dev
+    - libavutil-dev
+    - libavfilter-dev
+    - libswscale-dev
+    - libpostproc-dev
+    - libavresample-dev
+    - libswresample-dev
 
 matrix:
   include:
-    - language: cpp
-      name: "FFmpeg 2"
-      before_script:
-      - sudo add-apt-repository ppa:openshot.developers/libopenshot-daily -y
-      - sudo add-apt-repository ppa:beineri/opt-qt-5.10.0-xenial -y
-      - sudo apt-get update -qq
-      - sudo apt-get install gcc-4.8 cmake libavcodec-dev libavformat-dev libswscale-dev libavresample-dev libavutil-dev libopenshot-audio-dev libopenshot-dev libfdk-aac-dev libfdk-aac-dev libjsoncpp-dev libmagick++-dev libopenshot-audio-dev libunittest++-dev libzmq3-dev pkg-config python3-dev qtbase5-dev qtmultimedia5-dev swig -y
-      - sudo apt autoremove -y
-      script:
-      - mkdir -p build; cd build;
-      - cmake -D"CMAKE_BUILD_TYPE:STRING=Debug" ../
-      - make VERBOSE=1
-      - make os_test
-      - make install DESTDIR=dist/
-      
-    - language: cpp
-      name: "FFmpeg 3"
-      before_script:
-      - sudo add-apt-repository ppa:openshot.developers/libopenshot-daily -y
-      - sudo add-apt-repository ppa:beineri/opt-qt-5.10.0-xenial -y
-      - sudo add-apt-repository ppa:jonathonf/ffmpeg-3 -y
-      - sudo apt-get update -qq
-      - sudo apt-get install gcc-4.8 cmake libavcodec-dev libavformat-dev libswscale-dev libavresample-dev libavutil-dev libopenshot-audio-dev libopenshot-dev libfdk-aac-dev libfdk-aac-dev libjsoncpp-dev libmagick++-dev libopenshot-audio-dev libunittest++-dev libzmq3-dev pkg-config python3-dev qtbase5-dev qtmultimedia5-dev swig -y
-      - sudo apt autoremove -y
-      script:
-      - mkdir -p build; cd build;
-      - cmake -D"CMAKE_BUILD_TYPE:STRING=Debug" ../
-      - make VERBOSE=1
-      - make os_test
-      - make install DESTDIR=dist/
-      
-    - language: cpp
-      name: "FFmpeg 4"
-      before_script:
-      - sudo add-apt-repository ppa:openshot.developers/libopenshot-daily -y
-      - sudo add-apt-repository ppa:beineri/opt-qt-5.10.0-xenial -y
-      - sudo add-apt-repository ppa:jonathonf/ffmpeg -y
-      - sudo add-apt-repository ppa:jonathonf/ffmpeg-4 -y
-      - sudo add-apt-repository ppa:jonathonf/backports -y
-      - sudo apt-get update -qq
-      - sudo apt-get install gcc-4.8 cmake libavcodec58 libavformat58 libavcodec-dev libavformat-dev libswscale-dev libavresample-dev libavutil-dev libopenshot-audio-dev libopenshot-dev libfdk-aac-dev libfdk-aac-dev libjsoncpp-dev libmagick++-dev libopenshot-audio-dev libunittest++-dev libzmq3-dev pkg-config python3-dev qtbase5-dev qtmultimedia5-dev swig -y
-      - sudo apt autoremove -y
-      script:
-      - mkdir -p build; cd build;
-      - cmake -D"CMAKE_BUILD_TYPE:STRING=Debug" ../
-      - make VERBOSE=1
-      - make os_test
-      - make install DESTDIR=dist/
+    - name: "FFmpeg 2 (Ubuntu 16.04 Xenial)"
+      env: BUILD_VERSION=ffmpeg2
+      os: linux
+      dist: xenial
+      addons:
+        apt:
+          sources:
+          - sourceline: 'ppa:openshot.developers/libopenshot-daily'
+          - sourceline: 'ppa:beineri/opt-qt-5.10.0-xenial'
+          packages:
+          - *ff_common
+
+    - name: "FFmpeg 3 (Ubuntu 18.04 Bionic)"
+      env: BUILD_VERSION=ffmpeg3
+      os: linux
+      dist: bionic
+      addons:
+        apt:
+          sources:
+          - sourceline: 'ppa:openshot.developers/libopenshot-daily'
+          - sourceline: 'ppa:beineri/opt-qt-5.12.3-bionic'
+          packages:
+          - *ff_common
+          - qt5-default
+
+    - name: "FFmpeg 4 (Ubuntu 18.04 Bionic)"
+      env: BUILD_VERSION=ffmpeg4
+      os: linux
+      dist: bionic
+      addons:
+        apt:
+          sources:
+          - sourceline: 'ppa:openshot.developers/libopenshot-daily'
+          - sourceline: 'ppa:beineri/opt-qt-5.12.3-bionic'
+          - sourceline: 'ppa:jonathonf/ffmpeg-4'
+          packages:
+          - *ff_common
+          - qt5-default
+          - libavcodec58
+          - libavformat58
+          - libavdevice58
+          - libavutil56
+          - libavfilter7
+          - libswscale5
+          - libpostproc55
+          - libavresample4
+          - libswresample3
+
+script:
+  - mkdir -p build; cd build;
+  - cmake -DCMAKE_BUILD_TYPE:STRING="Debug" ../
+  - make VERBOSE=1
+  - make os_test
+  - make install DESTDIR="$BUILD_VERSION"


### PR DESCRIPTION
This PR modernizes our Travis build configs (no more manual `sudo`, packages managed using Travis' supported `apt` addon, etc.), as well as makes some updates:
* The FFmpeg 3 and 4 builds are upgraded to their Ubuntu 18.04 (Bionic) image. FFmpeg 2 remains on the 16.04 (Xenial) image
* The Bionic builds are also upgraded from Qt 5.10 to 5.12.3
* The FFmpeg 3 PPA is dropped, because Bionic includes FFmpeg 3 by default