### PR TITLE
Add fixes for Clang/IWYU building, correct juce:: namespacing

### DIFF
--- a/include/AudioBufferSource.h
+++ b/include/AudioBufferSource.h
@@ -54,25 +54,25 @@ namespace openshot
 	 * The <a href="http://www.juce.com/">JUCE</a> library cannot play audio directly from an AudioSampleBuffer, so this class exposes
 	 * an AudioSampleBuffer as a AudioSource, so that JUCE can play the audio.
 	 */
-	class AudioBufferSource : public PositionableAudioSource
+	class AudioBufferSource : public juce::PositionableAudioSource
 	{
 	private:
 		int position;
 		int start;
 		bool repeat;
-		AudioSampleBuffer *buffer;
+		juce::AudioSampleBuffer *buffer;
 
 	public:
 		/// @brief Default constructor
 		/// @param audio_buffer This buffer contains the samples you want to play through JUCE.
-		AudioBufferSource(AudioSampleBuffer *audio_buffer);
+		AudioBufferSource(juce::AudioSampleBuffer *audio_buffer);
 
 		/// Destructor
 		~AudioBufferSource();
 
 		/// @brief Get the next block of audio samples
 		/// @param info This struct informs us of which samples are needed next.
-		void getNextAudioBlock (const AudioSourceChannelInfo& info);
+		void getNextAudioBlock (const juce::AudioSourceChannelInfo& info);
 
 		/// Prepare to play this audio source
 		void prepareToPlay(int, double);
@@ -82,13 +82,13 @@ namespace openshot
 
 		/// @brief Set the next read position of this source
 		/// @param newPosition The sample # to start reading from
-		void setNextReadPosition (int64 newPosition);
+		void setNextReadPosition (juce::int64 newPosition);
 
 		/// Get the next read position of this source
-		int64 getNextReadPosition() const;
+		juce::int64 getNextReadPosition() const;
 
 		/// Get the total length (in samples) of this audio source
-		int64 getTotalLength() const;
+		juce::int64 getTotalLength() const;
 
 		/// Determines if this audio source should repeat when it reaches the end
 		bool isLooping() const;
@@ -98,7 +98,7 @@ namespace openshot
 		void setLooping (bool shouldLoop);
 
 		/// Update the internal buffer used by this source
-		void setBuffer (AudioSampleBuffer *audio_buffer);
+		void setBuffer (juce::AudioSampleBuffer *audio_buffer);
 	};
 
 }

--- a/include/AudioReaderSource.h
+++ b/include/AudioReaderSource.h
@@ -54,13 +54,13 @@ namespace openshot
 	 *
 	 * This allows any reader to play audio through JUCE (our audio framework).
 	 */
-	class AudioReaderSource : public PositionableAudioSource
+	class AudioReaderSource : public juce::PositionableAudioSource
 	{
 	private:
 		int position; /// The position of the audio source (index of buffer)
 		bool repeat; /// Repeat the audio source when finished
 		int size; /// The size of the internal buffer
-		AudioSampleBuffer *buffer; /// The audio sample buffer
+		juce::AudioSampleBuffer *buffer; /// The audio sample buffer
 		int speed; /// The speed and direction to playback a reader (1=normal, 2=fast, 3=faster, -1=rewind, etc...)
 
 		ReaderBase *reader; /// The reader to pull samples from
@@ -90,7 +90,7 @@ namespace openshot
 
 		/// @brief Get the next block of audio samples
 		/// @param info This struct informs us of which samples are needed next.
-		void getNextAudioBlock (const AudioSourceChannelInfo& info);
+		void getNextAudioBlock (const juce::AudioSourceChannelInfo& info);
 
 		/// Prepare to play this audio source
 		void prepareToPlay(int, double);
@@ -100,13 +100,13 @@ namespace openshot
 
 		/// @brief Set the next read position of this source
 		/// @param newPosition The sample # to start reading from
-		void setNextReadPosition (int64 newPosition);
+		void setNextReadPosition (juce::int64 newPosition);
 
 		/// Get the next read position of this source
-		int64 getNextReadPosition() const;
+		juce::int64 getNextReadPosition() const;
 
 		/// Get the total length (in samples) of this audio source
-		int64 getTotalLength() const;
+		juce::int64 getTotalLength() const;
 
 		/// Determines if this audio source should repeat when it reaches the end
 		bool isLooping() const;
@@ -116,7 +116,7 @@ namespace openshot
 		void setLooping (bool shouldLoop);
 
 		/// Update the internal buffer used by this source
-		void setBuffer (AudioSampleBuffer *audio_buffer);
+		void setBuffer (juce::AudioSampleBuffer *audio_buffer);
 
 	    const ReaderInfo & getReaderInfo() const { return reader->info; }
 

--- a/include/AudioResampler.h
+++ b/include/AudioResampler.h
@@ -55,11 +55,11 @@ namespace openshot {
 	 */
 	class AudioResampler {
 	private:
-		AudioSampleBuffer *buffer;
-		AudioSampleBuffer *resampled_buffer;
+		juce::AudioSampleBuffer *buffer;
+		juce::AudioSampleBuffer *resampled_buffer;
 		AudioBufferSource *buffer_source;
-		ResamplingAudioSource *resample_source;
-		AudioSourceChannelInfo resample_callback_buffer;
+		juce::ResamplingAudioSource *resample_source;
+		juce::AudioSourceChannelInfo resample_callback_buffer;
 
 		int num_of_samples;
 		int new_num_of_samples;
@@ -78,15 +78,15 @@ namespace openshot {
 		/// @param new_buffer The buffer of audio samples needing to be resampled
 		/// @param sample_rate The original sample rate of the buffered samples
 		/// @param new_sample_rate The requested sample rate you need
-		void SetBuffer(AudioSampleBuffer *new_buffer, double sample_rate, double new_sample_rate);
+		void SetBuffer(juce::AudioSampleBuffer *new_buffer, double sample_rate, double new_sample_rate);
 
 		/// @brief Sets the audio buffer and key settings
 		/// @param new_buffer The buffer of audio samples needing to be resampled
 		/// @param ratio The multiplier that needs to be applied to the sample rate (this is how resampling happens)
-		void SetBuffer(AudioSampleBuffer *new_buffer, double ratio);
+		void SetBuffer(juce::AudioSampleBuffer *new_buffer, double ratio);
 
 		/// Get the resampled audio buffer
-		AudioSampleBuffer* GetResampledBuffer();
+		juce::AudioSampleBuffer* GetResampledBuffer();
 	};
 
 }

--- a/include/CacheBase.h
+++ b/include/CacheBase.h
@@ -53,7 +53,7 @@ namespace openshot {
 		int64_t max_bytes; ///< This is the max number of bytes to cache (0 = no limit)
 
 		/// Section lock for multiple threads
-	    CriticalSection *cacheCriticalSection;
+	    juce::CriticalSection *cacheCriticalSection;
 
 
 	public:

--- a/include/Clip.h
+++ b/include/Clip.h
@@ -103,15 +103,15 @@ namespace openshot {
 	class Clip : public ClipBase {
 	protected:
 		/// Section lock for multiple threads
-	    CriticalSection getFrameCriticalSection;
+	    juce::CriticalSection getFrameCriticalSection;
 
 	private:
 		bool waveform; ///< Should a waveform be used instead of the clip's image
-		list<EffectBase*> effects; ///<List of clips on this timeline
+		std::list<EffectBase*> effects; ///<List of clips on this timeline
 
 		// Audio resampler (if time mapping)
 		AudioResampler *resampler;
-		AudioSampleBuffer *audio_cache;
+		juce::AudioSampleBuffer *audio_cache;
 
 		// File Reader object
 		ReaderBase* reader;
@@ -127,7 +127,7 @@ namespace openshot {
 		std::shared_ptr<Frame> apply_effects(std::shared_ptr<Frame> frame);
 
 		/// Get file extension
-		string get_file_extension(string path);
+		std::string get_file_extension(std::string path);
 
 		/// Get a frame object or create a blank one
 		std::shared_ptr<Frame> GetOrCreateFrame(int64_t number);

--- a/include/Frame.h
+++ b/include/Frame.h
@@ -119,8 +119,8 @@ namespace openshot
 		std::shared_ptr<QImage> wave_image;
 		std::shared_ptr<juce::AudioSampleBuffer> audio;
 		std::shared_ptr<QApplication> previewApp;
-		CriticalSection addingImageSection;
-        CriticalSection addingAudioSection;
+		juce::CriticalSection addingImageSection;
+        juce::CriticalSection addingAudioSection;
 		const unsigned char *qbuffer;
 		Fraction pixel_ratio;
 		int channels;

--- a/include/ReaderBase.h
+++ b/include/ReaderBase.h
@@ -100,8 +100,8 @@ namespace openshot
 	{
 	protected:
 		/// Section lock for multiple threads
-	    CriticalSection getFrameCriticalSection;
-	    CriticalSection processingCriticalSection;
+	    juce::CriticalSection getFrameCriticalSection;
+	    juce::CriticalSection processingCriticalSection;
 		ClipBase* parent;
 
 	public:

--- a/include/ZmqLogger.h
+++ b/include/ZmqLogger.h
@@ -55,7 +55,7 @@ namespace openshot {
 	 */
 	class ZmqLogger {
 	private:
-		CriticalSection loggerCriticalSection;
+		juce::CriticalSection loggerCriticalSection;
 		std::string connection;
 
 		// Logfile related vars

--- a/src/AudioBufferSource.cpp
+++ b/src/AudioBufferSource.cpp
@@ -34,7 +34,7 @@ using namespace std;
 using namespace openshot;
 
 // Default constructor
-AudioBufferSource::AudioBufferSource(AudioSampleBuffer *audio_buffer)
+AudioBufferSource::AudioBufferSource(juce::AudioSampleBuffer *audio_buffer)
 		: position(0), start(0), repeat(false), buffer(audio_buffer)
 { }
 
@@ -46,7 +46,7 @@ AudioBufferSource::~AudioBufferSource()
 };
 
 // Get the next block of audio samples
-void AudioBufferSource::getNextAudioBlock (const AudioSourceChannelInfo& info)
+void AudioBufferSource::getNextAudioBlock (const juce::AudioSourceChannelInfo& info)
 {
 	int buffer_samples = buffer->getNumSamples();
 	int buffer_channels = buffer->getNumChannels();
@@ -98,7 +98,7 @@ void AudioBufferSource::prepareToPlay(int, double) { }
 void AudioBufferSource::releaseResources() { }
 
 // Set the next read position of this source
-void AudioBufferSource::setNextReadPosition (int64 newPosition)
+void AudioBufferSource::setNextReadPosition (juce::int64 newPosition)
 {
 	// set position (if the new position is in range)
 	if (newPosition >= 0 && newPosition < buffer->getNumSamples())
@@ -106,14 +106,14 @@ void AudioBufferSource::setNextReadPosition (int64 newPosition)
 }
 
 // Get the next read position of this source
-int64 AudioBufferSource::getNextReadPosition() const
+juce::int64 AudioBufferSource::getNextReadPosition() const
 {
 	// return the next read position
 	return position;
 }
 
 // Get the total length (in samples) of this audio source
-int64 AudioBufferSource::getTotalLength() const
+juce::int64 AudioBufferSource::getTotalLength() const
 {
 	// Get the length
 	return buffer->getNumSamples();
@@ -134,7 +134,7 @@ void AudioBufferSource::setLooping (bool shouldLoop)
 }
 
 // Use a different AudioSampleBuffer for this source
-void AudioBufferSource::setBuffer (AudioSampleBuffer *audio_buffer)
+void AudioBufferSource::setBuffer (juce::AudioSampleBuffer *audio_buffer)
 {
 	buffer = audio_buffer;
 	setNextReadPosition(0);

--- a/src/AudioReaderSource.cpp
+++ b/src/AudioReaderSource.cpp
@@ -152,7 +152,7 @@ juce::AudioSampleBuffer* AudioReaderSource::reverse_buffer(juce::AudioSampleBuff
 	ZmqLogger::Instance()->AppendDebugMethod("AudioReaderSource::reverse_buffer", "number_of_samples", number_of_samples, "channels", channels);
 
 	// Reverse array (create new buffer to hold the reversed version)
-	AudioSampleBuffer *reversed = new juce::AudioSampleBuffer(channels, number_of_samples);
+	juce::AudioSampleBuffer *reversed = new juce::AudioSampleBuffer(channels, number_of_samples);
 	reversed->clear();
 
 	for (int channel = 0; channel < channels; channel++)
@@ -177,7 +177,7 @@ juce::AudioSampleBuffer* AudioReaderSource::reverse_buffer(juce::AudioSampleBuff
 }
 
 // Get the next block of audio samples
-void AudioReaderSource::getNextAudioBlock(const AudioSourceChannelInfo& info)
+void AudioReaderSource::getNextAudioBlock(const juce::AudioSourceChannelInfo& info)
 {
 	int buffer_samples = buffer->getNumSamples();
 	int buffer_channels = buffer->getNumChannels();
@@ -248,7 +248,7 @@ void AudioReaderSource::prepareToPlay(int, double) { }
 void AudioReaderSource::releaseResources() { }
 
 // Set the next read position of this source
-void AudioReaderSource::setNextReadPosition (int64 newPosition)
+void AudioReaderSource::setNextReadPosition (juce::int64 newPosition)
 {
 	// set position (if the new position is in range)
 	if (newPosition >= 0 && newPosition < buffer->getNumSamples())
@@ -256,14 +256,14 @@ void AudioReaderSource::setNextReadPosition (int64 newPosition)
 }
 
 // Get the next read position of this source
-int64 AudioReaderSource::getNextReadPosition() const
+juce::int64 AudioReaderSource::getNextReadPosition() const
 {
 	// return the next read position
 	return position;
 }
 
 // Get the total length (in samples) of this audio source
-int64 AudioReaderSource::getTotalLength() const
+juce::int64 AudioReaderSource::getTotalLength() const
 {
 	// Get the length
 	if (reader)
@@ -287,7 +287,7 @@ void AudioReaderSource::setLooping (bool shouldLoop)
 }
 
 // Update the internal buffer used by this source
-void AudioReaderSource::setBuffer (AudioSampleBuffer *audio_buffer)
+void AudioReaderSource::setBuffer (juce::AudioSampleBuffer *audio_buffer)
 {
 	buffer = audio_buffer;
 	setNextReadPosition(0);

--- a/src/AudioResampler.cpp
+++ b/src/AudioResampler.cpp
@@ -49,10 +49,10 @@ AudioResampler::AudioResampler()
 	buffer_source = new AudioBufferSource(buffer);
 
 	// Init resampling source
-	resample_source = new ResamplingAudioSource(buffer_source, false, 2);
+	resample_source = new juce::ResamplingAudioSource(buffer_source, false, 2);
 
 	// Init resampled buffer
-	resampled_buffer = new AudioSampleBuffer(2, 1);
+	resampled_buffer = new juce::AudioSampleBuffer(2, 1);
 	resampled_buffer->clear();
 
 	// Init callback buffer
@@ -74,7 +74,7 @@ AudioResampler::~AudioResampler()
 }
 
 // Sets the audio buffer and updates the key settings
-void AudioResampler::SetBuffer(AudioSampleBuffer *new_buffer, double sample_rate, double new_sample_rate)
+void AudioResampler::SetBuffer(juce::AudioSampleBuffer *new_buffer, double sample_rate, double new_sample_rate)
 {
 	if (sample_rate <= 0)
 		sample_rate = 44100;
@@ -89,7 +89,7 @@ void AudioResampler::SetBuffer(AudioSampleBuffer *new_buffer, double sample_rate
 }
 
 // Sets the audio buffer and key settings
-void AudioResampler::SetBuffer(AudioSampleBuffer *new_buffer, double ratio)
+void AudioResampler::SetBuffer(juce::AudioSampleBuffer *new_buffer, double ratio)
 {
 	// Update buffer & buffer source
 	buffer = new_buffer;
@@ -120,7 +120,7 @@ void AudioResampler::SetBuffer(AudioSampleBuffer *new_buffer, double ratio)
 }
 
 // Get the resampled audio buffer
-AudioSampleBuffer* AudioResampler::GetResampledBuffer()
+juce::AudioSampleBuffer* AudioResampler::GetResampledBuffer()
 {
 	// Resample the current frame's audio buffer (into the temp callback buffer)
 	resample_source->getNextAudioBlock(resample_callback_buffer);

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -36,6 +36,7 @@ include(FeatureSummary)
 ################ OPTIONS ##################
 # Optional build settings for libopenshot
 OPTION(USE_SYSTEM_JSONCPP "Use system installed JsonCpp" OFF)
+option(ENABLE_IWYU "Enable 'Include What You Use' scanner" OFF)
 
 ################ WINDOWS ##################
 # Set some compiler options for Windows
@@ -180,6 +181,21 @@ endif(USE_SYSTEM_JSONCPP)
 ###############  PROFILING  #################
 #set(PROFILER "/usr/lib/libprofiler.so.0.3.2")
 #set(PROFILER "/usr/lib/libtcmalloc.so.4")
+
+if(ENABLE_IWYU)
+	find_program(IWYU_PATH NAMES "iwyu"
+		DOC "include-what-you-use source code scanner executable")
+	if(IWYU_PATH)
+		if(IWYU_OPTS)
+			separate_arguments(IWYU_OPTS)
+			list(APPEND _iwyu_cmd ${IWYU_PATH} "-Xiwyu" ${IWYU_OPTS})
+		endif()
+		set(CMAKE_CXX_INCLUDE_WHAT_YOU_USE ${_iwyu_cmd})
+	else()
+		set(ENABLE_IWYU FALSE)
+	endif()
+endif()
+add_feature_info("IWYU (include-what-you-use)" ENABLE_IWYU "Scan all source files with 'iwyu'")
 
 #### GET LIST OF EFFECT FILES ####
 FILE(GLOB EFFECT_FILES "${CMAKE_CURRENT_SOURCE_DIR}/effects/*.cpp")

--- a/src/Clip.cpp
+++ b/src/Clip.cpp
@@ -367,7 +367,7 @@ void Clip::reverse_buffer(juce::AudioSampleBuffer* buffer)
 	int channels = buffer->getNumChannels();
 
 	// Reverse array (create new buffer to hold the reversed version)
-	AudioSampleBuffer *reversed = new juce::AudioSampleBuffer(channels, number_of_samples);
+	juce::AudioSampleBuffer *reversed = new juce::AudioSampleBuffer(channels, number_of_samples);
 	reversed->clear();
 
 	for (int channel = 0; channel < channels; channel++)
@@ -399,7 +399,7 @@ void Clip::get_time_mapped_frame(std::shared_ptr<Frame> frame, int64_t frame_num
 	// Check for a valid time map curve
 	if (time.Values.size() > 1)
 	{
-		const GenericScopedLock<CriticalSection> lock(getFrameCriticalSection);
+		const GenericScopedLock<juce::CriticalSection> lock(getFrameCriticalSection);
 
 		// create buffer and resampler
 		juce::AudioSampleBuffer *samples = NULL;
@@ -423,7 +423,7 @@ void Clip::get_time_mapped_frame(std::shared_ptr<Frame> frame, int64_t frame_num
 			if (time.GetRepeatFraction(frame_number).den > 1) {
 				// SLOWING DOWN AUDIO
 				// Resample data, and return new buffer pointer
-				AudioSampleBuffer *resampled_buffer = NULL;
+				juce::AudioSampleBuffer *resampled_buffer = NULL;
 				int resampled_buffer_size = 0;
 
 				// SLOW DOWN audio (split audio)
@@ -482,7 +482,7 @@ void Clip::get_time_mapped_frame(std::shared_ptr<Frame> frame, int64_t frame_num
 						 delta_frame <= new_frame_number; delta_frame++) {
 						// buffer to hold detal samples
 						int number_of_delta_samples = GetOrCreateFrame(delta_frame)->GetAudioSamplesCount();
-						AudioSampleBuffer *delta_samples = new juce::AudioSampleBuffer(channels,
+						juce::AudioSampleBuffer *delta_samples = new juce::AudioSampleBuffer(channels,
 																					   number_of_delta_samples);
 						delta_samples->clear();
 
@@ -526,7 +526,7 @@ void Clip::get_time_mapped_frame(std::shared_ptr<Frame> frame, int64_t frame_num
 						 delta_frame >= new_frame_number; delta_frame--) {
 						// buffer to hold delta samples
 						int number_of_delta_samples = GetOrCreateFrame(delta_frame)->GetAudioSamplesCount();
-						AudioSampleBuffer *delta_samples = new juce::AudioSampleBuffer(channels,
+						juce::AudioSampleBuffer *delta_samples = new juce::AudioSampleBuffer(channels,
 																					   number_of_delta_samples);
 						delta_samples->clear();
 
@@ -557,7 +557,7 @@ void Clip::get_time_mapped_frame(std::shared_ptr<Frame> frame, int64_t frame_num
 				resampler->SetBuffer(samples, float(start) / float(number_of_samples));
 
 				// Resample data, and return new buffer pointer
-				AudioSampleBuffer *buffer = resampler->GetResampledBuffer();
+				juce::AudioSampleBuffer *buffer = resampler->GetResampledBuffer();
 				int resampled_buffer_size = buffer->getNumSamples();
 
 				// Add the newly resized audio samples to the current frame

--- a/src/Frame.cpp
+++ b/src/Frame.cpp
@@ -340,7 +340,7 @@ float* Frame::GetAudioSamples(int channel)
 float* Frame::GetPlanarAudioSamples(int new_sample_rate, AudioResampler* resampler, int* sample_count)
 {
 	float *output = NULL;
-	AudioSampleBuffer *buffer(audio.get());
+	juce::AudioSampleBuffer *buffer(audio.get());
 	int num_of_channels = audio->getNumChannels();
 	int num_of_samples = GetAudioSamplesCount();
 
@@ -386,7 +386,7 @@ float* Frame::GetPlanarAudioSamples(int new_sample_rate, AudioResampler* resampl
 float* Frame::GetInterleavedAudioSamples(int new_sample_rate, AudioResampler* resampler, int* sample_count)
 {
 	float *output = NULL;
-	AudioSampleBuffer *buffer(audio.get());
+	juce::AudioSampleBuffer *buffer(audio.get());
 	int num_of_channels = audio->getNumChannels();
 	int num_of_samples = GetAudioSamplesCount();
 
@@ -430,7 +430,7 @@ float* Frame::GetInterleavedAudioSamples(int new_sample_rate, AudioResampler* re
 // Get number of audio channels
 int Frame::GetAudioChannelsCount()
 {
-    const GenericScopedLock<CriticalSection> lock(addingAudioSection);
+    const GenericScopedLock<juce::CriticalSection> lock(addingAudioSection);
 	if (audio)
 		return audio->getNumChannels();
 	else
@@ -440,7 +440,7 @@ int Frame::GetAudioChannelsCount()
 // Get number of audio samples
 int Frame::GetAudioSamplesCount()
 {
-    const GenericScopedLock<CriticalSection> lock(addingAudioSection);
+    const GenericScopedLock<juce::CriticalSection> lock(addingAudioSection);
 	return max_audio_sample;
 }
 
@@ -735,7 +735,7 @@ void Frame::AddColor(int new_width, int new_height, string new_color)
 	color = new_color;
 
 	// Create new image object, and fill with pixel data
-	const GenericScopedLock<CriticalSection> lock(addingImageSection);
+	const GenericScopedLock<juce::CriticalSection> lock(addingImageSection);
 	#pragma omp critical (AddImage)
 	{
 		image = std::shared_ptr<QImage>(new QImage(new_width, new_height, QImage::Format_RGBA8888));
@@ -753,7 +753,7 @@ void Frame::AddColor(int new_width, int new_height, string new_color)
 void Frame::AddImage(int new_width, int new_height, int bytes_per_pixel, QImage::Format type, const unsigned char *pixels_)
 {
 	// Create new buffer
-	const GenericScopedLock<CriticalSection> lock(addingImageSection);
+	const GenericScopedLock<juce::CriticalSection> lock(addingImageSection);
 	int buffer_size = new_width * new_height * bytes_per_pixel;
 	qbuffer = new unsigned char[buffer_size]();
 
@@ -784,7 +784,7 @@ void Frame::AddImage(std::shared_ptr<QImage> new_image)
 		return;
 
 	// assign image data
-	const GenericScopedLock<CriticalSection> lock(addingImageSection);
+	const GenericScopedLock<juce::CriticalSection> lock(addingImageSection);
 	#pragma omp critical (AddImage)
 	{
 		image = new_image;
@@ -823,7 +823,7 @@ void Frame::AddImage(std::shared_ptr<QImage> new_image, bool only_odd_lines)
 			return;
 
 		// Get the frame's image
-		const GenericScopedLock<CriticalSection> lock(addingImageSection);
+		const GenericScopedLock<juce::CriticalSection> lock(addingImageSection);
 		#pragma omp critical (AddImage)
 		{
 			const unsigned char *pixels = image->bits();
@@ -851,7 +851,7 @@ void Frame::AddImage(std::shared_ptr<QImage> new_image, bool only_odd_lines)
 // Resize audio container to hold more (or less) samples and channels
 void Frame::ResizeAudio(int channels, int length, int rate, ChannelLayout layout)
 {
-    const GenericScopedLock<CriticalSection> lock(addingAudioSection);
+    const GenericScopedLock<juce::CriticalSection> lock(addingAudioSection);
 
     // Resize JUCE audio buffer
 	audio->setSize(channels, length, true, true, false);
@@ -864,7 +864,7 @@ void Frame::ResizeAudio(int channels, int length, int rate, ChannelLayout layout
 
 // Add audio samples to a specific channel
 void Frame::AddAudio(bool replaceSamples, int destChannel, int destStartSample, const float* source, int numSamples, float gainToApplyToSource = 1.0f) {
-	const GenericScopedLock<CriticalSection> lock(addingAudioSection);
+	const GenericScopedLock<juce::CriticalSection> lock(addingAudioSection);
 	#pragma omp critical (adding_audio)
     {
 		// Clamp starting sample to 0
@@ -895,7 +895,7 @@ void Frame::AddAudio(bool replaceSamples, int destChannel, int destStartSample, 
 // Apply gain ramp (i.e. fading volume)
 void Frame::ApplyGainRamp(int destChannel, int destStartSample, int numSamples, float initial_gain = 0.0f, float final_gain = 1.0f)
 {
-    const GenericScopedLock<CriticalSection> lock(addingAudioSection);
+    const GenericScopedLock<juce::CriticalSection> lock(addingAudioSection);
 
     // Apply gain ramp
 	audio->applyGainRamp(destChannel, destStartSample, numSamples, initial_gain, final_gain);
@@ -970,7 +970,7 @@ void Frame::Play()
 	if (!GetAudioSamplesCount())
 		return;
 
-	AudioDeviceManager deviceManager;
+	juce::AudioDeviceManager deviceManager;
 	String error = deviceManager.initialise (0, /* number of input channels */
 	        2, /* number of output channels */
 	        0, /* no XML settings.. */
@@ -981,14 +981,14 @@ void Frame::Play()
 		cout << "Error on initialise(): " << error.toStdString() << endl;
 	}
 
-	AudioSourcePlayer audioSourcePlayer;
+	juce::AudioSourcePlayer audioSourcePlayer;
 	deviceManager.addAudioCallback (&audioSourcePlayer);
 
 	ScopedPointer<AudioBufferSource> my_source;
 	my_source = new AudioBufferSource(audio.get());
 
 	// Create TimeSliceThread for audio buffering
-	TimeSliceThread my_thread("Audio buffer thread");
+	juce::TimeSliceThread my_thread("Audio buffer thread");
 
 	// Start thread
 	my_thread.startThread();
@@ -1004,7 +1004,7 @@ void Frame::Play()
 
 
 	// Create MIXER
-	MixerAudioSource mixer;
+	juce::MixerAudioSource mixer;
 	mixer.addInputSource(&transport1, false);
 	audioSourcePlayer.setSource (&mixer);
 
@@ -1047,7 +1047,7 @@ void Frame::cleanUpBuffer(void *info)
 // Add audio silence
 void Frame::AddAudioSilence(int numSamples)
 {
-    const GenericScopedLock<CriticalSection> lock(addingAudioSection);
+    const GenericScopedLock<juce::CriticalSection> lock(addingAudioSection);
 
     // Resize audio container
 	audio->setSize(channels, numSamples, false, true, false);

--- a/tests/Cache_Tests.cpp
+++ b/tests/Cache_Tests.cpp
@@ -29,10 +29,11 @@
  */
 
 #include "UnitTest++.h"
+// Prevent name clashes with juce::UnitTest
+#define DONT_SET_USING_JUCE_NAMESPACE 1
 #include "../include/OpenShot.h"
 #include "../include/Json.h"
 
-using namespace std;
 using namespace openshot;
 
 TEST(Cache_Default_Constructor)

--- a/tests/Clip_Tests.cpp
+++ b/tests/Clip_Tests.cpp
@@ -29,6 +29,8 @@
  */
 
 #include "UnitTest++.h"
+// Prevent name clashes with juce::UnitTest
+#define DONT_SET_USING_JUCE_NAMESPACE 1
 #include "../include/OpenShot.h"
 
 using namespace std;

--- a/tests/Color_Tests.cpp
+++ b/tests/Color_Tests.cpp
@@ -29,6 +29,8 @@
  */
 
 #include "UnitTest++.h"
+// Prevent name clashes with juce::UnitTest
+#define DONT_SET_USING_JUCE_NAMESPACE 1
 #include "../include/OpenShot.h"
 
 using namespace std;

--- a/tests/Coordinate_Tests.cpp
+++ b/tests/Coordinate_Tests.cpp
@@ -29,6 +29,8 @@
  */
 
 #include "UnitTest++.h"
+// Prevent name clashes with juce::UnitTest
+#define DONT_SET_USING_JUCE_NAMESPACE 1
 #include "../include/OpenShot.h"
 
 using namespace std;

--- a/tests/FFmpegReader_Tests.cpp
+++ b/tests/FFmpegReader_Tests.cpp
@@ -29,6 +29,8 @@
  */
 
 #include "UnitTest++.h"
+// Prevent name clashes with juce::UnitTest
+#define DONT_SET_USING_JUCE_NAMESPACE 1
 #include "../include/OpenShot.h"
 
 using namespace std;
@@ -219,4 +221,3 @@ TEST(FFmpegReader_Multiple_Open_and_Close)
 	// Close reader
 	r.Close();
 }
-

--- a/tests/FFmpegWriter_Tests.cpp
+++ b/tests/FFmpegWriter_Tests.cpp
@@ -29,6 +29,8 @@
  */
 
 #include "UnitTest++.h"
+// Prevent name clashes with juce::UnitTest
+#define DONT_SET_USING_JUCE_NAMESPACE 1
 #include "../include/OpenShot.h"
 
 using namespace std;

--- a/tests/Fraction_Tests.cpp
+++ b/tests/Fraction_Tests.cpp
@@ -29,6 +29,8 @@
  */
 
 #include "UnitTest++.h"
+// Prevent name clashes with juce::UnitTest
+#define DONT_SET_USING_JUCE_NAMESPACE 1
 #include "../include/OpenShot.h"
 
 using namespace std;

--- a/tests/FrameMapper_Tests.cpp
+++ b/tests/FrameMapper_Tests.cpp
@@ -29,6 +29,8 @@
  */
 
 #include "UnitTest++.h"
+// Prevent name clashes with juce::UnitTest
+#define DONT_SET_USING_JUCE_NAMESPACE 1
 #include "../include/OpenShot.h"
 
 using namespace std;

--- a/tests/ImageWriter_Tests.cpp
+++ b/tests/ImageWriter_Tests.cpp
@@ -29,6 +29,8 @@
  */
 
 #include "UnitTest++.h"
+// Prevent name clashes with juce::UnitTest
+#define DONT_SET_USING_JUCE_NAMESPACE 1
 #include "../include/OpenShot.h"
 
 using namespace std;

--- a/tests/KeyFrame_Tests.cpp
+++ b/tests/KeyFrame_Tests.cpp
@@ -29,6 +29,8 @@
  */
 
 #include "UnitTest++.h"
+// Prevent name clashes with juce::UnitTest
+#define DONT_SET_USING_JUCE_NAMESPACE 1
 #include "../include/OpenShot.h"
 
 using namespace std;

--- a/tests/Point_Tests.cpp
+++ b/tests/Point_Tests.cpp
@@ -29,6 +29,8 @@
  */
 
 #include "UnitTest++.h"
+// Prevent name clashes with juce::UnitTest
+#define DONT_SET_USING_JUCE_NAMESPACE 1
 #include "../include/OpenShot.h"
 
 using namespace std;

--- a/tests/ReaderBase_Tests.cpp
+++ b/tests/ReaderBase_Tests.cpp
@@ -29,6 +29,8 @@
  */
 
 #include "UnitTest++.h"
+// Prevent name clashes with juce::UnitTest
+#define DONT_SET_USING_JUCE_NAMESPACE 1
 #include "../include/OpenShot.h"
 
 using namespace std;

--- a/tests/Settings_Tests.cpp
+++ b/tests/Settings_Tests.cpp
@@ -29,6 +29,8 @@
  */
 
 #include "UnitTest++.h"
+// Prevent name clashes with juce::UnitTest
+#define DONT_SET_USING_JUCE_NAMESPACE 1
 #include "../include/OpenShot.h"
 
 using namespace std;

--- a/tests/Timeline_Tests.cpp
+++ b/tests/Timeline_Tests.cpp
@@ -29,6 +29,8 @@
  */
 
 #include "UnitTest++.h"
+// Prevent name clashes with juce::UnitTest
+#define DONT_SET_USING_JUCE_NAMESPACE 1
 #include "../include/OpenShot.h"
 
 using namespace std;


### PR DESCRIPTION
So, I spent part of the weekend running libopenshot through [include-what-you-use (IWYU)](https://github.com/include-what-you-use/include-what-you-use/), a `#include` scanner that attempts to help you... well, it [does exactly what it says on the tin](https://en.wikipedia.org/wiki/Does_exactly_what_it_says_on_the_tin). I may have some changes to submit along those lines down the road, but this PR isn't actually about that.

#### include-what-you-use

IWYU is based on, and runs best with, Clang, so in order to run the code through IWYU I first had to get it buildable under Clang. This PR is the work necessary to make that happen.

It was actually fairly easy; the main library source _initially_ didn't require any changes at all.

#### The `juce::` namespace and header pollution

What _did_ ultimately force me to make changes, and where things snagged up a bit at first, was when I got to the unit tests. The unit tests are all based on UnitTest++, and as such they `#include` the `UnitTest++.h` header, which supplies a set of test macros. Those macros all call various methods in the `UnitTest::Test` namespace.

However, JUCE _also_ has a unit test framework, which lives at `juce::UnitTest`. Because the `OpenShot.h` header indirectly includes the JUCE headers from libopenshot-audio, and because those headers (by default) apply a `using namespace juce;` when they're included, _technically_ the name `UnitTest` is ambiguous — it could mean either the `UnitTest` namespace from UnitTest++, _or_ the `juce::UnitTest` class from libopenshot-audio. GCC was able to ignore this ambiguity and figure things out, but it turns out Clang is pickier. The unit tests **would not** compile with Clang as long as that `using namespace juce;` was being added by the headers.

#### Clearing the <strike>air</strike> global namespace

The obvious solution was to add a `#define DONT_SET_USING_JUCE_NAMESPACE 1` to the unit tests before they did their `#include "../include/OpenShot.h"`, and that's exactly what I did.

But doing that means our _headers_ have to be COMPATIBLE when included with _or_ without the `juce` symbols imported into the global namespace, meaning they  have to fully-qualify all of their JUCE symbols as `juce::WhateverClass`. This PR is the work necessary to do that, as well as the modifications to the unit test files to disable the automatic `using namespace juce;`.

This is exactly the kind of issue PR #296 is all about, and a perfect example of why `using namespace foo;` is _such_ bad practice in header files. It's dangerous, it causes problems, and it makes it much, much harder to use the headers in question, if they're going to pollute the global namespace when included, _and_ (worse!) if they're written in a way that **REQUIRES** the global namespace to be polluted with foreign symbols, in order for them to build properly.

#### ENABLE_IWYU

I also tossed in changes to `src/CMakeLists.txt` to facilitate use of IWYU:
* A new `option(ENABLE_IWYU)` is defined, default `OFF` but you can switch it on with `cmake -DENABLE_IWYU=1` at configure time. That'll turn on IWYU as long as CMake finds an executable `iwyu` program in the PATH, and all of the source files will be run through it.
* Another variable, `IWYU_OPTS`, can be set to pass options to `iwyu`. So, for example, you might run:
   ```sh
   cmake -DENABLE_IWYU=1 -DIWYU_OPTS="--max_line_length=120 --verbose=1"
   ```
   to configure the build.

Note that, as I said, IWYU is best paired with Clang. However, the CMake environment doesn't _enforce_ that, and you're welcome to try and run it with any compiler you like. It might even work. But for optimal and best-supported results, you really want to set `CC=clang CXX=clang++` in the environment before running `cmake`. (Or add `-DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++` to the `cmake` command line.)