### PR TITLE
Re-enable 'make test' when possible (requires CMake 3.11+)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,13 +92,17 @@ ENDIF(WIN32)
 set(QT_HEADER_DIR ${CMAKE_CURRENT_SOURCE_DIR}/include/Qt)
 FILE(GLOB QT_HEADER_FILES "${QT_HEADER_DIR}/*.h")
 
-############## PROCESS SUB-DIRECTORIES ##############
+############## PROCESS src/ DIRECTORIES ##############
 add_subdirectory(src)
-add_subdirectory(tests)
 
 ################### DOCUMENTATION ###################
 # Find Doxygen (used for documentation)
 include(cmake/Modules/UseDoxygen.cmake)
+
+# Doxygen was found
+if (TARGET doc)
+	message(STATUS "Doxygen found, documentation target enabled")
+	message("\nTo compile documentation in doc/html, run: 'make doc'")
 
 # Install docs, if the user builds them with `make doc`
 install(CODE "MESSAGE(\"Checking for documentation files to install...\")")
@@ -108,3 +112,8 @@ install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/doc/html/
         DESTINATION ${CMAKE_INSTALL_DOCDIR}/API
         MESSAGE_NEVER # Don't spew about file copies
         OPTIONAL )    # No error if the docs aren't found
+endif()
+
+############# PROCESS tests/ DIRECTORY ##############
+add_subdirectory(tests)
+

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -202,7 +202,7 @@ endif(USE_SYSTEM_JSONCPP)
 
 IF (NOT DISABLE_TESTS)
 	###############  SET TEST SOURCE FILES  #################
-	SET ( OPENSHOT_TEST_FILES tests.cpp
+	SET ( OPENSHOT_TEST_FILES
 		   Cache_Tests.cpp
 		   Clip_Tests.cpp
 		   Color_Tests.cpp
@@ -220,6 +220,7 @@ IF (NOT DISABLE_TESTS)
 
 	################ TESTER EXECUTABLE #################
 	# Create unit test executable (openshot-test)
+	message (STATUS "Tests enabled, test executable will be built as tests/openshot-test")
 	add_executable(openshot-test
 				   tests.cpp
 				   ${OPENSHOT_TEST_FILES} )
@@ -227,7 +228,24 @@ IF (NOT DISABLE_TESTS)
 	# Link libraries to the new executable
 	target_link_libraries(openshot-test openshot ${UNITTEST++_LIBRARY})
 
-	#################### MAKE TEST ######################
+	##### RUNNING TESTS (make os_test / make test) #####
 	# Hook up the 'make os_test' target to the 'openshot-test' executable
 	ADD_CUSTOM_TARGET(os_test COMMAND openshot-test)
-ENDIF (NOT DISABLE_TESTS)
+	list(APPEND OS_TEST_CMDS "'make os_test'")
+
+	# Also hook up 'make test', if possible
+	# This requires CMake 3.11+, where the CMP0037 policy
+	# configured to 'NEW' mode will not reserve target names
+	# unless the corresponding feature is actually used
+	if (POLICY CMP0037)
+		cmake_policy(SET CMP0037 NEW)
+	endif()
+	if (CMAKE_VERSION VERSION_GREATER 3.11)
+		message(STATUS "Cmake 3.11+ detected, enabling 'test' target")
+		add_custom_target(test COMMAND openshot-test)
+		list(APPEND OS_TEST_CMDS " or " "'make test'")
+	endif()
+
+	string(CONCAT t ${OS_TEST_CMDS})
+	message("\nTo run unit tests, use: ${t}")
+endif()


### PR DESCRIPTION
CMake's decision to reserve certain target names (test, package) was amended in CMake 3.11, so that the names are only reserved when the feature in question (CTest, CPack) is actually used in the project.

So, with newer CMake versions, it's again possible to provide a `make test` command to build and run the unit tests. This PR enables that functionality if the CMake version is sufficiently new. The old `make os_test` target is preserved for backwards-compatibility, and should still be preferred for build/CI purposes.

This change also adds a message to the CMake generation output detailing what targets are available for unit tests, and updates the documentation target with a similar message (if Doxygen i available).