### PR TITLE
DynamicEffects: Add code for Linux with tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@
 .project
 .cproject
 /.metadata/
+/plugins*
 *~

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,6 +95,7 @@ FILE(GLOB QT_HEADER_FILES "${QT_HEADER_DIR}/*.h")
 ############## PROCESS SUB-DIRECTORIES ##############
 add_subdirectory(src)
 add_subdirectory(tests)
+add_subdirectory(external-effects)
 
 ################### DOCUMENTATION ###################
 # Find Doxygen (used for documentation)

--- a/external-effects/CMakeLists.txt
+++ b/external-effects/CMakeLists.txt
@@ -1,0 +1,29 @@
+####################### CMakeLists.txt (libopenshot) #########################
+# @brief CMake build file for libopenshot (used to generate makefiles)
+# @author Jonathan Thomas <jonathan@openshot.org>
+#
+# @section LICENSE
+#
+# Copyright (c) 2008-2019 OpenShot Studios, LLC
+# <http://www.openshotstudios.com/>. This file is part of
+# OpenShot Library (libopenshot), an open-source project dedicated to
+# delivering high quality video editing and animation solutions to the
+# world. For more information visit <http://www.openshot.org/>.
+#
+# OpenShot Library (libopenshot) is free software: you can redistribute it
+# and/or modify it under the terms of the GNU Lesser General Public License
+# as published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# OpenShot Library (libopenshot) is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with OpenShot Library. If not, see <http://www.gnu.org/licenses/>.
+################################################################################
+
+############## PROCESS SUB-DIRECTORIES ##############
+add_subdirectory(super-blur)
+

--- a/external-effects/super-blur/CMakeLists.txt
+++ b/external-effects/super-blur/CMakeLists.txt
@@ -27,28 +27,6 @@
 # Pick up our include directories from the parent context
 include_directories(${OPENSHOT_INCLUDE_DIRS})
 
-SET(TEST_MEDIA_PATH "${PROJECT_SOURCE_DIR}/src/examples/")
-SET(TEST_PLUGINS_PATH "${PROJECT_SOURCE_DIR}/plugins/")
-add_definitions( -DTEST_PLUGINS_PATH="${TEST_PLUGINS_PATH}" )
-
-################ WINDOWS ##################
-# Set some compiler options for Windows
-# required for libopenshot-audio headers
-IF (WIN32)
-	STRING(REPLACE "/" "\\\\" TEST_MEDIA_PATH TEST_MEDIA_PATH)
-	add_definitions( -DIGNORE_JUCE_HYPOT=1 )
-	SET(CMAKE_CXX_FLAGS " ${CMAKE_CXX_FLAGS} -include cmath")
-ENDIF(WIN32)
-
-add_definitions( -DTEST_MEDIA_PATH="${TEST_MEDIA_PATH}" )
-
-################### UNITTEST++ #####################
-# Find UnitTest++ libraries (used for unit testing)
-FIND_PACKAGE(UnitTest++ REQUIRED)
-
-# Include UnitTest++ headers (needed for compile)
-include_directories(${UNITTEST++_INCLUDE_DIR})
-
 ################ IMAGE MAGICK ##################
 # Set the Quantum Depth that ImageMagick was built with (default to 16 bits)
 IF (MAGICKCORE_QUANTUM_DEPTH)
@@ -159,38 +137,25 @@ if (USE_SYSTEM_JSONCPP)
 	find_package(JsonCpp REQUIRED)
 	include_directories(${JSONCPP_INCLUDE_DIRS})
 else()
-	include_directories("../thirdparty/jsoncpp")
+	include_directories("../../thirdparty/jsoncpp")
 endif(USE_SYSTEM_JSONCPP)
 
-IF (NOT DISABLE_TESTS)
-	###############  SET TEST SOURCE FILES  #################
-	SET ( OPENSHOT_TEST_FILES tests.cpp
-		   Cache_Tests.cpp
-		   Clip_Tests.cpp
-		   Color_Tests.cpp
-		   Coordinate_Tests.cpp
-           DynamicEffects_Tests.cpp
-		   ReaderBase_Tests.cpp
-		   ImageWriter_Tests.cpp
-		   FFmpegReader_Tests.cpp
-		   FFmpegWriter_Tests.cpp
-		   Fraction_Tests.cpp
-		   FrameMapper_Tests.cpp
-		   KeyFrame_Tests.cpp
-		   Point_Tests.cpp
-		   Settings_Tests.cpp
-		   Timeline_Tests.cpp )
+SET ( EFFECT_SOURCE_FILES
+		SuperBlur.cpp)
 
-	################ TESTER EXECUTABLE #################
-	# Create unit test executable (openshot-test)
-	add_executable(openshot-test
-				   tests.cpp
-				   ${OPENSHOT_TEST_FILES} )
+IF (NOT DISABLE_EXTERNAL_EFFECTS)
+	# Create shared openshot library
+	add_library(libeffectsuperblur SHARED
+			${EFFECT_SOURCE_FILES})
 
-	# Link libraries to the new executable
-	target_link_libraries(openshot-test openshot ${UNITTEST++_LIBRARY} libeffectsuperblur)
+	set(LIB_INSTALL_DIR libeffect${LIB_SUFFIX}) # determine correct lib folder
 
-	#################### MAKE TEST ######################
-	# Hook up the 'make os_test' target to the 'openshot-test' executable
-	ADD_CUSTOM_TARGET(os_test COMMAND openshot-test)
-ENDIF (NOT DISABLE_TESTS)
+	add_custom_command(
+			TARGET libeffectsuperblur
+			POST_BUILD
+			COMMAND ${CMAKE_COMMAND} -E copy
+			$<TARGET_FILE:libeffectsuperblur>
+			${PROJECT_SOURCE_DIR}/plugins/$<TARGET_FILE_NAME:libeffectsuperblur>
+	)
+
+ENDIF (NOT DISABLE_EXTERNAL_EFFECTS)

--- a/external-effects/super-blur/SuperBlur.cpp
+++ b/external-effects/super-blur/SuperBlur.cpp
@@ -1,0 +1,348 @@
+/**
+ * @file
+ * @brief Source file for Blur effect class
+ * @author Jonathan Thomas <jonathan@openshot.org>
+ *
+ * @ref License
+ */
+
+/* LICENSE
+ *
+ * Copyright (c) 2008-2019 OpenShot Studios, LLC
+ * <http://www.openshotstudios.com/>. This file is part of
+ * OpenShot Library (libopenshot), an open-source project dedicated to
+ * delivering high quality video editing and animation solutions to the
+ * world. For more information visit <http://www.openshot.org/>.
+ *
+ * OpenShot Library (libopenshot) is free software: you can redistribute it
+ * and/or modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * OpenShot Library (libopenshot) is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with OpenShot Library. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "./SuperBlur.h"
+
+using namespace openshot;
+
+void * factory(){
+    return (void *)new SuperBlur();
+}
+
+/// Blank constructor, useful when using Json to load the effect properties
+SuperBlur::SuperBlur() : horizontal_radius(6.0), vertical_radius(6.0), sigma(3.0), iterations(3.0) {
+	// Init effect properties
+	init_effect_details();
+}
+
+// Default constructor
+SuperBlur::SuperBlur(Keyframe new_horizontal_radius, Keyframe new_vertical_radius, Keyframe new_sigma, Keyframe new_iterations) :
+		horizontal_radius(new_horizontal_radius), vertical_radius(new_vertical_radius),
+		sigma(new_sigma), iterations(new_iterations)
+{
+	// Init effect properties
+	init_effect_details();
+}
+
+// Init effect settings
+void SuperBlur::init_effect_details()
+{
+	/// Initialize the values of the EffectInfo struct.
+	InitEffectInfo();
+
+	/// Set the effect info
+	info.class_name = "SuperBlur";
+	info.name = "SuperBlur";
+	info.description = "Adjust the blur of the frame's image.";
+	info.has_audio = false;
+	info.has_video = true;
+}
+
+// This method is required for all derived classes of EffectBase, and returns a
+// modified openshot::Frame object
+std::shared_ptr<Frame> SuperBlur::GetFrame(std::shared_ptr<Frame> frame, int64_t frame_number)
+{
+	// Get the frame's image
+	std::shared_ptr<QImage> frame_image = frame->GetImage();
+
+	// Get the current blur radius
+	int horizontal_radius_value = horizontal_radius.GetValue(frame_number);
+	int vertical_radius_value = vertical_radius.GetValue(frame_number);
+	float sigma_value = sigma.GetValue(frame_number);
+	int iteration_value = iterations.GetInt(frame_number);
+
+
+	// Declare arrays for each color channel
+	unsigned char *red = new unsigned char[frame_image->width() * frame_image->height()]();
+	unsigned char *green = new unsigned char[frame_image->width() * frame_image->height()]();
+	unsigned char *blue = new unsigned char[frame_image->width() * frame_image->height()]();
+	unsigned char *alpha = new unsigned char[frame_image->width() * frame_image->height()]();
+	// Create empty target RGBA arrays (for the results of our blur)
+	unsigned char *blur_red = new unsigned char[frame_image->width() * frame_image->height()]();
+	unsigned char *blur_green = new unsigned char[frame_image->width() * frame_image->height()]();
+	unsigned char *blur_blue = new unsigned char[frame_image->width() * frame_image->height()]();
+	unsigned char *blur_alpha = new unsigned char[frame_image->width() * frame_image->height()]();
+
+	// Loop through pixels and split RGBA channels into separate arrays
+	unsigned char *pixels = (unsigned char *) frame_image->bits();
+	for (int pixel = 0, byte_index=0; pixel < frame_image->width() * frame_image->height(); pixel++, byte_index+=4)
+	{
+		// Get the RGBA values from each pixel
+		unsigned char R = pixels[byte_index];
+		unsigned char G = pixels[byte_index + 1];
+		unsigned char B = pixels[byte_index + 2];
+		unsigned char A = pixels[byte_index + 3];
+
+		// Split channels into their own arrays
+		red[pixel] = R;
+		green[pixel] = G;
+		blue[pixel] = B;
+		alpha[pixel] = A;
+	}
+
+	// Init target RGBA arrays
+	for (int i = 0; i < (frame_image->width() * frame_image->height()); i++) blur_red[i] = red[i];
+	for (int i = 0; i < (frame_image->width() * frame_image->height()); i++) blur_green[i] = green[i];
+	for (int i = 0; i < (frame_image->width() * frame_image->height()); i++) blur_blue[i] = blue[i];
+	for (int i = 0; i < (frame_image->width() * frame_image->height()); i++) blur_alpha[i] = alpha[i];
+
+	// Loop through each iteration
+	for (int iteration = 0; iteration < iteration_value; iteration++)
+	{
+		// HORIZONTAL BLUR (if any)
+		if (horizontal_radius_value > 0.0) {
+			// Init boxes for computing blur
+			int *bxs = initBoxes(sigma_value, horizontal_radius_value);
+
+			// Apply horizontal blur to target RGBA channels
+			boxBlurH(red, blur_red, frame_image->width(), frame_image->height(), horizontal_radius_value);
+			boxBlurH(green, blur_green, frame_image->width(), frame_image->height(), horizontal_radius_value);
+			boxBlurH(blue, blur_blue, frame_image->width(), frame_image->height(), horizontal_radius_value);
+			boxBlurH(alpha, blur_alpha, frame_image->width(), frame_image->height(), horizontal_radius_value);
+
+			// Remove boxes
+			delete[] bxs;
+
+			// Copy blur_<chan> back to <chan> for vertical blur or next iteration
+			for (int i = 0; i < (frame_image->width() * frame_image->height()); i++) red[i] = blur_red[i];
+			for (int i = 0; i < (frame_image->width() * frame_image->height()); i++) green[i] = blur_green[i];
+			for (int i = 0; i < (frame_image->width() * frame_image->height()); i++) blue[i] = blur_blue[i];
+			for (int i = 0; i < (frame_image->width() * frame_image->height()); i++) alpha[i] = blur_alpha[i];
+		}
+
+		// VERTICAL BLUR (if any)
+		if (vertical_radius_value > 0.0) {
+			// Init boxes for computing blur
+			int *bxs = initBoxes(sigma_value, vertical_radius_value);
+
+			// Apply vertical blur to target RGBA channels
+			boxBlurT(red, blur_red, frame_image->width(), frame_image->height(), vertical_radius_value);
+			boxBlurT(green, blur_green, frame_image->width(), frame_image->height(), vertical_radius_value);
+			boxBlurT(blue, blur_blue, frame_image->width(), frame_image->height(), vertical_radius_value);
+			boxBlurT(alpha, blur_alpha, frame_image->width(), frame_image->height(), vertical_radius_value);
+
+			// Remove boxes
+			delete[] bxs;
+
+			// Copy blur_<chan> back to <chan> for vertical blur or next iteration
+			for (int i = 0; i < (frame_image->width() * frame_image->height()); i++) red[i] = blur_red[i];
+			for (int i = 0; i < (frame_image->width() * frame_image->height()); i++) green[i] = blur_green[i];
+			for (int i = 0; i < (frame_image->width() * frame_image->height()); i++) blue[i] = blur_blue[i];
+			for (int i = 0; i < (frame_image->width() * frame_image->height()); i++) alpha[i] = blur_alpha[i];
+		}
+	}
+
+	// Copy RGBA channels back to original image
+	for (int pixel = 0, byte_index=0; pixel < frame_image->width() * frame_image->height(); pixel++, byte_index+=4)
+	{
+		// Get the RGB values from the pixel
+		unsigned char R = blur_red[pixel];
+		unsigned char G = blur_green[pixel];
+		unsigned char B = blur_blue[pixel];
+		unsigned char A = blur_alpha[pixel];
+
+		// Split channels into their own arrays
+		pixels[byte_index] = R;
+		pixels[byte_index + 1] = G;
+		pixels[byte_index + 2] = B;
+		pixels[byte_index + 3] = A;
+	}
+
+	// Delete channel arrays
+	delete[] red;
+	delete[] green;
+	delete[] blue;
+	delete[] alpha;
+	delete[] blur_red;
+	delete[] blur_green;
+	delete[] blur_blue;
+	delete[] blur_alpha;
+
+	// return the modified frame
+	return frame;
+}
+
+// Credit: http://blog.ivank.net/fastest-gaussian-blur.html (MIT License)
+int* SuperBlur::initBoxes(float sigma, int n)  // standard deviation, number of boxes
+{
+	float wIdeal = sqrt((12.0 * sigma * sigma / n) + 1.0);  // Ideal averaging filter width
+	int wl = floor(wIdeal);
+	if (wl % 2 == 0) wl--;
+	int wu = wl + 2;
+
+	float mIdeal = (12.0 * sigma * sigma - n * wl * wl - 4 * n * wl - 3 * n) / (-4.0 * wl - 4);
+	int m = round(mIdeal);
+
+	int *sizes = new int[n]();
+	for (int i = 0; i < n; i++) sizes[i] = i < m ? wl : wu;
+	return sizes;
+}
+
+// Credit: http://blog.ivank.net/fastest-gaussian-blur.html (MIT License)
+void SuperBlur::boxBlurH(unsigned char *scl, unsigned char *tcl, int w, int h, int r) {
+	float iarr = 1.0 / (r + r + 1);
+	for (int i = 0; i < h; i++) {
+		int ti = i * w, li = ti, ri = ti + r;
+		int fv = scl[ti], lv = scl[ti + w - 1], val = (r + 1) * fv;
+		for (int j = 0; j < r; j++) val += scl[ti + j];
+		for (int j = 0; j <= r; j++) {
+			val += scl[ri++] - fv;
+			tcl[ti++] = round(val * iarr);
+		}
+		for (int j = r + 1; j < w - r; j++) {
+			val += scl[ri++] - scl[li++];
+			tcl[ti++] = round(val * iarr);
+		}
+		for (int j = w - r; j < w; j++) {
+			val += lv - scl[li++];
+			tcl[ti++] = round(val * iarr);
+		}
+	}
+}
+
+void SuperBlur::boxBlurT(unsigned char *scl, unsigned char *tcl, int w, int h, int r) {
+	float iarr = 1.0 / (r + r + 1);
+	for (int i = 0; i < w; i++) {
+		int ti = i, li = ti, ri = ti + r * w;
+		int fv = scl[ti], lv = scl[ti + w * (h - 1)], val = (r + 1) * fv;
+		for (int j = 0; j < r; j++) val += scl[ti + j * w];
+		for (int j = 0; j <= r; j++) {
+			val += scl[ri] - fv;
+			tcl[ti] = round(val * iarr);
+			ri += w;
+			ti += w;
+		}
+		for (int j = r + 1; j < h - r; j++) {
+			val += scl[ri] - scl[li];
+			tcl[ti] = round(val * iarr);
+			li += w;
+			ri += w;
+			ti += w;
+		}
+		for (int j = h - r; j < h; j++) {
+			val += lv - scl[li];
+			tcl[ti] = round(val * iarr);
+			li += w;
+			ti += w;
+		}
+	}
+}
+
+// Generate JSON string of this object
+string SuperBlur::Json() {
+
+	// Return formatted string
+	return JsonValue().toStyledString();
+}
+
+// Generate Json::JsonValue for this object
+Json::Value SuperBlur::JsonValue() {
+
+	// Create root json object
+	Json::Value root = EffectBase::JsonValue(); // get parent properties
+	root["type"] = info.class_name;
+	root["horizontal_radius"] = horizontal_radius.JsonValue();
+	root["vertical_radius"] = vertical_radius.JsonValue();
+	root["sigma"] = sigma.JsonValue();
+	root["iterations"] = iterations.JsonValue();
+
+	// return JsonValue
+	return root;
+}
+
+// Load JSON string into this object
+void SuperBlur::SetJson(string value) {
+
+	// Parse JSON string into JSON objects
+	Json::Value root;
+	Json::CharReaderBuilder rbuilder;
+	Json::CharReader* reader(rbuilder.newCharReader());
+
+	string errors;
+	bool success = reader->parse( value.c_str(),
+                 value.c_str() + value.size(), &root, &errors );
+	delete reader;
+
+	if (!success)
+		// Raise exception
+		throw InvalidJSON("JSON could not be parsed (or is invalid)", "");
+
+	try
+	{
+		// Set all values that match
+		SetJsonValue(root);
+	}
+	catch (const std::exception& e)
+	{
+		// Error parsing JSON (or missing keys)
+		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)", "");
+	}
+}
+
+// Load Json::JsonValue into this object
+void SuperBlur::SetJsonValue(Json::Value root) {
+
+	// Set parent data
+	EffectBase::SetJsonValue(root);
+
+	// Set data from Json (if key is found)
+	if (!root["horizontal_radius"].isNull())
+		horizontal_radius.SetJsonValue(root["horizontal_radius"]);
+	if (!root["vertical_radius"].isNull())
+		vertical_radius.SetJsonValue(root["vertical_radius"]);
+	if (!root["sigma"].isNull())
+		sigma.SetJsonValue(root["sigma"]);
+	if (!root["iterations"].isNull())
+		iterations.SetJsonValue(root["iterations"]);
+}
+
+// Get all properties for a specific frame
+string SuperBlur::PropertiesJSON(int64_t requested_frame) {
+
+	// Generate JSON properties list
+	Json::Value root;
+	root["id"] = add_property_json("ID", 0.0, "string", Id(), NULL, -1, -1, true, requested_frame);
+	root["position"] = add_property_json("Position", Position(), "float", "", NULL, 0, 1000 * 60 * 30, false, requested_frame);
+	root["layer"] = add_property_json("Track", Layer(), "int", "", NULL, 0, 20, false, requested_frame);
+	root["start"] = add_property_json("Start", Start(), "float", "", NULL, 0, 1000 * 60 * 30, false, requested_frame);
+	root["end"] = add_property_json("End", End(), "float", "", NULL, 0, 1000 * 60 * 30, false, requested_frame);
+	root["duration"] = add_property_json("Duration", Duration(), "float", "", NULL, 0, 1000 * 60 * 30, true, requested_frame);
+
+	// Keyframes
+	root["horizontal_radius"] = add_property_json("Horizontal Radius", horizontal_radius.GetValue(requested_frame), "float", "", &horizontal_radius, 0, 100, false, requested_frame);
+	root["vertical_radius"] = add_property_json("Vertical Radius", vertical_radius.GetValue(requested_frame), "float", "", &vertical_radius, 0, 100, false, requested_frame);
+	root["sigma"] = add_property_json("Sigma", sigma.GetValue(requested_frame), "float", "", &sigma, 0, 100, false, requested_frame);
+	root["iterations"] = add_property_json("Iterations", iterations.GetValue(requested_frame), "float", "", &iterations, 0, 100, false, requested_frame);
+
+	// Return formatted string
+	return root.toStyledString();
+}
+
+

--- a/external-effects/super-blur/SuperBlur.h
+++ b/external-effects/super-blur/SuperBlur.h
@@ -1,0 +1,130 @@
+/**
+ * @file
+ * @brief Header file for SuperBlur effect class
+ * @author Jonathan Thomas <jonathan@openshot.org>
+ *
+ * @ref License
+ */
+
+/* LICENSE
+ *
+ * Copyright (c) 2008-2019 OpenShot Studios, LLC
+ * <http://www.openshotstudios.com/>. This file is part of
+ * OpenShot Library (libopenshot), an open-source project dedicated to
+ * delivering high quality video editing and animation solutions to the
+ * world. For more information visit <http://www.openshot.org/>.
+ *
+ * OpenShot Library (libopenshot) is free software: you can redistribute it
+ * and/or modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * OpenShot Library (libopenshot) is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with OpenShot Library. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef OPENSHOT_EXTERNAL_BLUR_EFFECT_H
+#define OPENSHOT_EXTERNAL_BLUR_EFFECT_H
+
+#include "../../include/EffectBase.h"
+
+#include <cmath>
+#include <ctime>
+#include <iostream>
+#include <omp.h>
+#include <stdio.h>
+#include <memory>
+#include <QRect>
+#include "../../include/Color.h"
+#include "../../include/Exceptions.h"
+#include "../../include/Json.h"
+#include "../../include/KeyFrame.h"
+#include "../../include/ReaderBase.h"
+#include "../../include/FFmpegReader.h"
+#include "../../include/QtImageReader.h"
+#include "../../include/ChunkReader.h"
+
+using namespace std;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void * factory();
+
+#ifdef __cplusplus
+}
+#endif
+
+
+namespace openshot
+{
+
+	/**
+	 * @brief This class adjusts the blur of an image, and can be animated
+	 * with openshot::Keyframe curves over time.
+	 *
+	 * Adjusting the blur of an image over time can create many different powerful effects. To achieve a
+	 * box blur effect, use identical horizontal and vertical blur values. To achieve a Gaussian blur,
+	 * use 3 iterations, a sigma of 3.0, and a radius between 3 and X (depending on how much blur you want).
+	 */
+	class SuperBlur : public EffectBase
+	{
+	private:
+		/// Init effect settings
+		void init_effect_details();
+
+		/// Internal blur methods (inspired and credited to http://blog.ivank.net/fastest-gaussian-blur.html)
+		int* initBoxes(float sigma, int n);
+		void boxBlurH(unsigned char *scl, unsigned char *tcl, int w, int h, int r);
+		void boxBlurT(unsigned char *scl, unsigned char *tcl, int w, int h, int r);
+
+
+	public:
+		Keyframe horizontal_radius;	///< Horizontal blur radius keyframe. The size of the horizontal blur operation in pixels.
+		Keyframe vertical_radius;	///< Vertical blur radius keyframe. The size of the vertical blur operation in pixels.
+		Keyframe sigma;				///< Sigma keyframe. The amount of spread in the blur operation. Should be larger than radius.
+		Keyframe iterations;		///< Iterations keyframe. The # of blur iterations per pixel. 3 iterations = Gaussian.
+
+		/// Blank constructor, useful when using Json to load the effect properties
+        SuperBlur();
+
+		/// Default constructor, which takes 1 curve. The curve adjusts the blur radius
+		/// of a frame's image.
+		///
+		/// @param new_horizontal_radius The curve to adjust the horizontal blur radius (between 0 and 100, rounded to int)
+		/// @param new_vertical_radius The curve to adjust the vertical blur radius (between 0 and 100, rounded to int)
+		/// @param new_sigma The curve to adjust the sigma amount (the size of the blur brush (between 0 and 100), float values accepted)
+		/// @param new_iterations The curve to adjust the # of iterations (between 1 and 100)
+        SuperBlur(Keyframe new_horizontal_radius, Keyframe new_vertical_radius, Keyframe new_sigma, Keyframe new_iterations);
+
+		/// @brief This method is required for all derived classes of EffectBase, and returns a
+		/// modified openshot::Frame object
+		///
+		/// The frame object is passed into this method, and a frame_number is passed in which
+		/// tells the effect which settings to use from its keyframes (starting at 1).
+		///
+		/// @returns The modified openshot::Frame object
+		/// @param frame The frame object that needs the effect applied to it
+		/// @param frame_number The frame number (starting at 1) of the effect on the timeline.
+		std::shared_ptr<Frame> GetFrame(std::shared_ptr<Frame> frame, int64_t frame_number);
+
+		/// Get and Set JSON methods
+		string Json(); ///< Generate JSON string of this object
+		void SetJson(string value); ///< Load JSON string into this object
+		Json::Value JsonValue(); ///< Generate Json::JsonValue for this object
+		void SetJsonValue(Json::Value root); ///< Load Json::JsonValue into this object
+
+		/// Get all properties for a specific frame (perfect for a UI to display the current state
+		/// of all properties at any time)
+		string PropertiesJSON(int64_t requested_frame);
+	};
+
+}
+
+#endif

--- a/include/EffectInfo.h
+++ b/include/EffectInfo.h
@@ -32,6 +32,14 @@
 #define OPENSHOT_EFFECT_INFO_H
 
 #include "Effects.h"
+#include <vector>
+#include <map>
+#include <pthread.h>
+
+
+#if defined(__linux__)
+#include <dlfcn.h>
+#endif
 
 
 using namespace std;
@@ -51,9 +59,18 @@ namespace openshot
 		// Create an instance of an effect (factory style)
 		EffectBase* CreateEffect(string effect_type);
 
+		// Load effect built in shared library (factory style)
+		EffectBase* LoadEffect(string location);
+
+		// Unload all effect loaded dynamically
+		void UnloadDynamicEffects();
+
 		/// JSON methods
 		static string Json(); ///< Generate JSON string of this object
 		static Json::Value JsonValue(); ///< Generate Json::JsonValue for this object
+
+    private:
+        pthread_mutex_t		m_mutex;
 
 	};
 

--- a/tests/DynamicEffects_Tests.cpp
+++ b/tests/DynamicEffects_Tests.cpp
@@ -1,0 +1,93 @@
+/**
+ * @file
+ * @brief Unit tests for openshot::Timeline
+ * @author Jonathan Thomas <jonathan@openshot.org>
+ *
+ * @ref License
+ */
+
+/* LICENSE
+ *
+ * Copyright (c) 2008-2019 OpenShot Studios, LLC
+ * <http://www.openshotstudios.com/>. This file is part of
+ * OpenShot Library (libopenshot), an open-source project dedicated to
+ * delivering high quality video editing and animation solutions to the
+ * world. For more information visit <http://www.openshot.org/>.
+ *
+ * OpenShot Library (libopenshot) is free software: you can redistribute it
+ * and/or modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * OpenShot Library (libopenshot) is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with OpenShot Library. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "UnitTest++.h"
+#include "../include/OpenShot.h"
+
+#ifdef TEST_PLUGINS_PATH
+#define TEST_PLUGINS_PATH_LIB TEST_PLUGINS_PATH "liblibeffectsuperblur.so"
+#else
+#define TEST_PLUGINS_PATH_LIB "liblibeffectsuperblur.so"
+#endif
+
+using namespace std;
+using namespace openshot;
+
+
+TEST(DynamicEffect_Loader)
+{
+    auto effect_info = EffectInfo();
+    effect_info.UnloadDynamicEffects();
+
+    auto effect = effect_info.LoadEffect(TEST_PLUGINS_PATH_LIB);
+
+    CHECK(effect != nullptr);
+
+    delete effect;
+}
+
+
+TEST(DynamicEffect_DoubleLoader)
+{
+    auto effect_info = EffectInfo();
+    effect_info.UnloadDynamicEffects();
+
+    auto effect = effect_info.LoadEffect(TEST_PLUGINS_PATH_LIB);
+
+    CHECK(effect != nullptr);
+
+    delete effect;
+
+    effect = effect_info.LoadEffect(TEST_PLUGINS_PATH_LIB);
+
+    CHECK(effect != nullptr);
+
+    delete effect;
+}
+
+
+TEST(DynamicEffect_ReachByName)
+{
+    auto effect_info = EffectInfo();
+    effect_info.UnloadDynamicEffects();
+
+    auto effect = effect_info.LoadEffect(TEST_PLUGINS_PATH_LIB);
+
+    CHECK(effect != nullptr);
+
+    delete effect;
+
+    effect = effect_info.CreateEffect("SuperBlur");
+
+    CHECK(effect != nullptr);
+
+    delete effect;
+}
+


### PR DESCRIPTION
This PR adds possibility to develop and integrate effects for libopenshot as a shared library.
Right now it works only for Linux, on other platform this method does not do anything (returns NULL).

As an example of "plugin" I've copied Blur effect with name SuperBlur.

From user-perspective, this feature is needed to have an ability create granular "plugins" w/o entire libopenshot compilation.

Later, this system needs to be improved to:

1. Make an ability to contain more then one effect in library
2. Add version check during plugin loading (to be sure that plugin was developed for correct version of libopenshot)
3. Add after-loading of plugins if path to them is provided in env. variable