### PR TITLE
Fix target creation/importing for ZeroMQ on Windows

### DIFF
--- a/cmake/Modules/FindZeroMQ.cmake
+++ b/cmake/Modules/FindZeroMQ.cmake
@@ -23,13 +23,17 @@ set(ZeroMQ_INCLUDE_DIRS ${ZeroMQ_INCLUDE_DIR})
 list(APPEND ZeroMQ_INCLUDE_DIRS ${PC_LIBZMQ_INCLUDE_DIRS})
 list(REMOVE_DUPLICATES ZeroMQ_INCLUDE_DIRS)
 
-add_library(libzmq SHARED IMPORTED)
-set_property(TARGET libzmq PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${ZeroMQ_INCLUDE_DIRS})
-set_property(TARGET libzmq PROPERTY IMPORTED_LOCATION ${ZeroMQ_LIBRARY})
+if(ZeroMQ_LIBRARY)
+    add_library(libzmq SHARED IMPORTED)
+    set_property(TARGET libzmq PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${ZeroMQ_INCLUDE_DIRS})
+    set_property(TARGET libzmq PROPERTY IMPORTED_LOCATION ${ZeroMQ_LIBRARY})
+endif()
 
-add_library(libzmq-static STATIC IMPORTED ${ZeroMQ_INCLUDE_DIRS})
-set_property(TARGET libzmq-static PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${ZeroMQ_INCLUDE_DIRS})
-set_property(TARGET libzmq-static PROPERTY IMPORTED_LOCATION ${ZeroMQ_STATIC_LIBRARY})
+if(ZeroMQ_LIBRARY_STATIC)
+    add_library(libzmq-static STATIC IMPORTED ${ZeroMQ_INCLUDE_DIRS})
+    set_property(TARGET libzmq-static PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${ZeroMQ_INCLUDE_DIRS})
+    set_property(TARGET libzmq-static PROPERTY IMPORTED_LOCATION ${ZeroMQ_STATIC_LIBRARY})
+endif()
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(ZeroMQ

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -330,8 +330,13 @@ find_package(ZeroMQ REQUIRED) # Creates libzmq target
 # others (Ubuntu) bundle them in with libzmq itself
 find_package(cppzmq QUIET) # Creates cppzmq target
 
-# Include ZeroMQ headers (needed for compile)
-target_link_libraries(openshot PUBLIC libzmq)
+# Link ZeroMQ (shared or static, whichever's found)
+if (TARGET libzmq)
+	target_link_libraries(openshot PUBLIC libzmq)
+elseif (TARGET libzmq-static)
+	target_link_libraries(openshot PRIVATE libzmq-static)
+endif()
+# Include cppzmq headers, if not bundled into libzmq
 if (TARGET cppzmq)
   target_link_libraries(openshot PUBLIC cppzmq)
 endif()


### PR DESCRIPTION
Windows finds only the _static_ version of the library (`libzmq.dll.a`, but not `libzmq.dll`), which the `FindZeroMQ.cmake` from cppzmq places in a different target (`libzmq-static`).

It was also creating _both_ targets, with the `libzmq` `IMPORTED LOCATION` set to `libzmq-NOTFOUND`.

That's not particularly helpful, so it's been updated to only export `FOUND` targets, and `src/CMakeLists.txt` will link only the existing one — preferring `libzmq` (`SHARED`), falling back to `libzmq-static` if necessary.