### PR TITLE
Move feature summary to root CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,15 @@ Generating build files for OpenShot with CMake ${CMAKE_VERSION}
 #      in order to properly configure CMAKE_INSTALL_LIBDIR path
 include(GNUInstallDirs)
 
+# Collect and display summary of options/dependencies
+include(FeatureSummary)
+
+################ OPTIONS ##################
+# Optional build settings for libopenshot
+option(USE_SYSTEM_JSONCPP "Use system installed JsonCpp, if found" ON)
+option(DISABLE_BUNDLED_JSONCPP "Don't fall back to bundled JsonCpp" OFF)
+option(ENABLE_IWYU "Enable 'Include What You Use' scanner (CMake 3.3+)" OFF)
+
 ########## Configure Version.h header ##############
 configure_file(include/OpenShotVersion.h.in include/OpenShotVersion.h @ONLY)
 # We'll want that installed later
@@ -111,3 +120,9 @@ endif()
 if(NOT DISABLE_TESTS)
   add_subdirectory(tests)
 endif()
+
+########### PRINT FEATURE SUMMARY ##############
+feature_summary(WHAT ALL
+    INCLUDE_QUIET_PACKAGES
+    FATAL_ON_MISSING_REQUIRED_PACKAGES
+    DESCRIPTION "Displaying feature summary\n\nBuild configuration:")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -27,12 +27,6 @@
 # Collect and display summary of options/dependencies
 include(FeatureSummary)
 
-################ OPTIONS ##################
-# Optional build settings for libopenshot
-option(USE_SYSTEM_JSONCPP "Use system installed JsonCpp, if found" ON)
-option(DISABLE_BUNDLED_JSONCPP "Don't fall back to bundled JsonCpp" OFF)
-option(ENABLE_IWYU "Enable 'Include What You Use' scanner (CMake 3.3+)" OFF)
-
 # Automatically process Qt classes with meta-object compiler
 set(CMAKE_AUTOMOC True)
 
@@ -425,12 +419,6 @@ ENDIF (BLACKMAGIC_FOUND)
 
 ############### INCLUDE SWIG BINDINGS ################
 add_subdirectory(bindings)
-
-########### PRINT FEATURE SUMMARY ##############
-feature_summary(WHAT ALL
-    INCLUDE_QUIET_PACKAGES
-    FATAL_ON_MISSING_REQUIRED_PACKAGES
-    DESCRIPTION "Displaying feature summary\n\nBuild configuration:")
 
 ############### INSTALL HEADERS & LIBRARY ################
 set(LIB_INSTALL_DIR lib${LIB_SUFFIX}) # determine correct lib folder


### PR DESCRIPTION
PR #367 by @musteresel adds optional coverage reporting to the CMake build, which is controlled from the root `CMakeLists.txt` and `tests/CMakeLists.txt`.

Until now our FeatureSummary output has been done in the `src/CMakeLists.txt`, but it makes sense to list coverage reporting as a build feature. So, the FeatureSummary generation is moved to the bottom of the root `CMakeList.txt` where it can collect feature information from all build components.