### PR TITLE
Reverse order of Python detection

### DIFF
--- a/src/bindings/python/CMakeLists.txt
+++ b/src/bindings/python/CMakeLists.txt
@@ -37,8 +37,8 @@ if (POLICY CMP0086)
 	cmake_policy(SET CMP0086 OLD)
 endif()
 
-FIND_PACKAGE(PythonLibs 3)
 FIND_PACKAGE(PythonInterp 3)
+FIND_PACKAGE(PythonLibs 3)
 if (PYTHONLIBS_FOUND AND PYTHONINTERP_FOUND)
 
 	### Include Python header files


### PR DESCRIPTION
Detecting PythonLibs before PythonInterp can cause a non-default Python
library to be picked up, which then won't match the PythonInterp version
(which always matches the version of the `python3` command).

(e.g. on Fedora 30 with `python3-3.7.5` and `python3-libs-3.7.5` installed as the default `/usr/bin/python3`, plus `python38-3.8.0` installed as `/usr/bin/python38`...)

1. With `find_package(PythonLibs 3)` before `find_package(PythonInterp 3)`:
   ```
   -- Found PythonLibs: /usr/lib64/libpython3.8.so (found suitable version "3.8.0", minimum required is "3") 
   -- Found PythonInterp: /usr/bin/python3 (found suitable version "3.7.5", minimum required is "3") 
   ```

2. With `find_package(PythonInterp 3)` before `find_package(PythonLibs 3)`:
   ```
   -- Found PythonInterp: /usr/bin/python3 (found suitable version "3.7.5", minimum required is "3") 
   -- Found PythonLibs: /usr/lib64/libpython3.7m.so (found suitable version "3.7.5", minimum required is "3") 
   ```
