### PR TITLE
Wrap parentheses around assignment in conditional

### DIFF
--- a/src/Clip.cpp
+++ b/src/Clip.cpp
@@ -914,7 +914,7 @@ void Clip::SetJsonValue(Json::Value root) {
 
 			if (!existing_effect["type"].isNull()) {
 				// Create instance of effect
-				if (e = EffectInfo().CreateEffect(existing_effect["type"].asString())) {
+				if ( (e = EffectInfo().CreateEffect(existing_effect["type"].asString())) ) {
 
 					// Load Json into Effect
 					e->SetJsonValue(existing_effect);

--- a/src/Timeline.cpp
+++ b/src/Timeline.cpp
@@ -1098,7 +1098,7 @@ void Timeline::SetJsonValue(Json::Value root) {
 
 			if (!existing_effect["type"].isNull()) {
 				// Create instance of effect
-				if (e = EffectInfo().CreateEffect(existing_effect["type"].asString())) {
+				if ( (e = EffectInfo().CreateEffect(existing_effect["type"].asString())) ) {
 
 					// Load Json into Effect
 					e->SetJsonValue(existing_effect);
@@ -1364,7 +1364,7 @@ void Timeline::apply_json_to_effects(Json::Value change, EffectBase* existing_ef
 		EffectBase *e = NULL;
 
 		// Init the matching effect object
-		if (e = EffectInfo().CreateEffect(effect_type)) {
+		if ( (e = EffectInfo().CreateEffect(effect_type)) ) {
 
 			// Load Json into Effect
 			e->SetJsonValue(change["value"]);


### PR DESCRIPTION
When warnings are enabled, the compiler will flag any lines of the form:
```c++
if (result = get_result_for(thing))
```
due to the possibility that it's either _meant_ to be an equality test, or will be _interpreted_ as an equality test by someone reading the code in the future.

The warnings can be silenced by adding a second set of parens, i.e.
```c++
if ((result = get_result_for(thing)))
```
or, as this PR makes it (for readability, at the end of the line):
```c++
if ( (result = get_result_for(thing)) )
```

Double parens are added to the three remaining places in the code which trigger that warning.