### PR TITLE
Travis: allow FFmpeg4 build failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,11 @@ addons:
     - libswresample-dev
 
 matrix:
+
+  # The FFmpeg4 PPA is currently down as a protest
+  allow_failures:
+  - env: BUILD_VERSION=ffmpeg4
+
   include:
     - name: "FFmpeg 2 GCC (Ubuntu 16.04 Xenial)"
       env: BUILD_VERSION=ffmpeg2


### PR DESCRIPTION
As I noted in https://github.com/OpenShot/libopenshot/pull/386#issuecomment-564573049 :

The failed Travis check is due to our FFmpeg 4 build failing in the setup phase, as it's not able to install the ffmpeg 4 libs via apt. It seems the maintainer of the PPA for ffmpeg 4 on Bionic has chosen to [take his toys and go home](https://launchpad.net/~jonathonf/+archive/ubuntu/ffmpeg-4):

<blockquote>
This PPA has been removed from public access as part of a protest against the abuse of open-source projects by large companies. For more detail visit the main page here: <a href="https://launchpad.net/~jonathonf">https://launchpad.net/~jonathonf</a>

If you are a company and you would like this PPA to continue then let me know your preferred route for contributions and I will arrange something.

If we have already been in contact then ping me your Launchpad ID and I will add you to a private PPA in the meantime.
</blockquote>

🙄 Presumably some saner person will set up a replacement PPA, but until then it looks like we'll have to figure out whether we want to build FFmpeg 4 ourselves for the Travis environment, or disable the FFmpeg 4 branch of the CI builds.


...For now, allowing failures of the FFmpeg4 build (only) will get us back online as far as being able to develop and merge PRs.