### PR TITLE
Fix Windows ZeroMQ for real

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -70,13 +70,12 @@ windows-builder-x64:
     - Expand-Archive -Path artifacts.zip -DestinationPath .
     - $env:LIBOPENSHOT_AUDIO_DIR = "$CI_PROJECT_DIR\build\install-x64"
     - $env:UNITTEST_DIR = "C:\msys64\usr"
-    - $env:ZMQDIR = "C:\msys64\usr"
     - $env:RESVGDIR = "C:\msys64\usr"
     - $env:Path = "C:\msys64\mingw64\bin;C:\msys64\mingw64\lib;C:\msys64\usr\lib\cmake\UnitTest++;C:\msys64\home\jonathan\depot_tools;C:\msys64\usr;C:\msys64\usr\lib;" + $env:Path;
     - New-Item -ItemType Directory -Force -Path build
     - New-Item -ItemType Directory -Force -Path build\install-x64\python
     - cd build
-    - cmake -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -D"CMAKE_INSTALL_PREFIX:PATH=$CI_PROJECT_DIR\build\install-x64" -G "MSYS Makefiles" -DCMAKE_MAKE_PROGRAM=mingw32-make -D"CMAKE_BUILD_TYPE:STRING=Release" ../
+    - cmake -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -D"CMAKE_INSTALL_PREFIX:PATH=$CI_PROJECT_DIR\build\install-x64" -G "MSYS Makefiles" -DCMAKE_MAKE_PROGRAM=mingw32-make -D"CMAKE_BUILD_TYPE:STRING=Release" -D"ZeroMQ_DIR:PATH=C:\msys64\usr" ../
     - mingw32-make install
     - Move-Item -Force -path "install-x64\lib\python3.7\site-packages\*openshot*" -destination "install-x64\python\"
     - New-Item -path "install-x64/share/" -Name "$CI_PROJECT_NAME" -Value "CI_PROJECT_NAME:$CI_PROJECT_NAME`nCI_COMMIT_REF_NAME:$CI_COMMIT_REF_NAME`nCI_COMMIT_SHA:$CI_COMMIT_SHA`nCI_JOB_ID:$CI_JOB_ID" -ItemType file -force
@@ -106,7 +105,7 @@ windows-builder-x86:
     - New-Item -ItemType Directory -Force -Path build
     - New-Item -ItemType Directory -Force -Path build\install-x86\python
     - cd build
-    - cmake -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -D"CMAKE_INSTALL_PREFIX:PATH=$CI_PROJECT_DIR\build\install-x86" -G "MSYS Makefiles" -DCMAKE_MAKE_PROGRAM=mingw32-make -D"CMAKE_BUILD_TYPE:STRING=Release" -D"CMAKE_CXX_FLAGS=-m32" -D"CMAKE_EXE_LINKER_FLAGS=-Wl,--large-address-aware" -D"CMAKE_C_FLAGS=-m32" ../
+    - cmake -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -D"CMAKE_INSTALL_PREFIX:PATH=$CI_PROJECT_DIR\build\install-x86" -G "MSYS Makefiles" -DCMAKE_MAKE_PROGRAM=mingw32-make -D"CMAKE_BUILD_TYPE:STRING=Release" -D"ZeroMQ_DIR:PATH="C:\msys32\usr" -D"CMAKE_CXX_FLAGS=-m32" -D"CMAKE_EXE_LINKER_FLAGS=-Wl,--large-address-aware" -D"CMAKE_C_FLAGS=-m32" ../
     - mingw32-make install
     - Move-Item -Force -path "install-x86\lib\python3.7\site-packages\*openshot*" -destination "install-x86\python\"
     - New-Item -path "install-x86/share/" -Name "$CI_PROJECT_NAME" -Value "CI_PROJECT_NAME:$CI_PROJECT_NAME`nCI_COMMIT_REF_NAME:$CI_COMMIT_REF_NAME`nCI_COMMIT_SHA:$CI_COMMIT_SHA`nCI_JOB_ID:$CI_JOB_ID" -ItemType file -force

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -75,7 +75,7 @@ windows-builder-x64:
     - New-Item -ItemType Directory -Force -Path build
     - New-Item -ItemType Directory -Force -Path build\install-x64\python
     - cd build
-    - cmake -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -D"CMAKE_INSTALL_PREFIX:PATH=$CI_PROJECT_DIR\build\install-x64" -G "MSYS Makefiles" -DCMAKE_MAKE_PROGRAM=mingw32-make -D"CMAKE_BUILD_TYPE:STRING=Release" -D"ZeroMQ_DIR:PATH=C:\msys64\usr" ../
+    - cmake -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -D"CMAKE_INSTALL_PREFIX:PATH=$CI_PROJECT_DIR\build\install-x64" -G "MSYS Makefiles" -DCMAKE_MAKE_PROGRAM=mingw32-make -D"CMAKE_BUILD_TYPE:STRING=Release" ../
     - mingw32-make install
     - Move-Item -Force -path "install-x64\lib\python3.7\site-packages\*openshot*" -destination "install-x64\python\"
     - New-Item -path "install-x64/share/" -Name "$CI_PROJECT_NAME" -Value "CI_PROJECT_NAME:$CI_PROJECT_NAME`nCI_COMMIT_REF_NAME:$CI_COMMIT_REF_NAME`nCI_COMMIT_SHA:$CI_COMMIT_SHA`nCI_JOB_ID:$CI_JOB_ID" -ItemType file -force
@@ -100,14 +100,13 @@ windows-builder-x86:
     - $env:LIBOPENSHOT_AUDIO_DIR = "$CI_PROJECT_DIR\build\install-x86"
     - $env:UNITTEST_DIR = "C:\msys32\usr"
     - $env:RESVGDIR = "C:\msys32\usr"
-    - $env:ZMQDIR = "C:\msys32\usr"
     - $env:Path = "C:\msys32\mingw32\bin;C:\msys32\mingw32\lib;C:\msys32\usr\lib\cmake\UnitTest++;C:\msys32\home\jonathan\depot_tools;C:\msys32\usr;C:\msys32\usr\lib;" + $env:Path;
     - New-Item -ItemType Directory -Force -Path build
     - New-Item -ItemType Directory -Force -Path build\install-x86\python
     - cd build
-    - cmake -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -D"CMAKE_INSTALL_PREFIX:PATH=$CI_PROJECT_DIR\build\install-x86" -G "MSYS Makefiles" -DCMAKE_MAKE_PROGRAM=mingw32-make -D"CMAKE_BUILD_TYPE:STRING=Release" -D"ZeroMQ_DIR:PATH="C:\msys32\usr" -D"CMAKE_CXX_FLAGS=-m32" -D"CMAKE_EXE_LINKER_FLAGS=-Wl,--large-address-aware" -D"CMAKE_C_FLAGS=-m32" ../
+    - cmake -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -D"CMAKE_INSTALL_PREFIX:PATH=$CI_PROJECT_DIR\build\install-x86" -G "MSYS Makefiles" -DCMAKE_MAKE_PROGRAM=mingw32-make -D"CMAKE_BUILD_TYPE:STRING=Release" -D"CMAKE_CXX_FLAGS=-m32" -D"CMAKE_EXE_LINKER_FLAGS=-Wl,--large-address-aware" -D"CMAKE_C_FLAGS=-m32" ../
     - mingw32-make install
-    - Move-Item -Force -path "install-x86\lib\python3.7\site-packages\*openshot*" -destination "install-x86\python\"
+     Move-Item -Force -path "install-x86\lib\python3.7\site-packages\*openshot*" -destination "install-x86\python\"
     - New-Item -path "install-x86/share/" -Name "$CI_PROJECT_NAME" -Value "CI_PROJECT_NAME:$CI_PROJECT_NAME`nCI_COMMIT_REF_NAME:$CI_COMMIT_REF_NAME`nCI_COMMIT_SHA:$CI_COMMIT_SHA`nCI_JOB_ID:$CI_JOB_ID" -ItemType file -force
     - $PREV_GIT_LABEL=(git describe --tags --abbrev=0)
     - git log "$PREV_GIT_LABEL..HEAD" --oneline --pretty=format:"%C(auto,yellow)%h%C(auto,magenta)% %C(auto,blue)%>(12,trunc)%ad %C(auto,green)%<(25,trunc)%aN%C(auto,reset)%s%C(auto,red)% gD% D" --date=short > "install-x86/share/$CI_PROJECT_NAME.log"

--- a/cmake/Modules/FindZeroMQ.cmake
+++ b/cmake/Modules/FindZeroMQ.cmake
@@ -4,44 +4,30 @@ pkg_check_modules(PC_LIBZMQ QUIET libzmq)
 
 set(ZeroMQ_VERSION ${PC_LIBZMQ_VERSION})
 find_path(ZeroMQ_INCLUDE_DIR zmq.h
-          HINTS ${ZeroMQ_DIR} $ENV{ZMQDIR}
-          PATHS ${PC_LIBZMQ_INCLUDE_DIRS})
+	  PATHS ${ZeroMQ_DIR}/include
+                ${PC_LIBZMQ_INCLUDE_DIRS})
 
-find_library(ZeroMQ_LIBRARY NAMES libzmq.so libzmq.dylib libzmq.dll
-             HINTS ${ZeroMQ_DIR} $ENV{ZMQDIR}
-             PATHS ${PC_LIBZMQ_LIBDIR} ${PC_LIBZMQ_LIBRARY_DIRS})
-find_library(ZeroMQ_STATIC_LIBRARY NAMES libzmq-static.a libzmq.a libzmq.dll.a
-             HINTS ${ZeroMQ_DIR} $ENV{ZMQDIR}
-             PATHS ${PC_LIBZMQ_LIBDIR} ${PC_LIBZMQ_LIBRARY_DIRS})
+find_library(ZeroMQ_LIBRARY
+	     NAMES zmq
+	     PATHS ${ZeroMQ_DIR}/lib
+                   ${PC_LIBZMQ_LIBDIR}
+		   ${PC_LIBZMQ_LIBRARY_DIRS})
 
-if(ZeroMQ_LIBRARY OR ZeroMQ_STATIC_LIBRARY)
+if(ZeroMQ_LIBRARY)
     set(ZeroMQ_FOUND ON)
 endif()
 
-if (TARGET libzmq)
-    # avoid errors defining targets twice
-    return()
+set ( ZeroMQ_LIBRARIES ${ZeroMQ_LIBRARY} )
+set ( ZeroMQ_INCLUDE_DIRS ${ZeroMQ_INCLUDE_DIR} )
+
+if(NOT TARGET libzmq)
+	add_library(libzmq UNKNOWN IMPORTED)
+	set_target_properties(libzmq PROPERTIES
+		IMPORTED_LOCATION ${ZeroMQ_LIBRARIES}
+		INTERFACE_INCLUDE_DIRECTORIES ${ZeroMQ_INCLUDE_DIRS})
 endif()
 
-set(ZeroMQ_INCLUDE_DIRS ${ZeroMQ_INCLUDE_DIR})
-list(APPEND ZeroMQ_INCLUDE_DIRS ${PC_LIBZMQ_INCLUDE_DIRS})
-list(REMOVE_DUPLICATES ZeroMQ_INCLUDE_DIRS)
-
-if(ZeroMQ_LIBRARY)
-    add_library(libzmq SHARED IMPORTED)
-    set_property(TARGET libzmq PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${ZeroMQ_INCLUDE_DIRS})
-    set_property(TARGET libzmq PROPERTY IMPORTED_LOCATION ${ZeroMQ_LIBRARY})
-endif()
-
-if(ZeroMQ_LIBRARY_STATIC)
-    add_library(libzmq-static STATIC IMPORTED ${ZeroMQ_INCLUDE_DIRS})
-    set_property(TARGET libzmq-static PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${ZeroMQ_INCLUDE_DIRS})
-    set_property(TARGET libzmq-static PROPERTY IMPORTED_LOCATION ${ZeroMQ_STATIC_LIBRARY})
-endif()
-
-include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(ZeroMQ
-  REQUIRED_VARS
-    ZeroMQ_LIBRARY ZeroMQ_INCLUDE_DIRS
-  VERSION_VAR
-    ZeroMQ_VERSION)
+include ( FindPackageHandleStandardArgs )
+# handle the QUIETLY and REQUIRED arguments and set ZMQ_FOUND to TRUE
+# if all listed variables are TRUE
+find_package_handle_standard_args ( ZeroMQ DEFAULT_MSG ZeroMQ_LIBRARIES ZeroMQ_INCLUDE_DIRS )

--- a/cmake/Modules/FindZeroMQ.cmake
+++ b/cmake/Modules/FindZeroMQ.cmake
@@ -23,13 +23,17 @@ set(ZeroMQ_INCLUDE_DIRS ${ZeroMQ_INCLUDE_DIR})
 list(APPEND ZeroMQ_INCLUDE_DIRS ${PC_LIBZMQ_INCLUDE_DIRS})
 list(REMOVE_DUPLICATES ZeroMQ_INCLUDE_DIRS)
 
-add_library(libzmq SHARED IMPORTED)
-set_property(TARGET libzmq PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${ZeroMQ_INCLUDE_DIRS})
-set_property(TARGET libzmq PROPERTY IMPORTED_LOCATION ${ZeroMQ_LIBRARY})
+if(ZeroMQ_LIBRARY)
+    add_library(libzmq SHARED IMPORTED)
+    set_property(TARGET libzmq PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${ZeroMQ_INCLUDE_DIRS})
+    set_property(TARGET libzmq PROPERTY IMPORTED_LOCATION ${ZeroMQ_LIBRARY})
+endif()
 
-add_library(libzmq-static STATIC IMPORTED ${ZeroMQ_INCLUDE_DIRS})
-set_property(TARGET libzmq-static PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${ZeroMQ_INCLUDE_DIRS})
-set_property(TARGET libzmq-static PROPERTY IMPORTED_LOCATION ${ZeroMQ_STATIC_LIBRARY})
+if(ZeroMQ_LIBRARY_STATIC)
+    add_library(libzmq-static STATIC IMPORTED ${ZeroMQ_INCLUDE_DIRS})
+    set_property(TARGET libzmq-static PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${ZeroMQ_INCLUDE_DIRS})
+    set_property(TARGET libzmq-static PROPERTY IMPORTED_LOCATION ${ZeroMQ_STATIC_LIBRARY})
+endif()
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(ZeroMQ

--- a/cmake/Modules/FindZeroMQ.cmake
+++ b/cmake/Modules/FindZeroMQ.cmake
@@ -3,12 +3,16 @@ find_package(PkgConfig)
 pkg_check_modules(PC_LIBZMQ QUIET libzmq)
 
 set(ZeroMQ_VERSION ${PC_LIBZMQ_VERSION})
-find_path(ZeroMQ_INCLUDE_DIR zmq.h PATHS ${PC_LIBZMQ_INCLUDE_DIRS} $ENV{ZMQDIR})
+find_path(ZeroMQ_INCLUDE_DIR zmq.h
+          HINTS ${ZeroMQ_DIR} $ENV{ZMQDIR}
+          PATHS ${PC_LIBZMQ_INCLUDE_DIRS})
 
 find_library(ZeroMQ_LIBRARY NAMES libzmq.so libzmq.dylib libzmq.dll
-PATHS ${PC_LIBZMQ_LIBDIR} ${PC_LIBZMQ_LIBRARY_DIRS} $ENV{ZMQDIR})
+             HINTS ${ZeroMQ_DIR} $ENV{ZMQDIR}
+             PATHS ${PC_LIBZMQ_LIBDIR} ${PC_LIBZMQ_LIBRARY_DIRS})
 find_library(ZeroMQ_STATIC_LIBRARY NAMES libzmq-static.a libzmq.a libzmq.dll.a
-             PATHS ${PC_LIBZMQ_LIBDIR} ${PC_LIBZMQ_LIBRARY_DIRS} $ENV{ZMQDIR})
+             HINTS ${ZeroMQ_DIR} $ENV{ZMQDIR}
+             PATHS ${PC_LIBZMQ_LIBDIR} ${PC_LIBZMQ_LIBRARY_DIRS})
 
 if(ZeroMQ_LIBRARY OR ZeroMQ_STATIC_LIBRARY)
     set(ZeroMQ_FOUND ON)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -330,8 +330,13 @@ find_package(ZeroMQ REQUIRED) # Creates libzmq target
 # others (Ubuntu) bundle them in with libzmq itself
 find_package(cppzmq QUIET) # Creates cppzmq target
 
-# Include ZeroMQ headers (needed for compile)
-target_link_libraries(openshot PUBLIC libzmq)
+# Link ZeroMQ (shared or static, whichever's found)
+if (TARGET libzmq)
+	target_link_libraries(openshot PUBLIC libzmq)
+elseif (TARGET libzmq-static)
+	target_link_libraries(openshot PRIVATE libzmq-static)
+endif()
+# Include cppzmq headers, if not bundled into libzmq
 if (TARGET cppzmq)
   target_link_libraries(openshot PUBLIC cppzmq)
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -330,11 +330,9 @@ find_package(ZeroMQ REQUIRED) # Creates libzmq target
 # others (Ubuntu) bundle them in with libzmq itself
 find_package(cppzmq QUIET) # Creates cppzmq target
 
-# Link ZeroMQ (shared or static, whichever's found)
+# Link ZeroMQ library
 if (TARGET libzmq)
 	target_link_libraries(openshot PUBLIC libzmq)
-elseif (TARGET libzmq-static)
-	target_link_libraries(openshot PRIVATE libzmq-static)
 endif()
 # Include cppzmq headers, if not bundled into libzmq
 if (TARGET cppzmq)
@@ -372,6 +370,7 @@ target_link_libraries(openshot PUBLIC ${REQUIRED_LIBRARIES})
 
 # Pick up parameters from OpenMP target and propagate
 target_link_libraries(openshot PUBLIC OpenMP::OpenMP_CXX)
+
 
 ############### CLI EXECUTABLES ################
 # Create test executable


### PR DESCRIPTION
Not 100% sure _why_, honestly, but this version of the Find module works where the previous one didn't.

I believe it comes down to this note in the CMake docs for `add_library`:
<blockquote>An UNKNOWN library type is typically only used in the implementation of Find Modules. It allows the path to an imported library (often found using the find_library() command) to be used without having to know what type of library it is. <b>This is especially useful on Windows where a static library and a DLL’s import library both have the same file extension.</b></blockquote>

This also does away with the `ZMQ_DIR` envvar entirely — `ZeroMQ_DIR` can be set as a CMake variable (`cmake -DZeroMQ_DIR:PATH="C:\msys64\mingw64\"`, for example) to provide the location of ZeroMQ.

But that actually shouldn't be necessary, if it was installed using `pacman` on Windows it should be autodetected just like any other platform. I've removed any setting of the ZeroMQ path from the `.gitlab-ci.yml` Windows configs, as a test of that theory.

It _miiiiiiight_ break Win32, in which case we just add a `-DZeroMQ_DIR:PATH="C:\msys32\usr\"` there (only). But I hope it'll Just Work™, because `pkg-config` is in play on MSYS.