### PR TITLE
CMake: Fix IWYU invocation with unset IWYU_OPTS

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -33,7 +33,7 @@ include(FeatureSummary)
 ################ OPTIONS ##################
 # Optional build settings for libopenshot
 OPTION(USE_SYSTEM_JSONCPP "Use system installed JsonCpp" OFF)
-option(ENABLE_IWYU "Enable 'Include What You Use' scanner" OFF)
+option(ENABLE_IWYU "Enable 'Include What You Use' scanner (CMake 3.3+)" OFF)
 
 ################ WINDOWS ##################
 # Set some compiler options for Windows
@@ -165,15 +165,20 @@ endif(USE_SYSTEM_JSONCPP)
 #set(PROFILER "/usr/lib/libprofiler.so.0.3.2")
 #set(PROFILER "/usr/lib/libtcmalloc.so.4")
 
+if(CMAKE_VERSION VERSION_LESS 3.3)
+  # IWYU wasn't supported internally in 3.2
+  set(ENABLE_IWYU FALSE)
+endif()
+
 if(ENABLE_IWYU)
 	find_program(IWYU_PATH NAMES "iwyu"
 		DOC "include-what-you-use source code scanner executable")
 	if(IWYU_PATH)
 		if(IWYU_OPTS)
 			separate_arguments(IWYU_OPTS)
-			list(APPEND _iwyu_cmd ${IWYU_PATH} "-Xiwyu" ${IWYU_OPTS})
+			list(APPEND _iwyu_opts "-Xiwyu" ${IWYU_OPTS})
 		endif()
-		set(CMAKE_CXX_INCLUDE_WHAT_YOU_USE ${_iwyu_cmd})
+		set(CMAKE_CXX_INCLUDE_WHAT_YOU_USE ${IWYU_PATH} ${_iwyu_opts})
 	else()
 		set(ENABLE_IWYU FALSE)
 	endif()


### PR DESCRIPTION
I messed up the `ENABLE_IWYU` handling in #352, so that it wouldn't be run if you _didn't_ set `IWYU_OPTS`. This fixes that.

It also adds a `CMAKE_VERSION` check to disable IWYU checking in CMake 3.2, since support for it wasn't introduced until CMake 3.3. Under CMake 3.2 it won't be run even if it's installed and present. (A note to that effect is placed in the `OPTION` doc string.)