### PR TITLE
Version information: Separate implementation, add pythonic touches

### DIFF
--- a/include/OpenShotVersion.h.in
+++ b/include/OpenShotVersion.h.in
@@ -43,36 +43,28 @@
 #define OPENSHOT_VERSION_SO @PROJECT_SO_VERSION@         /// Shared object version number. This increments any time the API and ABI changes (so old apps will no longer link)
 
 #include <sstream>
-using namespace std;
 
 namespace openshot
 {
 	/// This struct holds version number information. Use the GetVersion() method to access the current version of libopenshot.
 	struct OpenShotVersion {
-		int major; /// Major version number
-		int minor; /// Minor version number
-		int build; /// Build number
-		int so; /// Shared Object Number (incremented when API or ABI changes)
+		static const int Major = OPENSHOT_VERSION_MAJOR; /// Major version number
+		static const int Minor = OPENSHOT_VERSION_MINOR; /// Minor version number
+		static const int Build = OPENSHOT_VERSION_BUILD; /// Build number
+		static const int So = OPENSHOT_VERSION_SO; /// Shared Object Number (incremented when API or ABI changes)
 
 		/// Get a string version of the version (i.e. "Major.Minor.Build")
-		string ToString() {
-			stringstream version_string;
-			version_string << major << "." << minor << "." << build;
+		inline static const std::string ToString() {
+			std::stringstream version_string;
+			version_string << Major << "." << Minor << "." << Build;
 			return version_string.str();
 		}
 	};
 
+	static const openshot::OpenShotVersion Version;
+
 	/// Get the current version number of libopenshot (major, minor, and build number)
-	static OpenShotVersion GetVersion() {
-		OpenShotVersion version;
-
-		// Set version info
-		version.major = OPENSHOT_VERSION_MAJOR;
-		version.minor = OPENSHOT_VERSION_MINOR;
-		version.build = OPENSHOT_VERSION_BUILD;
-		version.so = OPENSHOT_VERSION_SO;
-
-		return version;
-	}
+	openshot::OpenShotVersion GetVersion();
 }
-#endif
+
+#endif // OPENSHOT_VERSION_H

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -249,6 +249,7 @@ SET ( OPENSHOT_SOURCE_FILES
 		Frame.cpp
 		FrameMapper.cpp
 		KeyFrame.cpp
+		OpenShotVersion.cpp
 		ZmqLogger.cpp
 		PlayerBase.cpp
 		Point.cpp

--- a/src/OpenShotVersion.cpp
+++ b/src/OpenShotVersion.cpp
@@ -1,0 +1,38 @@
+/**
+ * @file
+ * @brief Source file for GetVersion function
+ * @author Jonathan Thomas <jonathan@openshot.org>
+ * @author FeRD (Frank Dana) <ferdnyc@gmail.com>
+ *
+ * @ref License
+ */
+
+/* LICENSE
+ *
+ * Copyright (c) 2008-2019 OpenShot Studios, LLC
+ * <http://www.openshotstudios.com/>. This file is part of
+ * OpenShot Library (libopenshot), an open-source project dedicated to
+ * delivering high quality video editing and animation solutions to the
+ * world. For more information visit <http://www.openshot.org/>.
+ *
+ * OpenShot Library (libopenshot) is free software: you can redistribute it
+ * and/or modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * OpenShot Library (libopenshot) is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with OpenShot Library. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "OpenShotVersion.h"
+
+namespace openshot {
+    OpenShotVersion GetVersion() {
+        return openshot::Version;
+    }
+}

--- a/src/bindings/python/openshot.i
+++ b/src/bindings/python/openshot.i
@@ -123,7 +123,7 @@
 %extend openshot::OpenShotVersion {
     // Give the struct a string representation
 	const std::string __str__() {
-		return std::string(openshot::OpenShotVersion::ToString());
+		return std::string(OPENSHOT_VERSION_FULL);
 	}
 }
 

--- a/src/bindings/python/openshot.i
+++ b/src/bindings/python/openshot.i
@@ -120,6 +120,13 @@
 	}
 }
 
+%extend openshot::OpenShotVersion {
+    // Give the struct a string representation
+	const std::string __str__() {
+		return std::string(openshot::OpenShotVersion::ToString());
+	}
+}
+
 %include "OpenShotVersion.h"
 %include "../../../include/ReaderBase.h"
 %include "../../../include/WriterBase.h"


### PR DESCRIPTION
With warnings enabled, `g++` was complaining about `GetVersion()` being unused every time the `OpenShotVersion.h` header file was included. So I separated out the implementation into `src/OpenShotVersion.cpp`, which silenced the warnings.

Then I added some conveniences, and some Pythonic flourishes:
1. I moved the initialization of the struct members to the struct itself, instead of in `GetVersion()`, and I made them `const`
1. I changed the const member names to uppercase first letter, since apparently Ruby has some rule about constants starting with a capital letter, and it complained otherwise (and renamed them anyway!)
1. I added a static `openshot::Version`, of type `openshot::OpenShotVersion`
1. I gave `openshot::OpenShotVersion` a string representation in the Python interface file

End result? The warnings are all gone, old code all works the same, but you don't _have_ to do things the old, clunky way anymore:
```python
Python 3.7.4 (default, Jul  9 2019, 16:32:37) 
[GCC 9.1.1 20190503 (Red Hat 9.1.1-1)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import openshot
>>> openshot.GetVersion().ToString()
'0.2.3'
>>> print(openshot.Version)
0.2.3
>>> str(openshot.Version)
'0.2.3'
>>> str(openshot.Version.Major)
'0'
>>> str(openshot.Version.Minor)
'2'
>>> str(openshot.Version.So)
'17'
>>> print(openshot.OpenShotVersion)
<class 'openshot.OpenShotVersion'>
>>> print(openshot.OpenShotVersion())
0.2.3
```

And then I changed things a bit more, and decided to use `OPENSHOT_VERSION_FULL` as the string representation instead:
```python
>>> import openshot
>>> str(openshot.Version)
'0.2.3-dev1'
>>> print(openshot.OpenShotVersion())
0.2.3-dev1
```