### PR TITLE
Ensure switch statements on enums cover all values

### DIFF
--- a/src/FFmpegReader.cpp
+++ b/src/FFmpegReader.cpp
@@ -191,10 +191,10 @@ static enum AVPixelFormat get_hw_dec_format(AVCodecContext *ctx, const enum AVPi
 #if defined(__APPLE__)
 			// Apple pix formats
 			case AV_PIX_FMT_VIDEOTOOLBOX:
-					hw_de_av_pix_fmt_global = AV_PIX_FMT_VIDEOTOOLBOX;
-					hw_de_av_device_type_global = AV_HWDEVICE_TYPE_VIDEOTOOLBOX;
-					return *p;
-					break;
+				hw_de_av_pix_fmt_global = AV_PIX_FMT_VIDEOTOOLBOX;
+				hw_de_av_device_type_global = AV_HWDEVICE_TYPE_VIDEOTOOLBOX;
+				return *p;
+				break;
 #endif
 				// Cross-platform pix formats
 			case AV_PIX_FMT_CUDA:
@@ -206,6 +206,9 @@ static enum AVPixelFormat get_hw_dec_format(AVCodecContext *ctx, const enum AVPi
 				hw_de_av_pix_fmt_global = AV_PIX_FMT_QSV;
 				hw_de_av_device_type_global = AV_HWDEVICE_TYPE_QSV;
 				return *p;
+				break;
+			default:
+				// This is only here to silence unused-enum warnings
 				break;
 		}
 	}

--- a/src/FFmpegWriter.cpp
+++ b/src/FFmpegWriter.cpp
@@ -1563,6 +1563,10 @@ void FFmpegWriter::write_audio_packets(bool is_final) {
 					output_sample_fmt = AV_SAMPLE_FMT_U8;
 					break;
 				}
+				default: {
+					// This is only here to silence unused-enum warnings
+					break;
+				}
 			}
 
 			// Update total samples & input frame size (due to bigger or smaller data types)

--- a/src/Timeline.cpp
+++ b/src/Timeline.cpp
@@ -466,34 +466,37 @@ void Timeline::add_layer(std::shared_ptr<Frame> new_frame, Clip* source_clip, in
     float crop_h = source_clip->crop_height.GetValue(clip_frame_number);
     switch(source_clip->crop_gravity)
     {
-      case (GRAVITY_TOP):
-          crop_x += 0.5;
-          break;
-      case (GRAVITY_TOP_RIGHT):
-          crop_x += 1.0;
-          break;
-      case (GRAVITY_LEFT):
-          crop_y += 0.5;
-          break;
-      case (GRAVITY_CENTER):
-          crop_x += 0.5;
-          crop_y += 0.5;
-          break;
-      case (GRAVITY_RIGHT):
-          crop_x += 1.0;
-          crop_y += 0.5;
-          break;
-      case (GRAVITY_BOTTOM_LEFT):
-          crop_y += 1.0;
-          break;
-      case (GRAVITY_BOTTOM):
-          crop_x += 0.5;
-          crop_y += 1.0;
-          break;
-      case (GRAVITY_BOTTOM_RIGHT):
-          crop_x += 1.0;
-          crop_y += 1.0;
-          break;
+    case (GRAVITY_TOP_LEFT):
+        // This is only here to prevent unused-enum warnings
+        break;
+    case (GRAVITY_TOP):
+        crop_x += 0.5;
+        break;
+    case (GRAVITY_TOP_RIGHT):
+        crop_x += 1.0;
+        break;
+    case (GRAVITY_LEFT):
+        crop_y += 0.5;
+        break;
+    case (GRAVITY_CENTER):
+        crop_x += 0.5;
+        crop_y += 0.5;
+        break;
+    case (GRAVITY_RIGHT):
+        crop_x += 1.0;
+        crop_y += 0.5;
+        break;
+    case (GRAVITY_BOTTOM_LEFT):
+        crop_y += 1.0;
+        break;
+    case (GRAVITY_BOTTOM):
+        crop_x += 0.5;
+        crop_y += 1.0;
+        break;
+    case (GRAVITY_BOTTOM_RIGHT):
+        crop_x += 1.0;
+        crop_y += 1.0;
+        break;
     }
 
 
@@ -509,6 +512,9 @@ void Timeline::add_layer(std::shared_ptr<Frame> new_frame, Clip* source_clip, in
 
 	switch (source_clip->gravity)
 	{
+	case (GRAVITY_TOP_LEFT):
+		// This is only here to prevent unused-enum warnings
+		break;
 	case (GRAVITY_TOP):
 		x = (Settings::Instance()->MAX_WIDTH - scaled_source_width) / 2.0; // center
 		break;
@@ -611,6 +617,10 @@ void Timeline::add_layer(std::shared_ptr<Frame> new_frame, Clip* source_clip, in
         std::stringstream frame_number_str;
         switch (source_clip->display)
         {
+            case (FRAME_DISPLAY_NONE):
+                // This is only here to prevent unused-enum warnings
+                break;
+
             case (FRAME_DISPLAY_CLIP):
                 frame_number_str << clip_frame_number;
                 break;


### PR DESCRIPTION
When compiling with `-Wall`, GCC will issue a warning whenever a `switch()` on an enum type doesn't account for all of the possible enum values, either through explicit `case` statements or by including a `default` case.

This PR silences all of those warnings, by ensuring that all enum values are covered in `switch()` statements.