### PR TITLE
CMake: Use targets for QT, AUTOMOC sources, eliminate source globbing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,13 +72,6 @@ configure_file(include/OpenShotVersion.h.in include/OpenShotVersion.h @ONLY)
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/include/OpenShotVersion.h
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/libopenshot)
 
-############### Set up include paths #################
-list(APPEND OPENSHOT_INCLUDE_DIRS
-    ${CMAKE_CURRENT_SOURCE_DIR}/include
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/effects
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/Qt
-    ${CMAKE_CURRENT_BINARY_DIR}/include )
-
 #### Enable C++11 (for std::shared_ptr support)
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -88,9 +81,9 @@ IF (WIN32)
 	SET_PROPERTY(GLOBAL PROPERTY WIN32 "WIN32")
 ENDIF(WIN32)
 
-############## FIND ALL QT RELATED HEADERS ##############
-set(QT_HEADER_DIR ${CMAKE_CURRENT_SOURCE_DIR}/include/Qt)
-FILE(GLOB QT_HEADER_FILES "${QT_HEADER_DIR}/*.h")
+include_directories(
+  ${CMAKE_CURRENT_SOURCE_DIR}/include
+  ${CMAKE_CURRENT_BINARY_DIR}/include)
 
 ############## PROCESS src/ DIRECTORIES ##############
 add_subdirectory(src)

--- a/cmake/Modules/FindFFmpeg.cmake
+++ b/cmake/Modules/FindFFmpeg.cmake
@@ -180,9 +180,16 @@ foreach (_component ${FFmpeg_FIND_COMPONENTS})
   endif ()
 endforeach ()
 
-# Build the include path with duplicates removed.
+# Build the result lists with duplicates removed, in case of repeated
+# invocations.
 if (FFmpeg_INCLUDE_DIRS)
   list(REMOVE_DUPLICATES FFmpeg_INCLUDE_DIRS)
+endif()
+if (FFmpeg_LIBRARIES)
+  list(REMOVE_DUPLICATES FFmpeg_LIBRARIES)
+endif()
+if(FFmpeg_DEFINITIONS)
+  list(REMOVE_DUPLICATES FFmpeg_DEFINITIONS)
 endif ()
 
 # cache the vars.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -367,34 +367,18 @@ endif()
 
 
 ###############  LINK LIBRARY  #################
-SET ( REQUIRED_LIBRARIES
-		${LIBOPENSHOT_AUDIO_LIBRARIES}
-		${PROFILER}
-		)
+# Link remaining dependency libraries
+target_link_libraries(openshot PUBLIC
+	${LIBOPENSHOT_AUDIO_LIBRARIES}
+	${PROFILER}
+	$<$<BOOL:${ImageMagick_FOUND}>:${ImageMagick_LIBRARIES}>
+	$<$<BOOL:${RESVG_FOUND}>:${RESVG_LIBRARIES}>
+  $<$<BOOL:${BLACKMAGIC_FOUND}>:${BLACKMAGIC_LIBRARY_DIR}>)
 
-IF (RESVG_FOUND)
-	list(APPEND REQUIRED_LIBRARIES ${RESVG_LIBRARIES})
-ENDIF(RESVG_FOUND)
-
-
-IF (ImageMagick_FOUND)
-  list(APPEND REQUIRED_LIBRARIES ${ImageMagick_LIBRARIES})
-ENDIF (ImageMagick_FOUND)
-
-IF (BLACKMAGIC_FOUND)
-	list(APPEND REQUIRED_LIBRARIES ${BLACKMAGIC_LIBRARY_DIR})
-ENDIF (BLACKMAGIC_FOUND)
-
-IF (WIN32)
+if(WIN32)
 	# Required for exception handling on Windows
-	list(APPEND REQUIRED_LIBRARIES "imagehlp" "dbghelp" )
-ENDIF(WIN32)
-
-# Link all referenced libraries
-target_link_libraries(openshot PUBLIC ${REQUIRED_LIBRARIES})
-
-# Pick up parameters from OpenMP target and propagate
-target_link_libraries(openshot PUBLIC OpenMP::OpenMP_CXX)
+	target_link_libraries(openshot PUBLIC "imagehlp" "dbghelp" )
+endif()
 
 ############### CLI EXECUTABLES ################
 # Create test executable

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -24,10 +24,7 @@
 # along with OpenShot Library. If not, see <http://www.gnu.org/licenses/>.
 ################################################################################
 
-# Pick up our include directories from the parent context
-include_directories(${OPENSHOT_INCLUDE_DIRS})
-
-####### Display summary of options/dependencies ######
+# Collect and display summary of options/dependencies
 include(FeatureSummary)
 
 ################ OPTIONS ##################
@@ -35,6 +32,9 @@ include(FeatureSummary)
 option(USE_SYSTEM_JSONCPP "Use system installed JsonCpp, if found" ON)
 option(DISABLE_BUNDLED_JSONCPP "Don't fall back to bundled JsonCpp" OFF)
 option(ENABLE_IWYU "Enable 'Include What You Use' scanner (CMake 3.3+)" OFF)
+
+# Automatically process Qt classes with meta-object compiler
+set(CMAKE_AUTOMOC True)
 
 ################ WINDOWS ##################
 # Set some compiler options for Windows
@@ -90,9 +90,6 @@ FIND_PACKAGE(OpenShotAudio 0.1.8 REQUIRED)
 # Include Juce headers (needed for compile)
 include_directories(${LIBOPENSHOT_AUDIO_INCLUDE_DIRS})
 
-# Manually moc Qt files
-qt5_wrap_cpp(MOC_FILES ${QT_HEADER_FILES})
-
 ################# BLACKMAGIC DECKLINK ###################
 # Find BlackMagic DeckLinkAPI libraries
 IF (ENABLE_BLACKMAGIC)
@@ -147,73 +144,71 @@ if(ENABLE_IWYU)
 endif()
 add_feature_info("IWYU (include-what-you-use)" ENABLE_IWYU "Scan all source files with 'iwyu'")
 
-#### GET LIST OF EFFECT FILES ####
-FILE(GLOB EFFECT_FILES "${CMAKE_CURRENT_SOURCE_DIR}/effects/*.cpp")
+# Main library sources
+set(OPENSHOT_SOURCES
+  AudioBufferSource.cpp
+  AudioReaderSource.cpp
+  AudioResampler.cpp
+  CacheBase.cpp
+  CacheDisk.cpp
+  CacheMemory.cpp
+  ChunkReader.cpp
+  ChunkWriter.cpp
+  Color.cpp
+  Clip.cpp
+  ClipBase.cpp
+  Coordinate.cpp
+  CrashHandler.cpp
+  DummyReader.cpp
+  ReaderBase.cpp
+  RendererBase.cpp
+  WriterBase.cpp
+  EffectBase.cpp
+  EffectInfo.cpp
+  FFmpegReader.cpp
+  FFmpegWriter.cpp
+  Fraction.cpp
+  Frame.cpp
+  FrameMapper.cpp
+  KeyFrame.cpp
+  OpenShotVersion.cpp
+  ZmqLogger.cpp
+  PlayerBase.cpp
+  Point.cpp
+  Profiles.cpp
+  QtHtmlReader.cpp
+  QtImageReader.cpp
+  QtPlayer.cpp
+  QtTextReader.cpp
+  Settings.cpp
+  Timeline.cpp)
 
-#### GET LIST OF QT PLAYER FILES ####
-FILE(GLOB QT_PLAYER_FILES "${CMAKE_CURRENT_SOURCE_DIR}/Qt/*.cpp")
+# Video effects
+set(EFFECTS_SOURCES
+  effects/Bars.cpp
+  effects/Blur.cpp
+  effects/Brightness.cpp
+  effects/ChromaKey.cpp
+  effects/ColorShift.cpp
+  effects/Crop.cpp
+  effects/Deinterlace.cpp
+  effects/Hue.cpp
+  effects/Mask.cpp
+  effects/Negate.cpp
+  effects/Pixelate.cpp
+  effects/Saturation.cpp
+  effects/Shift.cpp
+  effects/Wave.cpp)
 
-###############  SET LIBRARY SOURCE FILES  #################
-SET ( OPENSHOT_SOURCE_FILES
-		AudioBufferSource.cpp
-		AudioReaderSource.cpp
-		AudioResampler.cpp
-		CacheBase.cpp
-		CacheDisk.cpp
-		CacheMemory.cpp
-		ChunkReader.cpp
-		ChunkWriter.cpp
-		Color.cpp
-		Clip.cpp
-		ClipBase.cpp
-		Coordinate.cpp
-		CrashHandler.cpp
-		DummyReader.cpp
-		ReaderBase.cpp
-		RendererBase.cpp
-		WriterBase.cpp
-		EffectBase.cpp
-		${EFFECT_FILES}
-		EffectInfo.cpp
-		FFmpegReader.cpp
-		FFmpegWriter.cpp
-		Fraction.cpp
-		Frame.cpp
-		FrameMapper.cpp
-		KeyFrame.cpp
-		OpenShotVersion.cpp
-		ZmqLogger.cpp
-		PlayerBase.cpp
-		Point.cpp
-		Profiles.cpp
-		QtImageReader.cpp
-		QtPlayer.cpp
-		Settings.cpp
-		Timeline.cpp
-		QtTextReader.cpp
-		QtHtmlReader.cpp
-
-
-		# Qt Video Player
-		${QT_PLAYER_FILES}
-		${MOC_FILES})
-
-# ImageMagic related files
-IF (ImageMagick_FOUND)
-	SET ( OPENSHOT_SOURCE_FILES ${OPENSHOT_SOURCE_FILES}
-			ImageReader.cpp
-			ImageWriter.cpp
-			TextReader.cpp)
-ENDIF (ImageMagick_FOUND)
-
-# BlackMagic related files
-IF (BLACKMAGIC_FOUND)
-	SET ( OPENSHOT_SOURCE_FILES ${OPENSHOT_SOURCE_FILES}
-			DecklinkInput.cpp
-			DecklinkReader.cpp
-			DecklinkOutput.cpp
-			DecklinkWriter.cpp)
-ENDIF (BLACKMAGIC_FOUND)
+# Qt video player components
+set(QT_PLAYER_SOURCES
+  Qt/AudioPlaybackThread.cpp
+  Qt/PlayerDemo.cpp
+  Qt/PlayerPrivate.cpp
+  Qt/VideoCacheThread.cpp
+  Qt/VideoPlaybackThread.cpp
+  Qt/VideoRenderer.cpp
+  Qt/VideoRenderWidget.cpp)
 
 
 # Get list of headers
@@ -224,9 +219,13 @@ SET(CMAKE_MACOSX_RPATH 0)
 
 ############### CREATE LIBRARY #################
 # Create shared openshot library
-add_library(openshot SHARED
-		${OPENSHOT_SOURCE_FILES}
-		${headers} )
+add_library(openshot SHARED)
+
+target_sources(openshot
+  PRIVATE
+    ${OPENSHOT_SOURCES} ${EFFECTS_SOURCES} ${QT_PLAYER_SOURCES}
+  PUBLIC
+    ${headers})
 
 # Set SONAME and other library properties
 set_target_properties(openshot
@@ -235,6 +234,34 @@ set_target_properties(openshot
 		SOVERSION ${PROJECT_SO_VERSION}
 		INSTALL_NAME_DIR "${CMAKE_INSTALL_PREFIX}/lib"
 		)
+
+# Add optional ImageMagic-dependent sources
+if(ImageMagick_FOUND)
+	target_sources(openshot PRIVATE
+    ImageReader.cpp
+    ImageWriter.cpp
+    TextReader.cpp)
+endif()
+
+# BlackMagic related files
+if(BLACKMAGIC_FOUND)
+  target_sources(openshot PRIVATE
+    DecklinkInput.cpp
+    DecklinkReader.cpp
+    DecklinkOutput.cpp
+    DecklinkWriter.cpp)
+endif()
+
+# Location of our includes, both internally and when installed
+target_include_directories(openshot
+  PRIVATE
+    ${CMAKE_SOURCE_DIR}/include
+    ${CMAKE_BINARY_DIR}/include
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>
+    $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/include>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/libopenshot>)
+
 
 ################### JSONCPP #####################
 # Include jsoncpp headers (needed for JSON parsing)
@@ -342,7 +369,6 @@ endif()
 ###############  LINK LIBRARY  #################
 SET ( REQUIRED_LIBRARIES
 		${LIBOPENSHOT_AUDIO_LIBRARIES}
-		${QT_LIBRARIES}
 		${PROFILER}
 		)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -90,20 +90,6 @@ FIND_PACKAGE(OpenShotAudio 0.1.8 REQUIRED)
 # Include Juce headers (needed for compile)
 include_directories(${LIBOPENSHOT_AUDIO_INCLUDE_DIRS})
 
-################# QT5 ###################
-# Find QT5 libraries
-foreach(qt_lib Qt5Widgets Qt5Core Qt5Gui Qt5Multimedia Qt5MultimediaWidgets)
-    find_package(${qt_lib} REQUIRED)
-    # Header files
-    include_directories(${${qt_lib}_INCLUDE_DIRS})
-    # Compiler definitions
-    add_definitions(${${qt_lib}_DEFINITIONS})
-    # Other CFLAGS
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${${qt_lib}_EXECUTABLE_COMPILE_FLAGS}")
-    # For use when linking
-    list(APPEND QT_LIBRARIES ${${qt_lib}_LIBRARIES})
-endforeach()
-
 # Manually moc Qt files
 qt5_wrap_cpp(MOC_FILES ${QT_HEADER_FILES})
 
@@ -287,6 +273,17 @@ endif ()
 if (TARGET jsoncpp_lib)
   target_link_libraries(openshot PUBLIC jsoncpp_lib)
 endif ()
+
+################# QT5 ###################
+# Find QT5 libraries
+set(_qt_components Widgets Core Gui Multimedia MultimediaWidgets)
+find_package(Qt5 COMPONENTS ${_qt_components} REQUIRED)
+
+foreach(_qt_comp IN LISTS _qt_components)
+  if(TARGET Qt5::${_qt_comp})
+    target_link_libraries(openshot PUBLIC Qt5::${_qt_comp})
+  endif()
+endforeach()
 
 ################### FFMPEG #####################
 # Find FFmpeg libraries (used for video encoding / decoding)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -370,10 +370,19 @@ endif()
 # Link remaining dependency libraries
 target_link_libraries(openshot PUBLIC
 	${LIBOPENSHOT_AUDIO_LIBRARIES}
-	${PROFILER}
-	$<$<BOOL:${ImageMagick_FOUND}>:${ImageMagick_LIBRARIES}>
-	$<$<BOOL:${RESVG_FOUND}>:${RESVG_LIBRARIES}>
-  $<$<BOOL:${BLACKMAGIC_FOUND}>:${BLACKMAGIC_LIBRARY_DIR}>)
+  ${PROFILER})
+
+if(ImageMagick_FOUND)
+  target_link_libraries(openshot PUBLIC ${ImageMagick_LIBRARIES})
+endif()
+
+if(RESVG_FOUND)
+  target_link_libraries(openshot PUBLIC ${RESVG_LIBRARIES})
+endif()
+
+if(BLACKMAGIC_FOUND)
+  target_link_libraries(openshot PUBLIC ${BLACKMAGIC_LIBRARY_DIR})
+endif()
 
 if(WIN32)
 	# Required for exception handling on Windows

--- a/src/bindings/ruby/CMakeLists.txt
+++ b/src/bindings/ruby/CMakeLists.txt
@@ -24,9 +24,6 @@
 # along with OpenShot Library. If not, see <http://www.gnu.org/licenses/>.
 ################################################################################
 
-# Pick up our include directories from the parent context
-include_directories(${OPENSHOT_INCLUDE_DIRS})
-
 ############### RUBY BINDINGS ################
 FIND_PACKAGE(SWIG 3.0 REQUIRED)
 INCLUDE(${SWIG_USE_FILE})

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -24,9 +24,6 @@
 # along with OpenShot Library. If not, see <http://www.gnu.org/licenses/>.
 ################################################################################
 
-# Pick up our include directories from the parent context
-include_directories(${OPENSHOT_INCLUDE_DIRS})
-
 SET(TEST_MEDIA_PATH "${PROJECT_SOURCE_DIR}/src/examples/")
 
 ################ WINDOWS ##################

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -84,23 +84,6 @@ FIND_PACKAGE(OpenShotAudio 0.1.8 REQUIRED)
 # Include Juce headers (needed for compile)
 include_directories(${LIBOPENSHOT_AUDIO_INCLUDE_DIRS})
 
-################# QT5 ###################
-# Find QT5 libraries
-foreach(qt_lib Qt5Widgets Qt5Core Qt5Gui Qt5Multimedia Qt5MultimediaWidgets)
-    find_package(${qt_lib} REQUIRED)
-    # Header files
-    list(APPEND QT_INCLUDES ${${qt_lib}_INCLUDE_DIRS})
-    # Compiler definitions
-    add_definitions(${${qt_lib}_DEFINITIONS})
-    # Other CFLAGS
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${${qt_lib}_EXECUTABLE_COMPILE_FLAGS}")
-endforeach()
-list(REMOVE_DUPLICATES QT_INCLUDES)
-include_directories(${QT_INCLUDES})
-
-# Manually moc Qt files
-qt5_wrap_cpp(MOC_FILES ${QT_HEADER_FILES})
-
 
 ################# BLACKMAGIC DECKLINK ###################
 IF (ENABLE_BLACKMAGIC)


### PR DESCRIPTION
This is kind of a major one. Not only does it move to using the Qt targets for linking, but it:
* switches over to AUTOMOC instead of manually wrapping files (some of which never needed to be wrapped),
* removes the globbing for `src/effects/` and `src/Qt/` files. (All source files now have to be named explicitly in `src/CMakeLists.txt`, so if any are added the appropriate list needs to be updated.)
* Calls `include_directories()` once from the top level `CMakeLists.txt`, and then not again.
* Eliminates the `REQUIRED_LIBRARIES` variable from CMake, continuing the process begun in previous `IMPORTED`-target PRs where dependencies get linked separately using multiple `target_link_libraries()` calls.
* <strike>Switches to `$<$<BOOL:Foo_FOUND>:${Foo_LIBRARIES}>` generator expressions, for conditional linking.</strike> (OK, this last one didn't work out.)

The PR branch lives in the project repo, to give the builders a chance to chew on the changes. Marked WIP only pending the outcome of that testing.