### PR TITLE
tests: Add tolerance to pixel value checks

### DIFF
--- a/tests/FFmpegReader_Tests.cpp
+++ b/tests/FFmpegReader_Tests.cpp
@@ -97,10 +97,10 @@ TEST(FFmpegReader_Check_Video_File)
 	int pixel_index = 112 * 4; // pixel 112 (4 bytes per pixel)
 
 	// Check image properties on scanline 10, pixel 112
-	CHECK_EQUAL(21, (int)pixels[pixel_index]);
-	CHECK_EQUAL(191, (int)pixels[pixel_index + 1]);
-	CHECK_EQUAL(0, (int)pixels[pixel_index + 2]);
-	CHECK_EQUAL(255, (int)pixels[pixel_index + 3]);
+	CHECK_CLOSE(21, (int)pixels[pixel_index], 5);
+	CHECK_CLOSE(191, (int)pixels[pixel_index + 1], 5);
+	CHECK_CLOSE(0, (int)pixels[pixel_index + 2], 5);
+	CHECK_CLOSE(255, (int)pixels[pixel_index + 3], 5);
 
 	// Check pixel function
 	CHECK_EQUAL(true, f->CheckPixel(10, 112, 21, 191, 0, 255, 5));
@@ -114,10 +114,10 @@ TEST(FFmpegReader_Check_Video_File)
 	pixel_index = 112 * 4; // pixel 112 (4 bytes per pixel)
 
 	// Check image properties on scanline 10, pixel 112
-	CHECK_EQUAL(0, (int)pixels[pixel_index]);
-	CHECK_EQUAL(96, (int)pixels[pixel_index + 1]);
-	CHECK_EQUAL(188, (int)pixels[pixel_index + 2]);
-	CHECK_EQUAL(255, (int)pixels[pixel_index + 3]);
+	CHECK_CLOSE(0, (int)pixels[pixel_index], 5);
+	CHECK_CLOSE(96, (int)pixels[pixel_index + 1], 5);
+	CHECK_CLOSE(188, (int)pixels[pixel_index + 2], 5);
+	CHECK_CLOSE(255, (int)pixels[pixel_index + 3], 5);
 
 	// Check pixel function
 	CHECK_EQUAL(true, f->CheckPixel(10, 112, 0, 96, 188, 255, 5));

--- a/tests/FFmpegWriter_Tests.cpp
+++ b/tests/FFmpegWriter_Tests.cpp
@@ -75,8 +75,8 @@ TEST(FFmpegWriter_Test_Webm)
 	int pixel_index = 112 * 4; // pixel 112 (4 bytes per pixel)
 
 	// Check image properties on scanline 10, pixel 112
-	CHECK_EQUAL(23, (int)pixels[pixel_index]);
-	CHECK_EQUAL(23, (int)pixels[pixel_index + 1]);
-	CHECK_EQUAL(23, (int)pixels[pixel_index + 2]);
-	CHECK_EQUAL(255, (int)pixels[pixel_index + 3]);
+	CHECK_CLOSE(23, (int)pixels[pixel_index], 5);
+	CHECK_CLOSE(23, (int)pixels[pixel_index + 1], 5);
+	CHECK_CLOSE(23, (int)pixels[pixel_index + 2], 5);
+	CHECK_CLOSE(255, (int)pixels[pixel_index + 3], 5);
 }

--- a/tests/ImageWriter_Tests.cpp
+++ b/tests/ImageWriter_Tests.cpp
@@ -75,9 +75,9 @@ TEST(ImageWriter_Test_Gif)
 	int pixel_index = 230 * 4; // pixel 230 (4 bytes per pixel)
 
 	// Check image properties
-	CHECK_EQUAL(20, (int)pixels[pixel_index]);
-	CHECK_EQUAL(18, (int)pixels[pixel_index + 1]);
-	CHECK_EQUAL(11, (int)pixels[pixel_index + 2]);
-	CHECK_EQUAL(255, (int)pixels[pixel_index + 3]);
+	CHECK_CLOSE(20, (int)pixels[pixel_index], 5);
+	CHECK_CLOSE(18, (int)pixels[pixel_index + 1], 5);
+	CHECK_CLOSE(11, (int)pixels[pixel_index + 2], 5);
+	CHECK_CLOSE(255, (int)pixels[pixel_index + 3], 5);
 }
 #endif

--- a/tests/Timeline_Tests.cpp
+++ b/tests/Timeline_Tests.cpp
@@ -121,64 +121,64 @@ TEST(Timeline_Check_Two_Track_Video)
 	int pixel_index = 230 * 4; // pixel 230 (4 bytes per pixel)
 
 	// Check image properties
-	CHECK_EQUAL(21, (int)f->GetPixels(pixel_row)[pixel_index]);
-	CHECK_EQUAL(191, (int)f->GetPixels(pixel_row)[pixel_index + 1]);
-	CHECK_EQUAL(0, (int)f->GetPixels(pixel_row)[pixel_index + 2]);
-	CHECK_EQUAL(255, (int)f->GetPixels(pixel_row)[pixel_index + 3]);
+	CHECK_CLOSE(21, (int)f->GetPixels(pixel_row)[pixel_index], 5);
+	CHECK_CLOSE(191, (int)f->GetPixels(pixel_row)[pixel_index + 1], 5);
+	CHECK_CLOSE(0, (int)f->GetPixels(pixel_row)[pixel_index + 2], 5);
+	CHECK_CLOSE(255, (int)f->GetPixels(pixel_row)[pixel_index + 3], 5);
 
 	// Get frame
 	f = t.GetFrame(2);
 
 	// Check image properties
-	CHECK_EQUAL(176, (int)f->GetPixels(pixel_row)[pixel_index]);
-	CHECK_EQUAL(0, (int)f->GetPixels(pixel_row)[pixel_index + 1]);
-	CHECK_EQUAL(186, (int)f->GetPixels(pixel_row)[pixel_index + 2]);
-	CHECK_EQUAL(255, (int)f->GetPixels(pixel_row)[pixel_index + 3]);
+	CHECK_CLOSE(176, (int)f->GetPixels(pixel_row)[pixel_index], 5);
+	CHECK_CLOSE(0, (int)f->GetPixels(pixel_row)[pixel_index + 1], 5);
+	CHECK_CLOSE(186, (int)f->GetPixels(pixel_row)[pixel_index + 2], 5);
+	CHECK_CLOSE(255, (int)f->GetPixels(pixel_row)[pixel_index + 3], 5);
 
 	// Get frame
 	f = t.GetFrame(3);
 
 	// Check image properties
-	CHECK_EQUAL(23, (int)f->GetPixels(pixel_row)[pixel_index]);
-	CHECK_EQUAL(190, (int)f->GetPixels(pixel_row)[pixel_index + 1]);
-	CHECK_EQUAL(0, (int)f->GetPixels(pixel_row)[pixel_index + 2]);
-	CHECK_EQUAL(255, (int)f->GetPixels(pixel_row)[pixel_index + 3]);
+	CHECK_CLOSE(23, (int)f->GetPixels(pixel_row)[pixel_index], 5);
+	CHECK_CLOSE(190, (int)f->GetPixels(pixel_row)[pixel_index + 1], 5);
+	CHECK_CLOSE(0, (int)f->GetPixels(pixel_row)[pixel_index + 2], 5);
+	CHECK_CLOSE(255, (int)f->GetPixels(pixel_row)[pixel_index + 3], 5);
 
 	// Get frame
 	f = t.GetFrame(24);
 
 	// Check image properties
-	CHECK_EQUAL(186, (int)f->GetPixels(pixel_row)[pixel_index]);
-	CHECK_EQUAL(106, (int)f->GetPixels(pixel_row)[pixel_index + 1]);
-	CHECK_EQUAL(0, (int)f->GetPixels(pixel_row)[pixel_index + 2]);
-	CHECK_EQUAL(255, (int)f->GetPixels(pixel_row)[pixel_index + 3]);
+	CHECK_CLOSE(186, (int)f->GetPixels(pixel_row)[pixel_index], 5);
+	CHECK_CLOSE(106, (int)f->GetPixels(pixel_row)[pixel_index + 1], 5);
+	CHECK_CLOSE(0, (int)f->GetPixels(pixel_row)[pixel_index + 2], 5);
+	CHECK_CLOSE(255, (int)f->GetPixels(pixel_row)[pixel_index + 3], 5);
 
 	// Get frame
 	f = t.GetFrame(5);
 
 	// Check image properties
-	CHECK_EQUAL(23, (int)f->GetPixels(pixel_row)[pixel_index]);
-	CHECK_EQUAL(190, (int)f->GetPixels(pixel_row)[pixel_index + 1]);
-	CHECK_EQUAL(0, (int)f->GetPixels(pixel_row)[pixel_index + 2]);
-	CHECK_EQUAL(255, (int)f->GetPixels(pixel_row)[pixel_index + 3]);
+	CHECK_CLOSE(23, (int)f->GetPixels(pixel_row)[pixel_index], 5);
+	CHECK_CLOSE(190, (int)f->GetPixels(pixel_row)[pixel_index + 1], 5);
+	CHECK_CLOSE(0, (int)f->GetPixels(pixel_row)[pixel_index + 2], 5);
+	CHECK_CLOSE(255, (int)f->GetPixels(pixel_row)[pixel_index + 3], 5);
 
 	// Get frame
 	f = t.GetFrame(25);
 
 	// Check image properties
-	CHECK_EQUAL(0, (int)f->GetPixels(pixel_row)[pixel_index]);
-	CHECK_EQUAL(94, (int)f->GetPixels(pixel_row)[pixel_index + 1]);
-	CHECK_EQUAL(186, (int)f->GetPixels(pixel_row)[pixel_index + 2]);
-	CHECK_EQUAL(255, (int)f->GetPixels(pixel_row)[pixel_index + 3]);
+	CHECK_CLOSE(0, (int)f->GetPixels(pixel_row)[pixel_index], 5);
+	CHECK_CLOSE(94, (int)f->GetPixels(pixel_row)[pixel_index + 1], 5);
+	CHECK_CLOSE(186, (int)f->GetPixels(pixel_row)[pixel_index + 2], 5);
+	CHECK_CLOSE(255, (int)f->GetPixels(pixel_row)[pixel_index + 3], 5);
 
 	// Get frame
 	f = t.GetFrame(4);
 
 	// Check image properties
-	CHECK_EQUAL(176, (int)f->GetPixels(pixel_row)[pixel_index]);
-	CHECK_EQUAL(0, (int)f->GetPixels(pixel_row)[pixel_index + 1]);
-	CHECK_EQUAL(186, (int)f->GetPixels(pixel_row)[pixel_index + 2]);
-	CHECK_EQUAL(255, (int)f->GetPixels(pixel_row)[pixel_index + 3]);
+	CHECK_CLOSE(176, (int)f->GetPixels(pixel_row)[pixel_index], 5);
+	CHECK_CLOSE(0, (int)f->GetPixels(pixel_row)[pixel_index + 1], 5);
+	CHECK_CLOSE(186, (int)f->GetPixels(pixel_row)[pixel_index + 2], 5);
+	CHECK_CLOSE(255, (int)f->GetPixels(pixel_row)[pixel_index + 3], 5);
 
 	// Close reader
 	t.Close();


### PR DESCRIPTION
Our internal `CheckPixel()` function takes a tolerance argument, and is always given a tolerance of 5 when it's used in the unit tests. But the unit tests require pixel values to be exactly `CHECK_EQUAL` to some specific level, which is not always the case on non-i686 / non-x86_64 platforms.

This change adds the same 5-value tolerance to the pixel-value unit tests, allowing the tests to more readily pass on ARM and other platforms.

Fixes #332 #51 