### PR TITLE
Stop 24 hours worth for frames being loaded in to memory (#327)

### DIFF
--- a/src/ImageReader.cpp
+++ b/src/ImageReader.cpp
@@ -82,7 +82,7 @@ void ImageReader::Open()
 		info.height = image->size().height();
 		info.pixel_ratio.num = 1;
 		info.pixel_ratio.den = 1;
-		info.duration = 1;
+		info.duration = 60 * 60 * 1;  // 1 hour duration
 		info.fps.num = 30;
 		info.fps.den = 1;
 		info.video_timebase.num = 1;

--- a/src/ImageReader.cpp
+++ b/src/ImageReader.cpp
@@ -82,7 +82,7 @@ void ImageReader::Open()
 		info.height = image->size().height();
 		info.pixel_ratio.num = 1;
 		info.pixel_ratio.den = 1;
-		info.duration = 60 * 60 * 24; // 24 hour duration
+		info.duration = 1;
 		info.fps.num = 30;
 		info.fps.den = 1;
 		info.video_timebase.num = 1;

--- a/src/QtImageReader.cpp
+++ b/src/QtImageReader.cpp
@@ -123,7 +123,7 @@ void QtImageReader::Open()
 		info.height = image->height();
 		info.pixel_ratio.num = 1;
 		info.pixel_ratio.den = 1;
-		info.duration = 60 * 60 * 24; // 24 hour duration
+		info.duration = 1;
 		info.fps.num = 30;
 		info.fps.den = 1;
 		info.video_timebase.num = 1;

--- a/src/QtImageReader.cpp
+++ b/src/QtImageReader.cpp
@@ -123,7 +123,7 @@ void QtImageReader::Open()
 		info.height = image->height();
 		info.pixel_ratio.num = 1;
 		info.pixel_ratio.den = 1;
-		info.duration = 1;
+		info.duration = 60 * 60 * 1;  // 1 hour duration
 		info.fps.num = 30;
 		info.fps.den = 1;
 		info.video_timebase.num = 1;

--- a/src/TextReader.cpp
+++ b/src/TextReader.cpp
@@ -127,7 +127,7 @@ void TextReader::Open()
 		info.height = image->size().height();
 		info.pixel_ratio.num = 1;
 		info.pixel_ratio.den = 1;
-		info.duration = 60 * 60 * 24; // 24 hour duration
+		info.duration = 1;
 		info.fps.num = 30;
 		info.fps.den = 1;
 		info.video_timebase.num = 1;

--- a/src/TextReader.cpp
+++ b/src/TextReader.cpp
@@ -127,7 +127,7 @@ void TextReader::Open()
 		info.height = image->size().height();
 		info.pixel_ratio.num = 1;
 		info.pixel_ratio.den = 1;
-		info.duration = 1;
+		info.duration = 60 * 60 * 1;  // 1 hour duration
 		info.fps.num = 30;
 		info.fps.den = 1;
 		info.video_timebase.num = 1;


### PR DESCRIPTION
The 24 hours duration seems to be creating millions of additional frames (24 hours worth) in the FrameMapper for text readers and I presume image readers to as they are just single image frames. This is causing massive memory spikes in the text reader everytime a new TextReader is added.

Not sure why the duration is set to 24 hours, as far as I can tell everything works as expected with a duration of 1 and the memory issue is gone.

Fixes issue #327 