### PR TITLE
Bump CMake min-version to 3.2, display during build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@
 # along with OpenShot Library. If not, see <http://www.gnu.org/licenses/>.
 ################################################################################
 
-cmake_minimum_required(VERSION 3.1...3.14 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.2...3.14 FATAL_ERROR)
 
 message("\
 -----------------------------------------------------------------
@@ -56,7 +56,7 @@ STRING(REGEX REPLACE "\-.*$" "" VERSION_NUM "${PROJECT_VERSION_FULL}")
 PROJECT(libopenshot LANGUAGES C CXX VERSION ${VERSION_NUM})
 
 message("
-Generating build files for OpenShot
+Generating build files for OpenShot with CMake ${CMAKE_VERSION}
   Building ${PROJECT_NAME} (version ${PROJECT_VERSION})
   SO/API/ABI Version: ${PROJECT_SO_VERSION}
 ")


### PR DESCRIPTION
This bumps the minimum CMake version just _slightly_ to `3.2` (from `3.1`), as 3.2 was when the propagation of target properties to linked targets was fully realized in the source. While our current `CMakeLists.txt` files _seem_ to work with CMake 3.1, at least on Linux, I'm concerned there may be subtle breakages down the line. CMake 3.2 should be far safer, and is still well within the realm of what we can reasonably expect to have on even the oldest still-supported systems.

Output of the `${CMAKE_VERSION}` variable is also added to the config stage:
<pre><code>
$ cmake32 -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_VERBOSE_MAKEFILE=1 -DDISABLE_TESTS=1 ..
-----------------------------------------------------------------
          Welcome to the OpenShot Build System!

CMake will now check libopenshot's build dependencies and inform
you of any missing files or other issues.

For more information, please visit <http://www.openshot.org/>.
-----------------------------------------------------------------

Generating build files for OpenShot <b>with CMake 3.2.3</b>
  Building libopenshot (version 0.2.3)
  SO/API/ABI Version: 17

</code></pre>
