### PR TITLE
Minor adjustments to Doxygen API docs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,14 +97,14 @@ if (TARGET doc)
 	message(STATUS "Doxygen found, documentation target enabled")
 	message("\nTo compile documentation in doc/html, run: 'make doc'")
 
-# Install docs, if the user builds them with `make doc`
-install(CODE "MESSAGE(\"Checking for documentation files to install...\")")
-install(CODE "MESSAGE(\"(Compile with 'make doc' command, requires Doxygen)\")")
+  # Install docs, if the user builds them with `make doc`
+  install(CODE "MESSAGE(\"Checking for documentation files to install...\")")
+  install(CODE "MESSAGE(\"(Compile with 'make doc' command, requires Doxygen)\")")
 
-install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/doc/html/
-        DESTINATION ${CMAKE_INSTALL_DOCDIR}/API
-        MESSAGE_NEVER # Don't spew about file copies
-        OPTIONAL )    # No error if the docs aren't found
+  install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/doc/html/
+          DESTINATION ${CMAKE_INSTALL_DOCDIR}/API
+          MESSAGE_NEVER # Don't spew about file copies
+          OPTIONAL )    # No error if the docs aren't found
 endif()
 
 ############# PROCESS tests/ DIRECTORY ##############

--- a/Doxyfile.in
+++ b/Doxyfile.in
@@ -340,7 +340,7 @@ AUTOLINK_SUPPORT       = YES
 # diagrams that involve STL classes more complete and accurate.
 # The default value is: NO.
 
-BUILTIN_STL_SUPPORT    = NO
+BUILTIN_STL_SUPPORT    = YES
 
 # If you use Microsoft's C++/CLI language, you should set this option to YES to
 # enable parsing support.
@@ -2096,7 +2096,7 @@ INCLUDE_FILE_PATTERNS  =
 # recursively expanded use the := operator instead of the = operator.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-PREDEFINED             =
+PREDEFINED             = USE_BLACKMAGIC USE_IMAGEMAGICK
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The


### PR DESCRIPTION
- Define `USE_IMAGEMAGICK` and `USE_BLACKMAGIC` unconditionally when building docs, so that the classes will be documented.
- Improve handling of `std::`-prefixed types in doxygen output.