### PR TITLE
Change high quality scaling to use SWS_BICUBIC

### DIFF
--- a/src/FFmpegReader.cpp
+++ b/src/FFmpegReader.cpp
@@ -1339,7 +1339,7 @@ void FFmpegReader::ProcessVideoPacket(int64_t requested_frame) {
 
 		int scale_mode = SWS_FAST_BILINEAR;
 		if (openshot::Settings::Instance()->HIGH_QUALITY_SCALING) {
-			scale_mode = SWS_LANCZOS;
+			scale_mode = SWS_BICUBIC;
 		}
 		SwsContext *img_convert_ctx = sws_getContext(info.width, info.height, AV_GET_CODEC_PIXEL_FORMAT(pStream, pCodecCtx), width,
 															  height, PIX_FMT_RGBA, scale_mode, NULL, NULL, NULL);

--- a/src/FFmpegWriter.cpp
+++ b/src/FFmpegWriter.cpp
@@ -2111,7 +2111,7 @@ void FFmpegWriter::OutputStreamInfo() {
 void FFmpegWriter::InitScalers(int source_width, int source_height) {
 	int scale_mode = SWS_FAST_BILINEAR;
 	if (openshot::Settings::Instance()->HIGH_QUALITY_SCALING) {
-		scale_mode = SWS_LANCZOS;
+		scale_mode = SWS_BICUBIC;
 	}
 
 	// Init software rescalers vector (many of them, one for each thread)

--- a/src/FFmpegWriter.cpp
+++ b/src/FFmpegWriter.cpp
@@ -2119,11 +2119,11 @@ void FFmpegWriter::InitScalers(int source_width, int source_height) {
 		// Init the software scaler from FFMpeg
 #if IS_FFMPEG_3_2
 		if (hw_en_on && hw_en_supported) {
-			img_convert_ctx = sws_getContext(source_width, source_height, PIX_FMT_RGBA, info.width, info.height, AV_PIX_FMT_NV12, SWS_BILINEAR, NULL, NULL, NULL);
+			img_convert_ctx = sws_getContext(source_width, source_height, PIX_FMT_RGBA, info.width, info.height, AV_PIX_FMT_NV12, scale_mode, NULL, NULL, NULL);
 		} else
 #endif
 		{
-			img_convert_ctx = sws_getContext(source_width, source_height, PIX_FMT_RGBA, info.width, info.height, AV_GET_CODEC_PIXEL_FORMAT(video_st, video_st->codec), SWS_BILINEAR,
+			img_convert_ctx = sws_getContext(source_width, source_height, PIX_FMT_RGBA, info.width, info.height, AV_GET_CODEC_PIXEL_FORMAT(video_st, video_st->codec), scale_mode,
 											 NULL, NULL, NULL);
 		}
 


### PR DESCRIPTION
Fixing a small implementation detail related to using high quality scaling in FFMpegWriter, and switching from SWS_LANCZOS to SWS_BICUBIC, for better quality when upscaling images (with a small performance loss). But sharper exports are aim, and if it costs us 1 or 2% slower speed, it seems worth it to me.

Real-time previews still use a faster algorithm: SWS_FAST_BILINEAR.

Some comparisons of the FFmpeg scaling methods: 
http://www.programmersought.com/article/4493483389/