### PR TITLE
New Keyframe implementation

### DIFF
--- a/include/KeyFrame.h
+++ b/include/KeyFrame.h
@@ -66,13 +66,6 @@ namespace openshot {
 		bool needs_update;
 		double FactorialLookup[4];
 
-		/*
-		 * Because points can be added in any order, we need to reorder them
-		 * in ascending order based on the point.co.X value.  This simplifies
-		 * processing the curve, due to all the points going from left to right.
-		 */
-		void ReorderPoints();
-
 		// Process an individual segment
 		void ProcessSegment(int Segment, Point p1, Point p2);
 

--- a/include/KeyFrame.h
+++ b/include/KeyFrame.h
@@ -63,25 +63,7 @@ namespace openshot {
 	 */
 	class Keyframe {
 	private:
-		bool needs_update;
-		double FactorialLookup[4];
 		std::vector<Point> Points;			///< Vector of all Points
-		std::vector<Coordinate> Values;		///< Vector of all Values (i.e. the processed coordinates from the curve)
-
-		// Process an individual segment
-		void ProcessSegment(int Segment, Point p1, Point p2);
-
-		// create lookup table for fast factorial calculation
-		void CreateFactorialTable();
-
-		// Get a factorial for a coordinate
-		double Factorial(int64_t n);
-
-		// Calculate the factorial function for Bernstein basis
-		double Ni(int64_t n, int64_t i);
-
-		// Calculate Bernstein Basis
-		double Bernstein(int64_t n, int64_t i, double t);
 
 	public:
 
@@ -154,14 +136,6 @@ namespace openshot {
 		Json::Value JsonValue(); ///< Generate Json::JsonValue for this object
 		void SetJson(std::string value); ///< Load JSON string into this object
 		void SetJsonValue(Json::Value root); ///< Load Json::JsonValue into this object
-
-		/**
-		 * @brief Calculate all of the values for this keyframe.
-		 *
-		 * This clears any existing data in the "values" vector.  This method is automatically called
-		 * by AddPoint(), so you don't typically need to call this method.
-		 */
-		void Process();
 
 		/// Remove a point by matching a coordinate
 		void RemovePoint(Point p);

--- a/include/KeyFrame.h
+++ b/include/KeyFrame.h
@@ -65,6 +65,8 @@ namespace openshot {
 	private:
 		bool needs_update;
 		double FactorialLookup[4];
+		std::vector<Point> Points;			///< Vector of all Points
+		std::vector<Coordinate> Values;		///< Vector of all Values (i.e. the processed coordinates from the curve)
 
 		// Process an individual segment
 		void ProcessSegment(int Segment, Point p1, Point p2);
@@ -82,8 +84,6 @@ namespace openshot {
 		double Bernstein(int64_t n, int64_t i, double t);
 
 	public:
-		std::vector<Point> Points;			///< Vector of all Points
-		std::vector<Coordinate> Values;		///< Vector of all Values (i.e. the processed coordinates from the curve)
 
 		/// Default constructor for the Keyframe class
 		Keyframe();

--- a/include/KeyFrame.h
+++ b/include/KeyFrame.h
@@ -83,57 +83,57 @@ namespace openshot {
 		void AddPoint(double x, double y, InterpolationType interpolate);
 
 		/// Does this keyframe contain a specific point
-		bool Contains(Point p);
+		bool Contains(Point p) const;
 
 		/// Flip all the points in this openshot::Keyframe (useful for reversing an effect or transition, etc...)
 		void FlipPoints();
 
 		/// Get the index of a point by matching a coordinate
-		int64_t FindIndex(Point p);
+		int64_t FindIndex(Point p) const;
 
 		/// Get the value at a specific index
-		double GetValue(int64_t index);
+		double GetValue(int64_t index) const;
 
 		/// Get the rounded INT value at a specific index
-		int GetInt(int64_t index);
+		int GetInt(int64_t index) const;
 
 		/// Get the rounded LONG value at a specific index
-		int64_t GetLong(int64_t index);
+		int64_t GetLong(int64_t index) const;
 
 		/// Get the fraction that represents how many times this value is repeated in the curve
-		Fraction GetRepeatFraction(int64_t index);
+		Fraction GetRepeatFraction(int64_t index) const;
 
 		/// Get the change in Y value (from the previous Y value)
-		double GetDelta(int64_t index);
+		double GetDelta(int64_t index) const;
 
 		/// Get a point at a specific index
-		Point const & GetPoint(int64_t index);
+		Point const & GetPoint(int64_t index) const;
 
 		/// Get current point (or closest point to the right) from the X coordinate (i.e. the frame number)
-		Point GetClosestPoint(Point p);
+		Point GetClosestPoint(Point p) const;
 
 		/// Get current point (or closest point) from the X coordinate (i.e. the frame number)
 		/// Either use the closest left point, or right point
-		Point GetClosestPoint(Point p, bool useLeft);
+		Point GetClosestPoint(Point p, bool useLeft) const;
 
 		/// Get previous point (
-		Point GetPreviousPoint(Point p);
+		Point GetPreviousPoint(Point p) const;
 
 		/// Get max point (by Y coordinate)
-		Point GetMaxPoint();
+		Point GetMaxPoint() const;
 
 		// Get the number of values (i.e. coordinates on the X axis)
-		int64_t GetLength();
+		int64_t GetLength() const;
 
 		/// Get the number of points (i.e. # of points)
-		int64_t GetCount();
+		int64_t GetCount() const;
 
 		/// Get the direction of the curve at a specific index (increasing or decreasing)
-		bool IsIncreasing(int index);
+		bool IsIncreasing(int index) const;
 
 		/// Get and Set JSON methods
-		std::string Json(); ///< Generate JSON string of this object
-		Json::Value JsonValue(); ///< Generate Json::JsonValue for this object
+		std::string Json() const; ///< Generate JSON string of this object
+		Json::Value JsonValue() const; ///< Generate Json::JsonValue for this object
 		void SetJson(std::string value); ///< Load JSON string into this object
 		void SetJsonValue(Json::Value root); ///< Load Json::JsonValue into this object
 
@@ -151,10 +151,10 @@ namespace openshot {
 		void UpdatePoint(int64_t index, Point p);
 
 		/// Print a list of points
-		void PrintPoints();
+		void PrintPoints() const;
 
 		/// Print just the Y value of the point's primary coordinate
-		void PrintValues();
+		void PrintValues() const;
 
 	};
 

--- a/include/KeyFrame.h
+++ b/include/KeyFrame.h
@@ -125,7 +125,7 @@ namespace openshot {
 		double GetDelta(int64_t index);
 
 		/// Get a point at a specific index
-		Point& GetPoint(int64_t index);
+		Point const & GetPoint(int64_t index);
 
 		/// Get current point (or closest point to the right) from the X coordinate (i.e. the frame number)
 		Point GetClosestPoint(Point p);

--- a/include/KeyFrame.h
+++ b/include/KeyFrame.h
@@ -68,7 +68,7 @@ namespace openshot {
 	public:
 
 		/// Default constructor for the Keyframe class
-		Keyframe();
+		Keyframe() = default;
 
 		/// Constructor which sets the default point & coordinate at X=1
 		Keyframe(double value);

--- a/src/Clip.cpp
+++ b/src/Clip.cpp
@@ -109,10 +109,10 @@ void Clip::init_settings()
 // Init reader's rotation (if any)
 void Clip::init_reader_rotation() {
 	// Only init rotation from reader when needed
-	if (rotation.Points.size() > 1)
+	if (rotation.GetCount() > 1)
 		// Do nothing if more than 1 rotation Point
 		return;
-	else if (rotation.Points.size() == 1 && rotation.GetValue(1) != 0.0)
+	else if (rotation.GetCount() == 1 && rotation.GetValue(1) != 0.0)
 		// Do nothing if 1 Point, and it's not the default value
 		return;
 
@@ -273,7 +273,7 @@ void Clip::Close()
 float Clip::End()
 {
 	// if a time curve is present, use its length
-	if (time.Points.size() > 1)
+	if (time.GetCount() > 1)
 	{
 		// Determine the FPS fo this clip
 		float fps = 24.0;
@@ -314,8 +314,8 @@ std::shared_ptr<Frame> Clip::GetFrame(int64_t requested_frame)
 		// Is a time map detected
 		int64_t new_frame_number = requested_frame;
 		int64_t time_mapped_number = adjust_frame_number_minimum(time.GetLong(requested_frame));
-		if (time.Values.size() > 1)
-            new_frame_number = time_mapped_number;
+		if (time.GetLength() > 1)
+			new_frame_number = time_mapped_number;
 
 		// Now that we have re-mapped what frame number is needed, go and get the frame pointer
 		std::shared_ptr<Frame> original_frame;
@@ -397,7 +397,7 @@ void Clip::get_time_mapped_frame(std::shared_ptr<Frame> frame, int64_t frame_num
 		throw ReaderClosed("No Reader has been initialized for this Clip.  Call Reader(*reader) before calling this method.");
 
 	// Check for a valid time map curve
-	if (time.Values.size() > 1)
+	if (time.GetLength() > 1)
 	{
 		const GenericScopedLock<juce::CriticalSection> lock(getFrameCriticalSection);
 

--- a/src/KeyFrame.cpp
+++ b/src/KeyFrame.cpp
@@ -42,10 +42,6 @@ Keyframe::Keyframe(double value) {
 	AddPoint(Point(value));
 }
 
-// Keyframe constructor
-Keyframe::Keyframe() {
-}
-
 // Add a new point on the key-frame.  Each point has a primary coordinate,
 // a left handle, and a right handle.
 void Keyframe::AddPoint(Point p) {

--- a/src/KeyFrame.cpp
+++ b/src/KeyFrame.cpp
@@ -282,13 +282,23 @@ bool Keyframe::IsIncreasing(int index) const
 	if (index < 1 || (index + 1) >= GetLength()) {
 		return true;
 	}
-	int64_t const current = GetLong(index);
-	// TODO: skip over constant sections.
+	std::vector<Point>::const_iterator candidate =
+		std::lower_bound(begin(Points), end(Points), static_cast<double>(index), IsPointBeforeX);
+	if (candidate == end(Points)) {
+		return false; // After the last point, thus constant.
+	}
+	if ((candidate->co.X == index) || (candidate == begin(Points))) {
+		++candidate;
+	}
+	int64_t const value = GetLong(index);
 	do {
-		int64_t const next = GetLong(++index);
-		if (next > current) return true;
-		if (next < current) return false;
-	} while (index < GetLength());
+		if (value < round(candidate->co.Y)) {
+			return true;
+		} else if (value > round(candidate->co.Y)) {
+			return false;
+		}
+		++candidate;
+	} while (candidate != end(Points));
 	return false;
 }
 

--- a/src/KeyFrame.cpp
+++ b/src/KeyFrame.cpp
@@ -121,39 +121,32 @@ bool Keyframe::Contains(Point p) const {
 
 // Get current point (or closest point) from the X coordinate (i.e. the frame number)
 Point Keyframe::GetClosestPoint(Point p, bool useLeft) const {
-	Point closest(-1, -1);
-
-	// loop through points, and find a matching coordinate
-	for (int64_t x = 0; x < Points.size(); x++) {
-		// Get each point
-		Point existing_point = Points[x];
-
-		// find a match
-		if (existing_point.co.X >= p.co.X && !useLeft) {
-			// New closest point found (to the Right)
-			closest = existing_point;
-			break;
-		} else if (existing_point.co.X < p.co.X && useLeft) {
-			// New closest point found (to the Left)
-			closest = existing_point;
-		} else if (existing_point.co.X >= p.co.X && useLeft) {
-			// We've gone past the left point... so break
-			break;
-		}
+	if (Points.size() == 0) {
+		return Point(-1, -1);
 	}
 
-	// Handle edge cases (if no point was found)
-	if (closest.co.X == -1) {
-		if (p.co.X <= 1 && Points.size() > 0)
-			// Assign 1st point
-			closest = Points[0];
-		else if (Points.size() > 0)
-			// Assign last point
-			closest = Points[Points.size() - 1];
-	}
+	// Finds a point with an X coordinate which is "not less" (greater
+	// or equal) than the queried X coordinate.
+	std::vector<Point>::const_iterator candidate =
+		std::lower_bound(begin(Points), end(Points), p.co.X, IsPointBeforeX);
 
-	// no matching point found
-	return closest;
+	if (candidate == end(Points)) {
+		// All points are before the queried point.
+		//
+		// Note: Behavior the same regardless of useLeft!
+		return Points.back();
+	}
+	if (candidate == begin(Points)) {
+		// First point is greater or equal to the queried point.
+		//
+		// Note: Behavior the same regardless of useLeft!
+		return Points.front();
+	}
+	if (useLeft) {
+		return *(candidate - 1);
+	} else {
+		return *candidate;
+	}
 }
 
 // Get current point (or closest point to the right) from the X coordinate (i.e. the frame number)

--- a/src/KeyFrame.cpp
+++ b/src/KeyFrame.cpp
@@ -215,14 +215,8 @@ Point Keyframe::GetPreviousPoint(Point p) const {
 Point Keyframe::GetMaxPoint() const {
 	Point maxPoint(-1, -1);
 
-	// loop through points, and find the largest Y value
-	for (int64_t x = 0; x < Points.size(); x++) {
-		// Get each point
-		Point existing_point = Points[x];
-
-		// Is point larger than max point
+	for (Point const & existing_point: Points) {
 		if (existing_point.co.Y >= maxPoint.co.Y) {
-			// New max point found
 			maxPoint = existing_point;
 		}
 	}

--- a/src/KeyFrame.cpp
+++ b/src/KeyFrame.cpp
@@ -75,9 +75,10 @@ void Keyframe::AddPoint(Point p) {
 		// New point needs to be inserted before candidate; thus move
 		// candidate and all following one to the right and insert new
 		// point then where candidate was.
-		Points.push_back(p); // Make space; could also be a dummy point.
-		std::move_backward(candidate, end(Points) - 1, end(Points));
-		*candidate = p;
+		size_t const candidate_index = candidate - begin(Points);
+		Points.push_back(p); // Make space; could also be a dummy point. INVALIDATES candidate!
+		std::move_backward(begin(Points) + candidate_index, end(Points) - 1, end(Points));
+		Points[candidate_index] = p;
 	}
 }
 

--- a/src/KeyFrame.cpp
+++ b/src/KeyFrame.cpp
@@ -235,18 +235,18 @@ double Keyframe::GetValue(int64_t index) const {
 	assert(index < candidate->co.X);
 
 	// CONSTANT and LINEAR interpolations are fast to compute!
-	if (candidate->interpolation == CONSTANT) {
-		return predecessor->co.Y;
-	}
-	if (candidate->interpolation == LINEAR) {
+	switch (candidate->interpolation) {
+	case CONSTANT: return predecessor->co.Y;
+	case LINEAR: {
 		double const diff_Y = candidate->co.Y - predecessor->co.Y;
 		double const diff_X = candidate->co.X - predecessor->co.X;
 		double const slope = diff_Y / diff_X;
 		return predecessor->co.Y + slope * (index - predecessor->co.X);
 	}
+	case BEZIER: break;
+	}
 
 	// BEZIER curve!
-	// TODO: use switch instead of if for compiler warning support!
 	assert(candidate->interpolation == BEZIER);
 
 	double const X_diff = candidate->co.X - predecessor->co.X;

--- a/src/KeyFrame.cpp
+++ b/src/KeyFrame.cpp
@@ -251,45 +251,13 @@ double Keyframe::GetValue(int64_t index)
 // Get the rounded INT value at a specific index
 int Keyframe::GetInt(int64_t index)
 {
-	// Check if it needs to be processed
-	if (needs_update)
-		Process();
-
-	// Is index a valid point?
-	if (index >= 0 && index < Values.size())
-		// Return value
-		return int(round(Values[index].Y));
-	else if (index < 0 && Values.size() > 0)
-		// Return the minimum value
-		return int(round(Values[0].Y));
-	else if (index >= Values.size() && Values.size() > 0)
-		// return the maximum value
-		return int(round(Values[Values.size() - 1].Y));
-	else
-		// return a blank coordinate (0,0)
-		return 0;
+	return int(round(GetValue(index)));
 }
 
 // Get the rounded INT value at a specific index
 int64_t Keyframe::GetLong(int64_t index)
 {
-	// Check if it needs to be processed
-	if (needs_update)
-		Process();
-
-	// Is index a valid point?
-	if (index >= 0 && index < Values.size())
-		// Return value
-		return long(round(Values[index].Y));
-	else if (index < 0 && Values.size() > 0)
-		// Return the minimum value
-		return long(round(Values[0].Y));
-	else if (index >= Values.size() && Values.size() > 0)
-		// return the maximum value
-		return long(round(Values[Values.size() - 1].Y));
-	else
-		// return a blank coordinate (0,0)
-		return 0;
+	return long(round(GetValue(index)));
 }
 
 // Get the direction of the curve at a specific index (increasing or decreasing)

--- a/src/KeyFrame.cpp
+++ b/src/KeyFrame.cpp
@@ -91,7 +91,7 @@ void Keyframe::AddPoint(double x, double y, InterpolationType interpolate)
 }
 
 // Get the index of a point by matching a coordinate
-int64_t Keyframe::FindIndex(Point p) {
+int64_t Keyframe::FindIndex(Point p) const {
 	// loop through points, and find a matching coordinate
 	for (int64_t x = 0; x < Points.size(); x++) {
 		// Get each point
@@ -109,7 +109,7 @@ int64_t Keyframe::FindIndex(Point p) {
 }
 
 // Determine if point already exists
-bool Keyframe::Contains(Point p) {
+bool Keyframe::Contains(Point p) const {
 	// loop through points, and find a matching coordinate
 	for (int64_t x = 0; x < Points.size(); x++) {
 		// Get each point
@@ -127,7 +127,7 @@ bool Keyframe::Contains(Point p) {
 }
 
 // Get current point (or closest point) from the X coordinate (i.e. the frame number)
-Point Keyframe::GetClosestPoint(Point p, bool useLeft) {
+Point Keyframe::GetClosestPoint(Point p, bool useLeft) const {
 	Point closest(-1, -1);
 
 	// loop through points, and find a matching coordinate
@@ -164,12 +164,12 @@ Point Keyframe::GetClosestPoint(Point p, bool useLeft) {
 }
 
 // Get current point (or closest point to the right) from the X coordinate (i.e. the frame number)
-Point Keyframe::GetClosestPoint(Point p) {
+Point Keyframe::GetClosestPoint(Point p) const {
 	return GetClosestPoint(p, false);
 }
 
 // Get previous point (if any)
-Point Keyframe::GetPreviousPoint(Point p) {
+Point Keyframe::GetPreviousPoint(Point p) const {
 
 	// Lookup the index of this point
 	try {
@@ -188,7 +188,7 @@ Point Keyframe::GetPreviousPoint(Point p) {
 }
 
 // Get max point (by Y coordinate)
-Point Keyframe::GetMaxPoint() {
+Point Keyframe::GetMaxPoint() const {
 	Point maxPoint(-1, -1);
 
 	// loop through points, and find the largest Y value
@@ -207,12 +207,11 @@ Point Keyframe::GetMaxPoint() {
 }
 
 // Get the value at a specific index
-double Keyframe::GetValue(int64_t index)
-{
+double Keyframe::GetValue(int64_t index) const {
 	if (Points.empty()) {
 		return 0;
 	}
-	std::vector<Point>::iterator candidate =
+	std::vector<Point>::const_iterator candidate =
 		std::lower_bound(begin(Points), end(Points), Point(index, -1), [](Point const & l, Point const & r) {
 															return l.co.X < r.co.X;
 														});
@@ -229,7 +228,7 @@ double Keyframe::GetValue(int64_t index)
 		// index is directly on a point
 		return candidate->co.Y;
 	}
-	std::vector<Point>::iterator predecessor = candidate - 1;
+	std::vector<Point>::const_iterator predecessor = candidate - 1;
 	assert(predecessor->co.X < index);
 	assert(index < candidate->co.X);
 
@@ -284,19 +283,17 @@ double Keyframe::GetValue(int64_t index)
 }
 
 // Get the rounded INT value at a specific index
-int Keyframe::GetInt(int64_t index)
-{
+int Keyframe::GetInt(int64_t index) const {
 	return int(round(GetValue(index)));
 }
 
 // Get the rounded INT value at a specific index
-int64_t Keyframe::GetLong(int64_t index)
-{
+int64_t Keyframe::GetLong(int64_t index) const {
 	return long(round(GetValue(index)));
 }
 
 // Get the direction of the curve at a specific index (increasing or decreasing)
-bool Keyframe::IsIncreasing(int index)
+bool Keyframe::IsIncreasing(int index) const
 {
 	if (index < 1 || (index + 1) >= GetLength()) {
 		return true;
@@ -312,14 +309,14 @@ bool Keyframe::IsIncreasing(int index)
 }
 
 // Generate JSON string of this object
-std::string Keyframe::Json() {
+std::string Keyframe::Json() const {
 
 	// Return formatted string
 	return JsonValue().toStyledString();
 }
 
 // Generate Json::JsonValue for this object
-Json::Value Keyframe::JsonValue() {
+Json::Value Keyframe::JsonValue() const {
 
 	// Create root json object
 	Json::Value root;
@@ -389,8 +386,7 @@ void Keyframe::SetJsonValue(Json::Value root) {
 
 // Get the fraction that represents how many times this value is repeated in the curve
 // This is depreciated and will be removed soon.
-Fraction Keyframe::GetRepeatFraction(int64_t index)
-{
+Fraction Keyframe::GetRepeatFraction(int64_t index) const {
 	// Is index a valid point?
 	if (index >= 1 && (index + 1) < GetLength()) {
 		int64_t current_value = GetLong(index);
@@ -428,8 +424,7 @@ Fraction Keyframe::GetRepeatFraction(int64_t index)
 }
 
 // Get the change in Y value (from the previous Y value)
-double Keyframe::GetDelta(int64_t index)
-{
+double Keyframe::GetDelta(int64_t index) const {
 	if (index < 1) return 0;
 	if (index == 1 && ! Points.empty()) return Points[0].co.Y;
 	if (index >= GetLength()) return 0;
@@ -437,7 +432,7 @@ double Keyframe::GetDelta(int64_t index)
 }
 
 // Get a point at a specific index
-Point const & Keyframe::GetPoint(int64_t index) {
+Point const & Keyframe::GetPoint(int64_t index) const {
 	// Is index a valid point?
 	if (index >= 0 && index < Points.size())
 		return Points[index];
@@ -447,14 +442,14 @@ Point const & Keyframe::GetPoint(int64_t index) {
 }
 
 // Get the number of values (i.e. coordinates on the X axis)
-int64_t Keyframe::GetLength() {
+int64_t Keyframe::GetLength() const {
 	if (Points.empty()) return 0;
 	if (Points.size() == 1) return 1;
 	return round(Points.back().co.X) + 1;
 }
 
 // Get the number of points (i.e. # of points)
-int64_t Keyframe::GetCount() {
+int64_t Keyframe::GetCount() const {
 
 	return Points.size();
 }
@@ -499,15 +494,15 @@ void Keyframe::UpdatePoint(int64_t index, Point p) {
 	AddPoint(p);
 }
 
-void Keyframe::PrintPoints() {
+void Keyframe::PrintPoints() const {
 	cout << fixed << setprecision(4);
-	for (std::vector<Point>::iterator it = Points.begin(); it != Points.end(); it++) {
+	for (std::vector<Point>::const_iterator it = Points.begin(); it != Points.end(); it++) {
 		Point p = *it;
 		cout << p.co.X << "\t" << p.co.Y << endl;
 	}
 }
 
-void Keyframe::PrintValues() {
+void Keyframe::PrintValues() const {
 	cout << fixed << setprecision(4);
 	cout << "Frame Number (X)\tValue (Y)\tIs Increasing\tRepeat Numerator\tRepeat Denominator\tDelta (Y Difference)\n";
 
@@ -534,8 +529,7 @@ void Keyframe::ScalePoints(double scale)
 }
 
 // Flip all the points in this openshot::Keyframe (useful for reversing an effect or transition, etc...)
-void Keyframe::FlipPoints()
-{
+void Keyframe::FlipPoints() {
 	for (int64_t point_index = 0, reverse_index = Points.size() - 1; point_index < reverse_index; point_index++, reverse_index--) {
 		// Flip the points
 		using std::swap;

--- a/src/KeyFrame.cpp
+++ b/src/KeyFrame.cpp
@@ -550,9 +550,6 @@ int64_t Keyframe::GetCount() {
 
 // Remove a point by matching a coordinate
 void Keyframe::RemovePoint(Point p) {
-	// mark as dirty
-	needs_update = true;
-
 	// loop through points, and find a matching coordinate
 	for (int64_t x = 0; x < Points.size(); x++) {
 		// Get each point
@@ -562,6 +559,8 @@ void Keyframe::RemovePoint(Point p) {
 		if (p.co.X == existing_point.co.X && p.co.Y == existing_point.co.Y) {
 			// Remove the matching point, and break out of loop
 			Points.erase(Points.begin() + x);
+			// mark as dirty
+			needs_update = true;
 			return;
 		}
 	}
@@ -572,12 +571,11 @@ void Keyframe::RemovePoint(Point p) {
 
 // Remove a point by index
 void Keyframe::RemovePoint(int64_t index) {
-	// mark as dirty
-	needs_update = true;
-
 	// Is index a valid point?
 	if (index >= 0 && index < Points.size())
 	{
+		// mark as dirty
+		needs_update = true;
 		// Remove a specific point by index
 		Points.erase(Points.begin() + index);
 	}

--- a/src/KeyFrame.cpp
+++ b/src/KeyFrame.cpp
@@ -302,31 +302,12 @@ bool Keyframe::IsIncreasing(int index)
 	// Is index a valid point?
 	if (index >= 1 && (index + 1) < Values.size()) {
 		int64_t current_value = GetLong(index);
-		int64_t previous_value = 0;
 		int64_t next_value = 0;
-		int64_t previous_repeats = 0;
-		int64_t next_repeats = 0;
-
-		// Loop backwards and look for the next unique value
-		for (std::vector<Coordinate>::iterator backwards_it = Values.begin() + index; backwards_it != Values.begin(); backwards_it--) {
-			previous_value = long(round((*backwards_it).Y));
-			if (previous_value == current_value) {
-				// Found same value
-				previous_repeats++;
-			} else {
-				// Found non repeating value, no more repeats found
-				break;
-			}
-		}
 
 		// Loop forwards and look for the next unique value
 		for (std::vector<Coordinate>::iterator forwards_it = Values.begin() + (index + 1); forwards_it != Values.end(); forwards_it++) {
 			next_value = long(round((*forwards_it).Y));
-			if (next_value == current_value) {
-				// Found same value
-				next_repeats++;
-			} else {
-				// Found non repeating value, no more repeats found
+			if (next_value != current_value) {
 				break;
 			}
 		}

--- a/src/KeyFrame.cpp
+++ b/src/KeyFrame.cpp
@@ -587,17 +587,11 @@ void Keyframe::RemovePoint(int64_t index) {
 }
 
 void Keyframe::UpdatePoint(int64_t index, Point p) {
-	// mark as dirty
-	needs_update = true;
-
 	// Remove matching point
 	RemovePoint(index);
 
 	// Add new point
 	AddPoint(p);
-
-	// Reorder points
-	ReorderPoints();
 }
 
 void Keyframe::PrintPoints() {

--- a/src/KeyFrame.cpp
+++ b/src/KeyFrame.cpp
@@ -35,6 +35,12 @@
 using namespace std;
 using namespace openshot;
 
+namespace {
+	bool IsPointBeforeX(Point const & p, double const x) {
+		return p.co.X < x;
+	}
+}
+
 
 // Constructor which sets the default point & coordinate at X=1
 Keyframe::Keyframe(double value) {
@@ -48,9 +54,7 @@ void Keyframe::AddPoint(Point p) {
 	// candidate is not less (greater or equal) than the new point in
 	// the X coordinate.
 	std::vector<Point>::iterator candidate =
-		std::lower_bound(begin(Points), end(Points), p, [](Point const & l, Point const & r) {
-															return l.co.X < r.co.X;
-														});
+		std::lower_bound(begin(Points), end(Points), p.co.X, IsPointBeforeX);
 	if (candidate == end(Points)) {
 		// New point X is greater than all other points' X, add to
 		// back.
@@ -212,9 +216,7 @@ double Keyframe::GetValue(int64_t index) const {
 		return 0;
 	}
 	std::vector<Point>::const_iterator candidate =
-		std::lower_bound(begin(Points), end(Points), Point(index, -1), [](Point const & l, Point const & r) {
-															return l.co.X < r.co.X;
-														});
+		std::lower_bound(begin(Points), end(Points), static_cast<double>(index), IsPointBeforeX);
 
 	if (candidate == end(Points)) {
 		// index is behind last point

--- a/src/KeyFrame.cpp
+++ b/src/KeyFrame.cpp
@@ -449,7 +449,7 @@ double Keyframe::GetDelta(int64_t index)
 }
 
 // Get a point at a specific index
-Point& Keyframe::GetPoint(int64_t index) {
+Point const & Keyframe::GetPoint(int64_t index) {
 	// Is index a valid point?
 	if (index >= 0 && index < Points.size())
 		return Points[index];

--- a/src/KeyFrame.cpp
+++ b/src/KeyFrame.cpp
@@ -114,20 +114,9 @@ int64_t Keyframe::FindIndex(Point p) const {
 
 // Determine if point already exists
 bool Keyframe::Contains(Point p) const {
-	// loop through points, and find a matching coordinate
-	for (int64_t x = 0; x < Points.size(); x++) {
-		// Get each point
-		Point existing_point = Points[x];
-
-		// find a match
-		if (p.co.X == existing_point.co.X) {
-			// Remove the matching point, and break out of loop
-			return true;
-		}
-	}
-
-	// no matching point found
-	return false;
+	std::vector<Point>::const_iterator i =
+		std::lower_bound(begin(Points), end(Points), p.co.X, IsPointBeforeX);
+	return i != end(Points) && i->co.X == p.co.X;
 }
 
 // Get current point (or closest point) from the X coordinate (i.e. the frame number)

--- a/src/KeyFrame.cpp
+++ b/src/KeyFrame.cpp
@@ -29,6 +29,7 @@
  */
 
 #include "../include/KeyFrame.h"
+#include <utility>
 
 using namespace std;
 using namespace openshot;
@@ -904,16 +905,11 @@ void Keyframe::ScalePoints(double scale)
 void Keyframe::FlipPoints()
 {
 	// Loop through each point
-	std::vector<Point> FlippedPoints;
-	for (int64_t point_index = 0, reverse_index = Points.size() - 1; point_index < Points.size(); point_index++, reverse_index--) {
+	for (int64_t point_index = 0, reverse_index = Points.size() - 1; point_index < reverse_index; point_index++, reverse_index--) {
 		// Flip the points
-		Point p = Points[point_index];
-		p.co.Y = Points[reverse_index].co.Y;
-		FlippedPoints.push_back(p);
+		using std::swap;
+		swap(Points[point_index].co.Y, Points[reverse_index].co.Y);
 	}
-
-	// Swap vectors
-	Points.swap(FlippedPoints);
 
 	// Mark for re-processing
 	needs_update = true;

--- a/src/KeyFrame.cpp
+++ b/src/KeyFrame.cpp
@@ -888,11 +888,7 @@ double Keyframe::Bernstein(int64_t n, int64_t i, double t) {
 void Keyframe::ScalePoints(double scale)
 {
 	// Loop through each point (skipping the 1st point)
-	for (int64_t point_index = 0; point_index < Points.size(); point_index++) {
-		// Skip the 1st point
-		if (point_index == 0)
-			continue;
-
+	for (int64_t point_index = 1; point_index < Points.size(); point_index++) {
 		// Scale X value
 		Points[point_index].co.X = round(Points[point_index].co.X * scale);
 

--- a/src/KeyFrame.cpp
+++ b/src/KeyFrame.cpp
@@ -479,9 +479,7 @@ double Keyframe::GetDelta(int64_t index)
 	if (index >= 1 && (index + 1) < Values.size()) {
 		int64_t current_value = GetLong(index);
 		int64_t previous_value = 0;
-		int64_t next_value = 0;
 		int64_t previous_repeats = 0;
-		int64_t next_repeats = 0;
 
 		// Loop backwards and look for the next unique value
 		for (std::vector<Coordinate>::iterator backwards_it = Values.begin() + index; backwards_it != Values.begin(); backwards_it--) {
@@ -489,18 +487,6 @@ double Keyframe::GetDelta(int64_t index)
 			if (previous_value == current_value) {
 				// Found same value
 				previous_repeats++;
-			} else {
-				// Found non repeating value, no more repeats found
-				break;
-			}
-		}
-
-		// Loop forwards and look for the next unique value
-		for (std::vector<Coordinate>::iterator forwards_it = Values.begin() + (index + 1); forwards_it != Values.end(); forwards_it++) {
-			next_value = long(round((*forwards_it).Y));
-			if (next_value == current_value) {
-				// Found same value
-				next_repeats++;
 			} else {
 				// Found non repeating value, no more repeats found
 				break;

--- a/src/KeyFrame.cpp
+++ b/src/KeyFrame.cpp
@@ -29,6 +29,7 @@
  */
 
 #include "../include/KeyFrame.h"
+#include <algorithm>
 #include <utility>
 
 using namespace std;
@@ -38,22 +39,11 @@ using namespace openshot;
 // in ascending order based on the point.co.X value.  This simplifies
 // processing the curve, due to all the points going from left to right.
 void Keyframe::ReorderPoints() {
-	// Loop through all coordinates, and sort them by the X attribute
-	for (int64_t x = 0; x < Points.size(); x++) {
-		int64_t compare_index = x;
-		int64_t smallest_index = x;
-
-		for (int64_t compare_index = x + 1; compare_index < Points.size(); compare_index++) {
-			if (Points[compare_index].co.X < Points[smallest_index].co.X) {
-				smallest_index = compare_index;
-			}
-		}
-
-		// swap items
-		if (smallest_index != compare_index) {
-			swap(Points[compare_index], Points[smallest_index]);
-		}
-	}
+	std::sort(
+			begin(Points), end(Points),
+			[](Point const & l, Point const & r) {
+				return l.co.X < r.co.X;
+			});
 }
 
 // Constructor which sets the default point & coordinate at X=1

--- a/src/Timeline.cpp
+++ b/src/Timeline.cpp
@@ -824,7 +824,7 @@ std::shared_ptr<Frame> Timeline::GetFrame(int64_t requested_frame)
 				ZmqLogger::Instance()->AppendDebugMethod("Timeline::GetFrame (Adding solid color)", "frame_number", frame_number, "info.width", info.width, "info.height", info.height);
 
 				// Add Background Color to 1st layer (if animated or not black)
-				if ((color.red.Points.size() > 1 || color.green.Points.size() > 1 || color.blue.Points.size() > 1) ||
+				if ((color.red.GetCount() > 1 || color.green.GetCount() > 1 || color.blue.GetCount() > 1) ||
 					(color.red.GetValue(frame_number) != 0.0 || color.green.GetValue(frame_number) != 0.0 || color.blue.GetValue(frame_number) != 0.0))
 				new_frame->AddColor(Settings::Instance()->MAX_WIDTH, Settings::Instance()->MAX_HEIGHT, color.GetColorHex(frame_number));
 

--- a/tests/Color_Tests.cpp
+++ b/tests/Color_Tests.cpp
@@ -79,7 +79,7 @@ TEST(Color_HEX_Value)
 	c.blue.AddPoint(100, 255);
 
 	CHECK_EQUAL("#000000", c.GetColorHex(1));
-	CHECK_EQUAL("#7f7f7f", c.GetColorHex(50));
+	CHECK_EQUAL("#7d7d7d", c.GetColorHex(50));
 	CHECK_EQUAL("#ffffff", c.GetColorHex(100));
 
 }
@@ -93,7 +93,7 @@ TEST(Color_HEX_Constructor)
 	c.blue.AddPoint(100, 255);
 
 	CHECK_EQUAL("#4586db", c.GetColorHex(1));
-	CHECK_EQUAL("#a2c2ed", c.GetColorHex(50));
+	CHECK_EQUAL("#a0c1ed", c.GetColorHex(50));
 	CHECK_EQUAL("#ffffff", c.GetColorHex(100));
 }
 
@@ -118,7 +118,7 @@ TEST(Color_RGBA_Constructor)
 	c.blue.AddPoint(100, 255);
 
 	CHECK_EQUAL("#4586db", c.GetColorHex(1));
-	CHECK_EQUAL("#a2c2ed", c.GetColorHex(50));
+	CHECK_EQUAL("#a0c1ed", c.GetColorHex(50));
 	CHECK_EQUAL("#ffffff", c.GetColorHex(100));
 
 	// Color with alpha

--- a/tests/KeyFrame_Tests.cpp
+++ b/tests/KeyFrame_Tests.cpp
@@ -51,7 +51,7 @@ TEST(Keyframe_GetPoint_With_1_Points)
 	k1.AddPoint(openshot::Point(2,3));
 
 	CHECK_THROW(k1.GetPoint(-1), OutOfBoundsPoint);
-	CHECK_EQUAL(1, k1.Points.size());
+	CHECK_EQUAL(1, k1.GetCount());
 	CHECK_CLOSE(2.0f, k1.GetPoint(0).co.X, 0.00001);
 	CHECK_CLOSE(3.0f, k1.GetPoint(0).co.Y, 0.00001);
 	CHECK_THROW(k1.GetPoint(1), OutOfBoundsPoint);
@@ -98,7 +98,7 @@ TEST(Keyframe_GetValue_For_Bezier_Curve_2_Points)
 	CHECK_CLOSE(3.81602f, kf.GetValue(40), 0.0001);
 	CHECK_CLOSE(4.0f, kf.GetValue(50), 0.0001);
 	// Check the expected number of values
-	CHECK_EQUAL(kf.Values.size(), 51);
+	CHECK_EQUAL(kf.GetLength(), 51);
 }
 
 TEST(Keyframe_GetValue_For_Bezier_Curve_5_Points_40_Percent_Handle)
@@ -121,7 +121,7 @@ TEST(Keyframe_GetValue_For_Bezier_Curve_5_Points_40_Percent_Handle)
 	CHECK_CLOSE(1.77569f, kf.GetValue(177), 0.0001);
 	CHECK_CLOSE(3.0f, kf.GetValue(200), 0.0001);
 	// Check the expected number of values
-	CHECK_EQUAL(kf.Values.size(), 201);
+	CHECK_EQUAL(kf.GetLength(), 201);
 }
 
 TEST(Keyframe_GetValue_For_Bezier_Curve_5_Points_25_Percent_Handle)
@@ -144,7 +144,7 @@ TEST(Keyframe_GetValue_For_Bezier_Curve_5_Points_25_Percent_Handle)
 	CHECK_CLOSE(1.77569f, kf.GetValue(177), 0.0001);
 	CHECK_CLOSE(3.0f, kf.GetValue(200), 0.0001);
 	// Check the expected number of values
-	CHECK_EQUAL(kf.Values.size(), 201);
+	CHECK_EQUAL(kf.GetLength(), 201);
 }
 
 TEST(Keyframe_GetValue_For_Linear_Curve_3_Points)
@@ -164,7 +164,7 @@ TEST(Keyframe_GetValue_For_Linear_Curve_3_Points)
 	CHECK_CLOSE(4.4f, kf.GetValue(40), 0.0001);
 	CHECK_CLOSE(2.0f, kf.GetValue(50), 0.0001);
 	// Check the expected number of values
-	CHECK_EQUAL(kf.Values.size(), 51);
+	CHECK_EQUAL(kf.GetLength(), 51);
 }
 
 TEST(Keyframe_GetValue_For_Constant_Curve_3_Points)
@@ -185,7 +185,7 @@ TEST(Keyframe_GetValue_For_Constant_Curve_3_Points)
 	CHECK_CLOSE(8.0f, kf.GetValue(49), 0.0001);
 	CHECK_CLOSE(2.0f, kf.GetValue(50), 0.0001);
 	// Check the expected number of values
-	CHECK_EQUAL(kf.Values.size(), 51);
+	CHECK_EQUAL(kf.GetLength(), 51);
 }
 
 TEST(Keyframe_Check_Direction_and_Repeat_Fractions)

--- a/tests/KeyFrame_Tests.cpp
+++ b/tests/KeyFrame_Tests.cpp
@@ -92,10 +92,10 @@ TEST(Keyframe_GetValue_For_Bezier_Curve_2_Points)
 	// Spot check values from the curve
 	CHECK_CLOSE(1.0f, kf.GetValue(-1), 0.0001);
 	CHECK_CLOSE(1.0f, kf.GetValue(0), 0.0001);
-	CHECK_CLOSE(1.00023f, kf.GetValue(1), 0.0001);
-	CHECK_CLOSE(1.14025f, kf.GetValue(9), 0.0001);
-	CHECK_CLOSE(1.91492f, kf.GetValue(20), 0.0001);
-	CHECK_CLOSE(3.81602f, kf.GetValue(40), 0.0001);
+	CHECK_CLOSE(1.0f, kf.GetValue(1), 0.0001);
+	CHECK_CLOSE(1.12414f, kf.GetValue(9), 0.0001);
+	CHECK_CLOSE(1.86370f, kf.GetValue(20), 0.0001);
+	CHECK_CLOSE(3.79733f, kf.GetValue(40), 0.0001);
 	CHECK_CLOSE(4.0f, kf.GetValue(50), 0.0001);
 	// Check the expected number of values
 	CHECK_EQUAL(kf.GetLength(), 51);
@@ -114,11 +114,11 @@ TEST(Keyframe_GetValue_For_Bezier_Curve_5_Points_40_Percent_Handle)
 	// Spot check values from the curve
 	CHECK_CLOSE(kf.GetValue(-1), 1.0f, 0.0001);
 	CHECK_CLOSE(1.0f, kf.GetValue(0), 0.0001);
-	CHECK_CLOSE(1.00023f, kf.GetValue(1), 0.0001);
-	CHECK_CLOSE(2.73656f, kf.GetValue(27), 0.0001);
-	CHECK_CLOSE(7.55139f, kf.GetValue(77), 0.0001);
-	CHECK_CLOSE(4.08102f, kf.GetValue(127), 0.0001);
-	CHECK_CLOSE(1.77569f, kf.GetValue(177), 0.0001);
+	CHECK_CLOSE(1.0f, kf.GetValue(1), 0.0001);
+	CHECK_CLOSE(2.68197f, kf.GetValue(27), 0.0001);
+	CHECK_CLOSE(7.47719f, kf.GetValue(77), 0.0001);
+	CHECK_CLOSE(4.20468f, kf.GetValue(127), 0.0001);
+	CHECK_CLOSE(1.73860f, kf.GetValue(177), 0.0001);
 	CHECK_CLOSE(3.0f, kf.GetValue(200), 0.0001);
 	// Check the expected number of values
 	CHECK_EQUAL(kf.GetLength(), 201);
@@ -137,11 +137,11 @@ TEST(Keyframe_GetValue_For_Bezier_Curve_5_Points_25_Percent_Handle)
 	// Spot check values from the curve
 	CHECK_CLOSE(1.0f, kf.GetValue(-1), 0.0001);
 	CHECK_CLOSE(1.0f, kf.GetValue(0), 0.0001);
-	CHECK_CLOSE(1.00023f, kf.GetValue(1), 0.0001);
-	CHECK_CLOSE(2.73656f, kf.GetValue(27), 0.0001);
-	CHECK_CLOSE(7.55139f, kf.GetValue(77), 0.0001);
-	CHECK_CLOSE(4.08102f, kf.GetValue(127), 0.0001);
-	CHECK_CLOSE(1.77569f, kf.GetValue(177), 0.0001);
+	CHECK_CLOSE(1.0f, kf.GetValue(1), 0.0001);
+	CHECK_CLOSE(2.68197f, kf.GetValue(27), 0.0001);
+	CHECK_CLOSE(7.47719f, kf.GetValue(77), 0.0001);
+	CHECK_CLOSE(4.20468f, kf.GetValue(127), 0.0001);
+	CHECK_CLOSE(1.73860f, kf.GetValue(177), 0.0001);
 	CHECK_CLOSE(3.0f, kf.GetValue(200), 0.0001);
 	// Check the expected number of values
 	CHECK_EQUAL(kf.GetLength(), 201);
@@ -200,7 +200,7 @@ TEST(Keyframe_Check_Direction_and_Repeat_Fractions)
 	CHECK_EQUAL(kf.GetInt(1), 500);
 	CHECK_EQUAL(kf.IsIncreasing(1), false);
 	CHECK_EQUAL(kf.GetRepeatFraction(1).num, 1);
-	CHECK_EQUAL(kf.GetRepeatFraction(1).den, 12);
+	CHECK_EQUAL(kf.GetRepeatFraction(1).den, 13);
 	CHECK_EQUAL(kf.GetDelta(1), 500);
 
 	CHECK_EQUAL(kf.GetInt(24), 498);
@@ -212,13 +212,13 @@ TEST(Keyframe_Check_Direction_and_Repeat_Fractions)
 	CHECK_EQUAL(kf.GetLong(390), 100);
 	CHECK_EQUAL(kf.IsIncreasing(390), true);
 	CHECK_EQUAL(kf.GetRepeatFraction(390).num, 3);
-	CHECK_EQUAL(kf.GetRepeatFraction(390).den, 15);
+	CHECK_EQUAL(kf.GetRepeatFraction(390).den, 16);
 	CHECK_EQUAL(kf.GetDelta(390), 0);
 
 	CHECK_EQUAL(kf.GetLong(391), 100);
 	CHECK_EQUAL(kf.IsIncreasing(391), true);
 	CHECK_EQUAL(kf.GetRepeatFraction(391).num, 4);
-	CHECK_EQUAL(kf.GetRepeatFraction(391).den, 15);
+	CHECK_EQUAL(kf.GetRepeatFraction(391).den, 16);
 	CHECK_EQUAL(kf.GetDelta(388), -1);
 }
 
@@ -307,8 +307,8 @@ TEST(Keyframe_Scale_Keyframe)
 	CHECK_CLOSE(1.0f, kf.GetValue(1), 0.01);
 	CHECK_CLOSE(7.99f, kf.GetValue(24), 0.01);
 	CHECK_CLOSE(8.0f, kf.GetValue(25), 0.01);
-	CHECK_CLOSE(3.68f, kf.GetValue(40), 0.01);
-	CHECK_CLOSE(2.0f, kf.GetValue(49), 0.01);
+	CHECK_CLOSE(3.85f, kf.GetValue(40), 0.01);
+	CHECK_CLOSE(2.01f, kf.GetValue(49), 0.01);
 	CHECK_CLOSE(2.0f, kf.GetValue(50), 0.01);
 
 	// Resize / Scale the keyframe
@@ -316,12 +316,12 @@ TEST(Keyframe_Scale_Keyframe)
 
 	// Spot check values from the curve
 	CHECK_CLOSE(1.0f, kf.GetValue(1), 0.01);
-	CHECK_CLOSE(4.21f, kf.GetValue(24), 0.01);
-	CHECK_CLOSE(4.47f, kf.GetValue(25), 0.01);
-	CHECK_CLOSE(7.57f, kf.GetValue(40), 0.01);
+	CHECK_CLOSE(4.08f, kf.GetValue(24), 0.01);
+	CHECK_CLOSE(4.36f, kf.GetValue(25), 0.01);
+	CHECK_CLOSE(7.53f, kf.GetValue(40), 0.01);
 	CHECK_CLOSE(7.99f, kf.GetValue(49), 0.01);
 	CHECK_CLOSE(8.0f, kf.GetValue(50), 0.01);
-	CHECK_CLOSE(2.35f, kf.GetValue(90), 0.01);
+	CHECK_CLOSE(2.39f, kf.GetValue(90), 0.01);
 	CHECK_CLOSE(2.0f, kf.GetValue(100), 0.01);
 
 	// Resize / Scale the keyframe
@@ -331,8 +331,8 @@ TEST(Keyframe_Scale_Keyframe)
 	CHECK_CLOSE(1.0f, kf.GetValue(1), 0.01);
 	CHECK_CLOSE(7.99f, kf.GetValue(24), 0.01);
 	CHECK_CLOSE(8.0f, kf.GetValue(25), 0.01);
-	CHECK_CLOSE(3.68f, kf.GetValue(40), 0.01);
-	CHECK_CLOSE(2.0f, kf.GetValue(49), 0.01);
+	CHECK_CLOSE(3.85f, kf.GetValue(40), 0.01);
+	CHECK_CLOSE(2.01f, kf.GetValue(49), 0.01);
 	CHECK_CLOSE(2.0f, kf.GetValue(50), 0.01);
 
 }

--- a/tests/KeyFrame_Tests.cpp
+++ b/tests/KeyFrame_Tests.cpp
@@ -482,3 +482,15 @@ TEST(Keyframe_Use_Interpolation_of_Segment_End_Point)
 	f.AddPoint(100,155, BEZIER);
 	CHECK_CLOSE(75.9, f.GetValue(50), 0.1);
 }
+
+TEST(Keyframe_Handle_Large_Segment)
+{
+	Keyframe kf;
+	kf.AddPoint(1, 0, CONSTANT);
+	kf.AddPoint(1000000, 1, LINEAR);
+	UNITTEST_TIME_CONSTRAINT(10); // 10 milliseconds would still be relatively slow, but need to think about slower build machines!
+	CHECK_CLOSE(0.5, kf.GetValue(500000), 0.01);
+	CHECK_EQUAL(true, kf.IsIncreasing(10));
+	Fraction fr = kf.GetRepeatFraction(250000);
+	CHECK_CLOSE(0.5, (double)fr.num / fr.den, 0.01);
+}

--- a/tests/KeyFrame_Tests.cpp
+++ b/tests/KeyFrame_Tests.cpp
@@ -98,7 +98,7 @@ TEST(Keyframe_GetValue_For_Bezier_Curve_2_Points)
 	CHECK_CLOSE(3.79733f, kf.GetValue(40), 0.0001);
 	CHECK_CLOSE(4.0f, kf.GetValue(50), 0.0001);
 	// Check the expected number of values
-	CHECK_EQUAL(kf.GetLength(), 51);
+	CHECK_EQUAL(51, kf.GetLength());
 }
 
 TEST(Keyframe_GetValue_For_Bezier_Curve_5_Points_40_Percent_Handle)
@@ -121,7 +121,7 @@ TEST(Keyframe_GetValue_For_Bezier_Curve_5_Points_40_Percent_Handle)
 	CHECK_CLOSE(1.73860f, kf.GetValue(177), 0.0001);
 	CHECK_CLOSE(3.0f, kf.GetValue(200), 0.0001);
 	// Check the expected number of values
-	CHECK_EQUAL(kf.GetLength(), 201);
+	CHECK_EQUAL(201, kf.GetLength());
 }
 
 TEST(Keyframe_GetValue_For_Bezier_Curve_5_Points_25_Percent_Handle)
@@ -144,7 +144,7 @@ TEST(Keyframe_GetValue_For_Bezier_Curve_5_Points_25_Percent_Handle)
 	CHECK_CLOSE(1.73860f, kf.GetValue(177), 0.0001);
 	CHECK_CLOSE(3.0f, kf.GetValue(200), 0.0001);
 	// Check the expected number of values
-	CHECK_EQUAL(kf.GetLength(), 201);
+	CHECK_EQUAL(201, kf.GetLength());
 }
 
 TEST(Keyframe_GetValue_For_Linear_Curve_3_Points)
@@ -164,7 +164,7 @@ TEST(Keyframe_GetValue_For_Linear_Curve_3_Points)
 	CHECK_CLOSE(4.4f, kf.GetValue(40), 0.0001);
 	CHECK_CLOSE(2.0f, kf.GetValue(50), 0.0001);
 	// Check the expected number of values
-	CHECK_EQUAL(kf.GetLength(), 51);
+	CHECK_EQUAL(51, kf.GetLength());
 }
 
 TEST(Keyframe_GetValue_For_Constant_Curve_3_Points)
@@ -185,7 +185,7 @@ TEST(Keyframe_GetValue_For_Constant_Curve_3_Points)
 	CHECK_CLOSE(8.0f, kf.GetValue(49), 0.0001);
 	CHECK_CLOSE(2.0f, kf.GetValue(50), 0.0001);
 	// Check the expected number of values
-	CHECK_EQUAL(kf.GetLength(), 51);
+	CHECK_EQUAL(51, kf.GetLength());
 }
 
 TEST(Keyframe_Check_Direction_and_Repeat_Fractions)
@@ -197,29 +197,29 @@ TEST(Keyframe_Check_Direction_and_Repeat_Fractions)
 	kf.AddPoint(500, 500);
 
 	// Spot check values from the curve
-	CHECK_EQUAL(kf.GetInt(1), 500);
-	CHECK_EQUAL(kf.IsIncreasing(1), false);
-	CHECK_EQUAL(kf.GetRepeatFraction(1).num, 1);
-	CHECK_EQUAL(kf.GetRepeatFraction(1).den, 13);
-	CHECK_EQUAL(kf.GetDelta(1), 500);
+	CHECK_EQUAL(500, kf.GetInt(1));
+	CHECK_EQUAL(false, kf.IsIncreasing(1));
+	CHECK_EQUAL(1, kf.GetRepeatFraction(1).num);
+	CHECK_EQUAL(13, kf.GetRepeatFraction(1).den);
+	CHECK_EQUAL(500, kf.GetDelta(1));
 
-	CHECK_EQUAL(kf.GetInt(24), 498);
-	CHECK_EQUAL(kf.IsIncreasing(24), false);
-	CHECK_EQUAL(kf.GetRepeatFraction(24).num, 3);
-	CHECK_EQUAL(kf.GetRepeatFraction(24).den, 6);
-	CHECK_EQUAL(kf.GetDelta(24), 0);
+	CHECK_EQUAL(498, kf.GetInt(24));
+	CHECK_EQUAL(false, kf.IsIncreasing(24));
+	CHECK_EQUAL(3, kf.GetRepeatFraction(24).num);
+	CHECK_EQUAL(6, kf.GetRepeatFraction(24).den);
+	CHECK_EQUAL(0, kf.GetDelta(24));
 
-	CHECK_EQUAL(kf.GetLong(390), 100);
-	CHECK_EQUAL(kf.IsIncreasing(390), true);
-	CHECK_EQUAL(kf.GetRepeatFraction(390).num, 3);
-	CHECK_EQUAL(kf.GetRepeatFraction(390).den, 16);
-	CHECK_EQUAL(kf.GetDelta(390), 0);
+	CHECK_EQUAL(100, kf.GetLong(390));
+	CHECK_EQUAL(true, kf.IsIncreasing(390));
+	CHECK_EQUAL(3, kf.GetRepeatFraction(390).num);
+	CHECK_EQUAL(16, kf.GetRepeatFraction(390).den);
+	CHECK_EQUAL(0, kf.GetDelta(390));
 
-	CHECK_EQUAL(kf.GetLong(391), 100);
-	CHECK_EQUAL(kf.IsIncreasing(391), true);
-	CHECK_EQUAL(kf.GetRepeatFraction(391).num, 4);
-	CHECK_EQUAL(kf.GetRepeatFraction(391).den, 16);
-	CHECK_EQUAL(kf.GetDelta(388), -1);
+	CHECK_EQUAL(100, kf.GetLong(391));
+	CHECK_EQUAL(true, kf.IsIncreasing(391));
+	CHECK_EQUAL(4, kf.GetRepeatFraction(391).num);
+	CHECK_EQUAL(16, kf.GetRepeatFraction(391).den);
+	CHECK_EQUAL(-1, kf.GetDelta(388));
 }
 
 
@@ -232,22 +232,22 @@ TEST(Keyframe_Get_Closest_Point)
 	kf.AddPoint(2500, 0.0);
 
 	// Spot check values from the curve (to the right)
-	CHECK_EQUAL(kf.GetClosestPoint(openshot::Point(900, 900)).co.X, 1000);
-	CHECK_EQUAL(kf.GetClosestPoint(openshot::Point(1, 1)).co.X, 1);
-	CHECK_EQUAL(kf.GetClosestPoint(openshot::Point(5, 5)).co.X, 1000);
-	CHECK_EQUAL(kf.GetClosestPoint(openshot::Point(1000, 1000)).co.X, 1000);
-	CHECK_EQUAL(kf.GetClosestPoint(openshot::Point(1001, 1001)).co.X, 2500);
-	CHECK_EQUAL(kf.GetClosestPoint(openshot::Point(2500, 2500)).co.X, 2500);
-	CHECK_EQUAL(kf.GetClosestPoint(openshot::Point(3000, 3000)).co.X, 2500);
+	CHECK_EQUAL(1000, kf.GetClosestPoint(openshot::Point(900, 900)).co.X);
+	CHECK_EQUAL(1, kf.GetClosestPoint(openshot::Point(1, 1)).co.X);
+	CHECK_EQUAL(1000, kf.GetClosestPoint(openshot::Point(5, 5)).co.X);
+	CHECK_EQUAL(1000, kf.GetClosestPoint(openshot::Point(1000, 1000)).co.X);
+	CHECK_EQUAL(2500, kf.GetClosestPoint(openshot::Point(1001, 1001)).co.X);
+	CHECK_EQUAL(2500, kf.GetClosestPoint(openshot::Point(2500, 2500)).co.X);
+	CHECK_EQUAL(2500, kf.GetClosestPoint(openshot::Point(3000, 3000)).co.X);
 
 	// Spot check values from the curve (to the left)
-	CHECK_EQUAL(kf.GetClosestPoint(openshot::Point(900, 900), true).co.X, 1);
-	CHECK_EQUAL(kf.GetClosestPoint(openshot::Point(1, 1), true).co.X, 1);
-	CHECK_EQUAL(kf.GetClosestPoint(openshot::Point(5, 5), true).co.X, 1);
-	CHECK_EQUAL(kf.GetClosestPoint(openshot::Point(1000, 1000), true).co.X, 1);
-	CHECK_EQUAL(kf.GetClosestPoint(openshot::Point(1001, 1001), true).co.X, 1000);
-	CHECK_EQUAL(kf.GetClosestPoint(openshot::Point(2500, 2500), true).co.X, 1000);
-	CHECK_EQUAL(kf.GetClosestPoint(openshot::Point(3000, 3000), true).co.X, 2500);
+	CHECK_EQUAL(1, kf.GetClosestPoint(openshot::Point(900, 900), true).co.X);
+	CHECK_EQUAL(1, kf.GetClosestPoint(openshot::Point(1, 1), true).co.X);
+	CHECK_EQUAL(1, kf.GetClosestPoint(openshot::Point(5, 5), true).co.X);
+	CHECK_EQUAL(1, kf.GetClosestPoint(openshot::Point(1000, 1000), true).co.X);
+	CHECK_EQUAL(1000, kf.GetClosestPoint(openshot::Point(1001, 1001), true).co.X);
+	CHECK_EQUAL(1000, kf.GetClosestPoint(openshot::Point(2500, 2500), true).co.X);
+	CHECK_EQUAL(2500, kf.GetClosestPoint(openshot::Point(3000, 3000), true).co.X);
 }
 
 
@@ -260,13 +260,13 @@ TEST(Keyframe_Get_Previous_Point)
 	kf.AddPoint(2500, 0.0);
 
 	// Spot check values from the curve
-	CHECK_EQUAL(kf.GetPreviousPoint(kf.GetClosestPoint(openshot::Point(900, 900))).co.X, 1);
-	CHECK_EQUAL(kf.GetPreviousPoint(kf.GetClosestPoint(openshot::Point(1, 1))).co.X, 1);
-	CHECK_EQUAL(kf.GetPreviousPoint(kf.GetClosestPoint(openshot::Point(5, 5))).co.X, 1);
-	CHECK_EQUAL(kf.GetPreviousPoint(kf.GetClosestPoint(openshot::Point(1000, 1000))).co.X, 1);
-	CHECK_EQUAL(kf.GetPreviousPoint(kf.GetClosestPoint(openshot::Point(1001, 1001))).co.X, 1000);
-	CHECK_EQUAL(kf.GetPreviousPoint(kf.GetClosestPoint(openshot::Point(2500, 2500))).co.X, 1000);
-	CHECK_EQUAL(kf.GetPreviousPoint(kf.GetClosestPoint(openshot::Point(3000, 3000))).co.X, 1000);
+	CHECK_EQUAL(1, kf.GetPreviousPoint(kf.GetClosestPoint(openshot::Point(900, 900))).co.X);
+	CHECK_EQUAL(1, kf.GetPreviousPoint(kf.GetClosestPoint(openshot::Point(1, 1))).co.X);
+	CHECK_EQUAL(1, kf.GetPreviousPoint(kf.GetClosestPoint(openshot::Point(5, 5))).co.X);
+	CHECK_EQUAL(1, kf.GetPreviousPoint(kf.GetClosestPoint(openshot::Point(1000, 1000))).co.X);
+	CHECK_EQUAL(1000, kf.GetPreviousPoint(kf.GetClosestPoint(openshot::Point(1001, 1001))).co.X);
+	CHECK_EQUAL(1000, kf.GetPreviousPoint(kf.GetClosestPoint(openshot::Point(2500, 2500))).co.X);
+	CHECK_EQUAL(1000, kf.GetPreviousPoint(kf.GetClosestPoint(openshot::Point(3000, 3000))).co.X);
 
 }
 
@@ -277,22 +277,22 @@ TEST(Keyframe_Get_Max_Point)
 	kf.AddPoint(1, 1.0);
 
 	// Spot check values from the curve
-	CHECK_EQUAL(kf.GetMaxPoint().co.Y, 1.0);
+	CHECK_EQUAL(1.0, kf.GetMaxPoint().co.Y);
 
 	kf.AddPoint(2, 0.0);
 
 	// Spot check values from the curve
-	CHECK_EQUAL(kf.GetMaxPoint().co.Y, 1.0);
+	CHECK_EQUAL(1.0, kf.GetMaxPoint().co.Y);
 
 	kf.AddPoint(3, 2.0);
 
 	// Spot check values from the curve
-	CHECK_EQUAL(kf.GetMaxPoint().co.Y, 2.0);
+	CHECK_EQUAL(2.0, kf.GetMaxPoint().co.Y);
 
 	kf.AddPoint(4, 1.0);
 
 	// Spot check values from the curve
-	CHECK_EQUAL(kf.GetMaxPoint().co.Y, 2.0);
+	CHECK_EQUAL(2.0, kf.GetMaxPoint().co.Y);
 }
 
 TEST(Keyframe_Scale_Keyframe)
@@ -380,14 +380,14 @@ TEST(Keyframe_Remove_Duplicate_Point)
 	kf.AddPoint(1, 2.0);
 
 	// Spot check values from the curve
-	CHECK_EQUAL(kf.GetLength(), 1);
-	CHECK_CLOSE(kf.GetPoint(0).co.Y, 2.0, 0.01);
+	CHECK_EQUAL(1, kf.GetLength());
+	CHECK_CLOSE(2.0, kf.GetPoint(0).co.Y, 0.01);
 }
 
 TEST(Keyframe_Large_Number_Values)
 {
 	// Large value
-	int64_t large_value = 30 * 60 * 90;
+	int64_t const large_value = 30 * 60 * 90;
 
 	// Create a keyframe curve with 2 points
 	Keyframe kf;
@@ -395,9 +395,9 @@ TEST(Keyframe_Large_Number_Values)
 	kf.AddPoint(large_value, 100.0); // 90 minutes long
 
 	// Spot check values from the curve
-	CHECK_EQUAL(kf.GetLength(), large_value + 1);
-	CHECK_CLOSE(kf.GetPoint(0).co.Y, 1.0, 0.01);
-	CHECK_CLOSE(kf.GetPoint(1).co.Y, 100.0, 0.01);
+	CHECK_EQUAL(large_value + 1, kf.GetLength());
+	CHECK_CLOSE(1.0, kf.GetPoint(0).co.Y, 0.01);
+	CHECK_CLOSE(100.0, kf.GetPoint(1).co.Y, 0.01);
 }
 
 TEST(Keyframe_Remove_Point)


### PR DESCRIPTION
This is a new implementation of the Keyframe class.

**Differences**
The main difference is that the old implementation was "fully cached" - by which I mean that it computed all interpolated values for all X coordinates on first request, and had to re-compute all values when anything changed.

The new implementation is completely "on demand", it does not cache any previously computed value(s) but instead computes just the one requested value for each `GetValue()`, `GetInt()` or `GetLong()` call.  This means modifications to the points do not invalidate any cache (as there is none) and are thus fast.

Regarding points: The previously public data member `Points` is now private and needs to be modified via the provided `AddPoint` and `RemovePoint` functions.  Some code outside of the Keyframe class had to be modified to not access `Points.size()` but rather use the provided `GetCount()`. Same for the now gone `Values` vector: `Values.size()` has been replaced with `GetLength()`.

Many of the other member functions have been modified as well; some just to remove dead / unused code, others to use `GetValue()` instead of the now gone `Values` vector.

I've added new tests to capture the (in part strange, but that's for #370 ) old behavior of the modified member functions and to make sure the new functions follow the same behavior.

Some test values have been modified. This is because the new code produces much smoother Bezier curvers than the old one:

![0-to-255-in-12-with-gnuplot](https://user-images.githubusercontent.com/912651/69530617-9e046d00-0f72-11ea-9322-ae1fd9dc5a2d.png)


**Performance**

I tested two "scenarios":
 1. Setting up all points of the Keyframe and then querying all values.
 2. Setting up all points of the Keyframe, querying all values while also doing random changes to the Keyframe points.

Because I removed the caching I was expecting to see a performance *loss* in the first case. This is not the case however. The following shows a point for the time each `GetValue` call of a 100000 frames (X values) long Keyframe with random constant, linear, and Bezier curve segments:

![no-change](https://user-images.githubusercontent.com/912651/69530828-0f442000-0f73-11ea-9383-96826259fb19.png)

One clearly sees that the old code only starts to produce Values after some time due to the initial calculation of all values. The new code however starts producing values right from the start, and does so also considerably faster. The vertical lines indicate when "constructing" the keyframe (that is adding all points) has been finished, showing that also `AddPoint` has become significantly faster.  This is due to the old `AddPoint` code using selection sort to re-sort the points. The new code just inserts the new point at the correct position.

For the other scenario - the "interactive editing scenario" - I see even more drastic performance improvements:

![out-with-change](https://user-images.githubusercontent.com/912651/69531330-01db6580-0f74-11ea-8fef-229f67e0b70b.png)

The old code fails here because on each change it has to re-compute all values of the (long) Keyframe.

The test data has been generated with this program:

~~~c++
#include <OpenShot.h>


#include <algorithm>
#include <chrono>
#include <cstdlib>


using namespace openshot;
using std::chrono::steady_clock;


int main() {
	unsigned sections = 400;
	unsigned const section_length = 250;
	Keyframe f;
	InterpolationType types[] = {CONSTANT, BEZIER, LINEAR};
	double position = 0;
	auto const start = steady_clock::now();
	f.AddPoint(position, rand());
	while (sections-- > 0) {
		position += section_length;
		f.AddPoint(position, rand(), types[0]);
		std::rotate(std::begin(types), std::begin(types) + 1,
					std::end(types));
	}
	std::chrono::duration<double> const init =
		steady_clock::now() - start;
	std::cerr << "init after " << init.count() << std::endl;
	for (int i = 0; i < position; ++i) {
		#ifdef WITH_CHANGE
		if (rand() > (0.99 * RAND_MAX)) {
			f.AddPoint(i + 1, 0);
			std::cerr << " - added point @ " << i + 1 << std::endl;
		}
		#endif
		double const v = f.GetValue(i);
		std::chrono::duration<double> d = steady_clock::now() - start;
		std::cout << i << " = " << v <<  " after " << d.count() << "\n";
	}
}
~~~

**What now?**
Please test the code, also from OpenShot. Can you reproduce the performance difference? Let me hear suggestions where to further improve the code.

Things I want to improve further:

 - `SetJsonValue()` - which as I know now is used a lot from Openshot - currently calls `AddPoint` for each parsed point.  While asymptotically O(n * log n) I think this can be optimized by first storing the points, and then sorting them *if necessary* (as they will come sorted most of the time from Openshot eitherway).

 - Some functions (`RemovePoint`) still use looping instead of binary search on `Points`

 - Code quality: `int64_t` is not the best candidate to use as an index variable. `std::size_t` is the logical choice.

Things originally planned but probably not necessary:

 - Caching some results (e.g. parts of a Bezier curve).  This will add complexity, can make performance *worse* if the cache does not correctly predict the usage pattern and given the good performance is probably not worth the effort. 