### PR TITLE
DISABLE_TESTS covers entire tests/ dir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,5 +115,6 @@ install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/doc/html/
 endif()
 
 ############# PROCESS tests/ DIRECTORY ##############
-add_subdirectory(tests)
-
+if(NOT DISABLE_TESTS)
+  add_subdirectory(tests)
+endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -160,52 +160,50 @@ else()
 	include_directories("../thirdparty/jsoncpp")
 endif(USE_SYSTEM_JSONCPP)
 
-IF (NOT DISABLE_TESTS)
-	###############  SET TEST SOURCE FILES  #################
-	SET ( OPENSHOT_TEST_FILES
-		   Cache_Tests.cpp
-		   Clip_Tests.cpp
-		   Color_Tests.cpp
-		   Coordinate_Tests.cpp
-		   ReaderBase_Tests.cpp
-		   ImageWriter_Tests.cpp
-		   FFmpegReader_Tests.cpp
-		   FFmpegWriter_Tests.cpp
-		   Fraction_Tests.cpp
-		   FrameMapper_Tests.cpp
-		   KeyFrame_Tests.cpp
-		   Point_Tests.cpp
-		   Settings_Tests.cpp
-		   Timeline_Tests.cpp )
+###############  SET TEST SOURCE FILES  #################
+SET ( OPENSHOT_TEST_FILES
+	   Cache_Tests.cpp
+	   Clip_Tests.cpp
+	   Color_Tests.cpp
+	   Coordinate_Tests.cpp
+	   ReaderBase_Tests.cpp
+	   ImageWriter_Tests.cpp
+	   FFmpegReader_Tests.cpp
+	   FFmpegWriter_Tests.cpp
+	   Fraction_Tests.cpp
+	   FrameMapper_Tests.cpp
+	   KeyFrame_Tests.cpp
+	   Point_Tests.cpp
+	   Settings_Tests.cpp
+	   Timeline_Tests.cpp )
 
-	################ TESTER EXECUTABLE #################
-	# Create unit test executable (openshot-test)
-	message (STATUS "Tests enabled, test executable will be built as tests/openshot-test")
-	add_executable(openshot-test
-				   tests.cpp
-				   ${OPENSHOT_TEST_FILES} )
+################ TESTER EXECUTABLE #################
+# Create unit test executable (openshot-test)
+message (STATUS "Tests enabled, test executable will be built as tests/openshot-test")
+add_executable(openshot-test
+			   tests.cpp
+			   ${OPENSHOT_TEST_FILES} )
 
-	# Link libraries to the new executable
-	target_link_libraries(openshot-test openshot ${UNITTEST++_LIBRARY})
+# Link libraries to the new executable
+target_link_libraries(openshot-test openshot ${UNITTEST++_LIBRARY})
 
-	##### RUNNING TESTS (make os_test / make test) #####
-	# Hook up the 'make os_test' target to the 'openshot-test' executable
-	ADD_CUSTOM_TARGET(os_test COMMAND openshot-test)
-	list(APPEND OS_TEST_CMDS "'make os_test'")
+##### RUNNING TESTS (make os_test / make test) #####
+# Hook up the 'make os_test' target to the 'openshot-test' executable
+ADD_CUSTOM_TARGET(os_test COMMAND openshot-test)
+list(APPEND OS_TEST_CMDS "'make os_test'")
 
-	# Also hook up 'make test', if possible
-	# This requires CMake 3.11+, where the CMP0037 policy
-	# configured to 'NEW' mode will not reserve target names
-	# unless the corresponding feature is actually used
-	if (POLICY CMP0037)
-		cmake_policy(SET CMP0037 NEW)
-	endif()
-	if (CMAKE_VERSION VERSION_GREATER 3.11)
-		message(STATUS "Cmake 3.11+ detected, enabling 'test' target")
-		add_custom_target(test COMMAND openshot-test)
-		list(APPEND OS_TEST_CMDS " or " "'make test'")
-	endif()
-
-	string(CONCAT t ${OS_TEST_CMDS})
-	message("\nTo run unit tests, use: ${t}")
+# Also hook up 'make test', if possible
+# This requires CMake 3.11+, where the CMP0037 policy
+# configured to 'NEW' mode will not reserve target names
+# unless the corresponding feature is actually used
+if (POLICY CMP0037)
+	cmake_policy(SET CMP0037 NEW)
 endif()
+if (CMAKE_VERSION VERSION_GREATER 3.11)
+	message(STATUS "Cmake 3.11+ detected, enabling 'test' target")
+	add_custom_target(test COMMAND openshot-test)
+	list(APPEND OS_TEST_CMDS " or " "'make test'")
+endif()
+
+string(CONCAT t ${OS_TEST_CMDS})
+message("\nTo run unit tests, use: ${t}")


### PR DESCRIPTION
I found myself sympathetic to the argument (made in #17) that `DISABLE_TESTS` should completely prevent CMake from even entering the `tests/` dir. So, with this PR, that's what it does.

Fixes: #17