### PR TITLE
Add repr to openshot.Version

### DIFF
--- a/src/bindings/python/openshot.i
+++ b/src/bindings/python/openshot.i
@@ -153,9 +153,15 @@
 }
 
 %extend openshot::OpenShotVersion {
-    // Give the struct a string representation
+        // Give the struct a string representation
 	const std::string __str__() {
 		return std::string(OPENSHOT_VERSION_FULL);
+	}
+	// And a repr for interactive use
+	const std::string __repr__() {
+		std::ostringstream result;
+		result << "OpenShotVersion('" << OPENSHOT_VERSION_FULL << "')";
+		return result.str();
 	}
 }
 


### PR DESCRIPTION
The new Pythonic `openshot.Version` has a string representation, so these will all work:
```python
>>> import openshot
>>> print(openshot.Version)
0.2.3-dev1
>>> str(openshot.Version)
'0.2.3-dev1'
>>> print("Version: {}".format(openshot.Version))
Version: 0.2.3-dev1
>>> str(openshot.Version) > '0.2.3'
True
>>> str(openshot.Version) > '0.2.4'
False
```
But used interactively, this happens:
```python
>>> openshot.Version
<openshot.OpenShotVersion; proxy of <Swig Object of type
 'openshot::OpenShotVersion *' at 0x7f42f4a8bd80> >
```

So, this PR adds a `__repr__` method that returns a representation of the version object, in place of the autogenerated SWIG text:
```python
>>> import openshot
>>> openshot.Version
OpenShotVersion('0.2.3-dev1')
```

Note that this is only the _representation_ — the object is still not inherently a string unless converted to `str()`, so the following behavior is unchanged:
```python
>>> # Before
>>> a = ['a', 'string', 'list']
>>> a.append(openshot.Version)
>>> a
['a', 'string', 'list', <openshot.OpenShotVersion; proxy of <Swig Object of type
 'openshot::OpenShotVersion *' at 0x7f42f4a8bd80> >]
>>> print(",".join(a))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: sequence item 3: expected str instance, OpenShotVersion found

>>> # After
>>> a = ['a', 'string', 'list']
>>> a.append(openshot.Version)
>>> a
['a', 'string', 'list', OpenShotVersion('0.2.3-dev1')]
>>> print(",".join(a))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: sequence item 3: expected str instance, OpenShotVersion found

>>> # The right way(s)
>>> a = ['a', 'string', 'list']
>>> a.append(str(openshot.Version))
>>> a.append("{}".format(openshot.Version))
>>> a
['a', 'string', 'list', '0.2.3-dev1', '0.2.3-dev1']
```

The `repr()` is purely a convenience for interactive use and debugging.