### PR TITLE
Don't compare differently-signed types

### DIFF
--- a/src/AudioBufferSource.cpp
+++ b/src/AudioBufferSource.cpp
@@ -43,7 +43,7 @@ AudioBufferSource::~AudioBufferSource()
 {
 	// forget the AudioSampleBuffer. It still exists; we just don't know about it.
 	buffer = NULL;
-};
+}
 
 // Get the next block of audio samples
 void AudioBufferSource::getNextAudioBlock (const juce::AudioSourceChannelInfo& info)

--- a/src/AudioReaderSource.cpp
+++ b/src/AudioReaderSource.cpp
@@ -51,7 +51,7 @@ AudioReaderSource::~AudioReaderSource()
 	// Clear and delete the buffer
 	delete buffer;
 	buffer = NULL;
-};
+}
 
 // Get more samples from the reader
 void AudioReaderSource::GetMoreSamplesFromReader()

--- a/src/CacheBase.cpp
+++ b/src/CacheBase.cpp
@@ -37,13 +37,13 @@ using namespace openshot;
 CacheBase::CacheBase() : max_bytes(0) {
 	// Init the critical section
 	cacheCriticalSection = new CriticalSection();
-};
+}
 
 // Constructor that sets the max frames to cache
 CacheBase::CacheBase(int64_t max_bytes) : max_bytes(max_bytes) {
 	// Init the critical section
 	cacheCriticalSection = new CriticalSection();
-};
+}
 
 // Set maximum bytes to a different amount based on a ReaderInfo struct
 void CacheBase::SetMaxBytesFromInfo(int64_t number_of_frames, int width, int height, int sample_rate, int channels)

--- a/src/CacheDisk.cpp
+++ b/src/CacheDisk.cpp
@@ -47,7 +47,7 @@ CacheDisk::CacheDisk(std::string cache_path, std::string format, float quality, 
 
 	// Init path directory
 	InitPath(cache_path);
-};
+}
 
 // Constructor that sets the max bytes to cache
 CacheDisk::CacheDisk(std::string cache_path, std::string format, float quality, float scale, int64_t max_bytes) : CacheBase(max_bytes) {
@@ -62,7 +62,7 @@ CacheDisk::CacheDisk(std::string cache_path, std::string format, float quality, 
 
 	// Init path directory
 	InitPath(cache_path);
-};
+}
 
 // Initialize cache directory
 void CacheDisk::InitPath(std::string cache_path) {
@@ -103,13 +103,11 @@ void CacheDisk::CalculateRanges() {
 		// Increment range version
 		range_version++;
 
-		std::vector<int64_t>::iterator itr_ordered;
 		int64_t starting_frame = *ordered_frame_numbers.begin();
-		int64_t ending_frame = *ordered_frame_numbers.begin();
+		int64_t ending_frame = starting_frame;
 
 		// Loop through all known frames (in sequential order)
-		for (itr_ordered = ordered_frame_numbers.begin(); itr_ordered != ordered_frame_numbers.end(); ++itr_ordered) {
-			int64_t frame_number = *itr_ordered;
+		for (const auto frame_number : ordered_frame_numbers) {
 			if (frame_number - ending_frame > 1) {
 				// End of range detected
 				Json::Value range;

--- a/src/CacheMemory.cpp
+++ b/src/CacheMemory.cpp
@@ -39,7 +39,7 @@ CacheMemory::CacheMemory() : CacheBase(0) {
 	cache_type = "CacheMemory";
 	range_version = 0;
 	needs_range_processing = false;
-};
+}
 
 // Constructor that sets the max bytes to cache
 CacheMemory::CacheMemory(int64_t max_bytes) : CacheBase(max_bytes) {
@@ -47,7 +47,7 @@ CacheMemory::CacheMemory(int64_t max_bytes) : CacheBase(max_bytes) {
 	cache_type = "CacheMemory";
 	range_version = 0;
 	needs_range_processing = false;
-};
+}
 
 // Default destructor
 CacheMemory::~CacheMemory()

--- a/src/Clip.cpp
+++ b/src/Clip.cpp
@@ -782,11 +782,8 @@ Json::Value Clip::JsonValue() {
 	root["effects"] = Json::Value(Json::arrayValue);
 
 	// loop through effects
-	std::list<EffectBase*>::iterator effect_itr;
-	for (effect_itr=effects.begin(); effect_itr != effects.end(); ++effect_itr)
+	for (auto existing_effect : effects)
 	{
-		// Get clip object from the iterator
-		EffectBase *existing_effect = (*effect_itr);
 		root["effects"].append(existing_effect->JsonValue());
 	}
 
@@ -905,10 +902,7 @@ void Clip::SetJsonValue(Json::Value root) {
 		effects.clear();
 
 		// loop through effects
-		for (Json::Value::ArrayIndex x = 0; x < root["effects"].size(); x++) {
-			// Get each effect
-			Json::Value existing_effect = root["effects"][x];
-
+		for (const auto existing_effect : root["effects"]) {
 			// Create Effect
 			EffectBase *e = NULL;
 
@@ -1025,12 +1019,8 @@ void Clip::RemoveEffect(EffectBase* effect)
 std::shared_ptr<Frame> Clip::apply_effects(std::shared_ptr<Frame> frame)
 {
 	// Find Effects at this position and layer
-	std::list<EffectBase*>::iterator effect_itr;
-	for (effect_itr=effects.begin(); effect_itr != effects.end(); ++effect_itr)
+	for (auto effect : effects)
 	{
-		// Get clip object from the iterator
-		EffectBase *effect = (*effect_itr);
-
 		// Apply the effect to this frame
 		frame = effect->GetFrame(frame, frame->number);
 

--- a/src/Clip.cpp
+++ b/src/Clip.cpp
@@ -905,7 +905,7 @@ void Clip::SetJsonValue(Json::Value root) {
 		effects.clear();
 
 		// loop through effects
-		for (int x = 0; x < root["effects"].size(); x++) {
+		for (Json::Value::ArrayIndex x = 0; x < root["effects"].size(); x++) {
 			// Get each effect
 			Json::Value existing_effect = root["effects"][x];
 

--- a/src/FFmpegWriter.cpp
+++ b/src/FFmpegWriter.cpp
@@ -615,7 +615,7 @@ void FFmpegWriter::WriteFrame(std::shared_ptr<Frame> frame) {
 	ZmqLogger::Instance()->AppendDebugMethod("FFmpegWriter::WriteFrame", "frame->number", frame->number, "spooled_video_frames.size()", spooled_video_frames.size(), "spooled_audio_frames.size()", spooled_audio_frames.size(), "cache_size", cache_size, "is_writing", is_writing);
 
 	// Write the frames once it reaches the correct cache size
-	if (spooled_video_frames.size() == cache_size || spooled_audio_frames.size() == cache_size) {
+	if ((int)spooled_video_frames.size() == cache_size || (int)spooled_audio_frames.size() == cache_size) {
 		// Is writer currently writing?
 		if (!is_writing)
 			// Write frames to video file
@@ -1083,7 +1083,7 @@ AVStream *FFmpegWriter::add_audio_stream() {
 
 
 	// Set a valid number of channels (or throw error)
-	int channel_layout = info.channel_layout;
+	const uint64_t channel_layout = info.channel_layout;
 	if (codec->channel_layouts) {
 		int i;
 		for (i = 0; codec->channel_layouts[i] != 0; i++)

--- a/src/Frame.cpp
+++ b/src/Frame.cpp
@@ -43,7 +43,7 @@ Frame::Frame() : number(1), pixel_ratio(1,1), channels(2), width(1), height(1), 
 
 	// initialize the audio samples to zero (silence)
 	audio->clear();
-};
+}
 
 // Constructor - image only (48kHz audio silence)
 Frame::Frame(int64_t number, int width, int height, std::string color)
@@ -56,7 +56,7 @@ Frame::Frame(int64_t number, int width, int height, std::string color)
 
 	// initialize the audio samples to zero (silence)
 	audio->clear();
-};
+}
 
 // Constructor - audio only (300x200 blank image)
 Frame::Frame(int64_t number, int samples, int channels) :
@@ -69,7 +69,7 @@ Frame::Frame(int64_t number, int samples, int channels) :
 
 	// initialize the audio samples to zero (silence)
 	audio->clear();
-};
+}
 
 // Constructor - image & audio
 Frame::Frame(int64_t number, int width, int height, std::string color, int samples, int channels)
@@ -82,7 +82,7 @@ Frame::Frame(int64_t number, int width, int height, std::string color, int sampl
 
 	// initialize the audio samples to zero (silence)
 	audio->clear();
-};
+}
 
 
 // Copy constructor

--- a/src/FrameMapper.cpp
+++ b/src/FrameMapper.cpp
@@ -235,7 +235,7 @@ void FrameMapper::Init()
 	int64_t start_samples_frame = 1;
 	int start_samples_position = 0;
 
-	for (int64_t field = 1; field <= fields.size(); field++)
+	for (std::vector<Field>::size_type field = 1; field <= fields.size(); field++)
 	{
 		// Get the current field
 		Field f = fields[field - 1];
@@ -337,7 +337,7 @@ MappedFrame FrameMapper::GetMappedFrame(int64_t TargetFrameNumber)
 		// frame too small, return error
 		throw OutOfBoundsFrame("An invalid frame was requested.", TargetFrameNumber, frames.size());
 
-	else if (TargetFrameNumber > frames.size())
+	else if (TargetFrameNumber > (int64_t)frames.size())
 		// frame too large, set to end frame
 		TargetFrameNumber = frames.size();
 

--- a/src/KeyFrame.cpp
+++ b/src/KeyFrame.cpp
@@ -169,7 +169,7 @@ void Keyframe::AddPoint(double x, double y, InterpolationType interpolate)
 // Get the index of a point by matching a coordinate
 int64_t Keyframe::FindIndex(Point p) const {
 	// loop through points, and find a matching coordinate
-	for (int64_t x = 0; x < Points.size(); x++) {
+	for (std::vector<Point>::size_type x = 0; x < Points.size(); x++) {
 		// Get each point
 		Point existing_point = Points[x];
 
@@ -333,7 +333,7 @@ Json::Value Keyframe::JsonValue() const {
 	root["Points"] = Json::Value(Json::arrayValue);
 
 	// loop through points, and find a matching coordinate
-	for (int x = 0; x < Points.size(); x++) {
+	for (std::vector<Point>::size_type x = 0; x < Points.size(); x++) {
 		// Get each point
 		Point existing_point = Points[x];
 		root["Points"].append(existing_point.JsonValue());
@@ -509,7 +509,7 @@ double Keyframe::GetDelta(int64_t index) const {
 // Get a point at a specific index
 Point const & Keyframe::GetPoint(int64_t index) const {
 	// Is index a valid point?
-	if (index >= 0 && index < Points.size())
+	if (index >= 0 && index < (int64_t)Points.size())
 		return Points[index];
 	else
 		// Invalid index
@@ -532,7 +532,7 @@ int64_t Keyframe::GetCount() const {
 // Remove a point by matching a coordinate
 void Keyframe::RemovePoint(Point p) {
 	// loop through points, and find a matching coordinate
-	for (int64_t x = 0; x < Points.size(); x++) {
+	for (std::vector<Point>::size_type x = 0; x < Points.size(); x++) {
 		// Get each point
 		Point existing_point = Points[x];
 
@@ -551,7 +551,7 @@ void Keyframe::RemovePoint(Point p) {
 // Remove a point by index
 void Keyframe::RemovePoint(int64_t index) {
 	// Is index a valid point?
-	if (index >= 0 && index < Points.size())
+	if (index >= 0 && index < (int64_t)Points.size())
 	{
 		// Remove a specific point by index
 		Points.erase(Points.begin() + index);
@@ -581,7 +581,7 @@ void Keyframe::PrintValues() const {
 	cout << fixed << setprecision(4);
 	cout << "Frame Number (X)\tValue (Y)\tIs Increasing\tRepeat Numerator\tRepeat Denominator\tDelta (Y Difference)\n";
 
-	for (uint64_t i = 1; i < GetLength(); ++i) {
+	for (int64_t i = 1; i < GetLength(); ++i) {
 		cout << i << "\t" << GetValue(i) << "\t" << IsIncreasing(i) << "\t" ;
 		cout << GetRepeatFraction(i).num << "\t" << GetRepeatFraction(i).den << "\t" << GetDelta(i) << "\n";
 	}
@@ -597,7 +597,7 @@ void Keyframe::ScalePoints(double scale)
 	// TODO: What if scale < 0?
 
 	// Loop through each point (skipping the 1st point)
-	for (int64_t point_index = 1; point_index < Points.size(); point_index++) {
+	for (std::vector<Point>::size_type point_index = 1; point_index < Points.size(); point_index++) {
 		// Scale X value
 		Points[point_index].co.X = round(Points[point_index].co.X * scale);
 	}
@@ -605,7 +605,7 @@ void Keyframe::ScalePoints(double scale)
 
 // Flip all the points in this openshot::Keyframe (useful for reversing an effect or transition, etc...)
 void Keyframe::FlipPoints() {
-	for (int64_t point_index = 0, reverse_index = Points.size() - 1; point_index < reverse_index; point_index++, reverse_index--) {
+	for (std::vector<Point>::size_type point_index = 0, reverse_index = Points.size() - 1; point_index < reverse_index; point_index++, reverse_index--) {
 		// Flip the points
 		using std::swap;
 		swap(Points[point_index].co.Y, Points[reverse_index].co.Y);

--- a/src/KeyFrame.cpp
+++ b/src/KeyFrame.cpp
@@ -333,9 +333,7 @@ Json::Value Keyframe::JsonValue() const {
 	root["Points"] = Json::Value(Json::arrayValue);
 
 	// loop through points, and find a matching coordinate
-	for (std::vector<Point>::size_type x = 0; x < Points.size(); x++) {
-		// Get each point
-		Point existing_point = Points[x];
+	for (auto existing_point : Points) {
 		root["Points"].append(existing_point.JsonValue());
 	}
 
@@ -379,10 +377,7 @@ void Keyframe::SetJsonValue(Json::Value root) {
 
 	if (!root["Points"].isNull())
 		// loop through points
-		for (int64_t x = 0; x < root["Points"].size(); x++) {
-			// Get each point
-			Json::Value existing_point = root["Points"][(Json::UInt) x];
-
+		for (const auto existing_point : root["Points"]) {
 			// Create Point
 			Point p;
 

--- a/src/ReaderBase.cpp
+++ b/src/ReaderBase.cpp
@@ -108,9 +108,8 @@ void ReaderBase::DisplayInfo() {
 	std::cout << "----------------------------" << std::endl;
 
 	// Iterate through metadata
-	std::map<std::string, std::string>::iterator it;
-	for (it = info.metadata.begin(); it != info.metadata.end(); it++)
-		std::cout << "--> " << it->first << ": " << it->second << std::endl;
+	for (auto it : info.metadata)
+		std::cout << "--> " << it.first << ": " << it.second << std::endl;
 }
 
 // Generate Json::JsonValue for this object
@@ -160,9 +159,8 @@ Json::Value ReaderBase::JsonValue() {
 
 	// Append metadata map
 	root["metadata"] = Json::Value(Json::objectValue);
-	std::map<std::string, std::string>::iterator it;
-	for (it = info.metadata.begin(); it != info.metadata.end(); it++)
-		root["metadata"][it->first] = it->second;
+	for (auto it : info.metadata)
+		root["metadata"][it.first] = it.second;
 
 	// return JsonValue
 	return root;

--- a/src/Timeline.cpp
+++ b/src/Timeline.cpp
@@ -780,7 +780,7 @@ std::shared_ptr<Frame> Timeline::GetFrame(int64_t requested_frame)
 		for (int64_t frame_number = requested_frame; frame_number < requested_frame + minimum_frames; frame_number++)
 		{
 			// Loop through clips
-			for (int clip_index = 0; clip_index < nearby_clips.size(); clip_index++)
+			for (std::vector<Clip>::size_type clip_index = 0; clip_index < nearby_clips.size(); clip_index++)
 			{
 				// Get clip object from the iterator
 				Clip *clip = nearby_clips[clip_index];
@@ -832,7 +832,7 @@ std::shared_ptr<Frame> Timeline::GetFrame(int64_t requested_frame)
 				ZmqLogger::Instance()->AppendDebugMethod("Timeline::GetFrame (Loop through clips)", "frame_number", frame_number, "clips.size()", clips.size(), "nearby_clips.size()", nearby_clips.size());
 
 				// Find Clips near this time
-				for (int clip_index = 0; clip_index < nearby_clips.size(); clip_index++)
+				for (std::vector<Clip>::size_type clip_index = 0; clip_index < nearby_clips.size(); clip_index++)
 				{
 					// Get clip object from the iterator
 					Clip *clip = nearby_clips[clip_index];
@@ -850,7 +850,7 @@ std::shared_ptr<Frame> Timeline::GetFrame(int64_t requested_frame)
 						// Determine if clip is "top" clip on this layer (only happens when multiple clips are overlapping)
 						bool is_top_clip = true;
 						float max_volume = 0.0;
-						for (int top_clip_index = 0; top_clip_index < nearby_clips.size(); top_clip_index++)
+						for (std::vector<Clip>::size_type top_clip_index = 0; top_clip_index < nearby_clips.size(); top_clip_index++)
 						{
 							Clip *nearby_clip = nearby_clips[top_clip_index];
                             long nearby_clip_start_position = round(nearby_clip->Position() * info.fps.ToDouble()) + 1;
@@ -1069,7 +1069,7 @@ void Timeline::SetJsonValue(Json::Value root) {
 		clips.clear();
 
 		// loop through clips
-		for (int x = 0; x < root["clips"].size(); x++) {
+		for (Json::Value::ArrayIndex x = 0; x < root["clips"].size(); x++) {
 			// Get each clip
 			Json::Value existing_clip = root["clips"][x];
 
@@ -1089,7 +1089,7 @@ void Timeline::SetJsonValue(Json::Value root) {
 		effects.clear();
 
 		// loop through effects
-		for (int x = 0; x < root["effects"].size(); x++) {
+		for (Json::Value::ArrayIndex x = 0; x < root["effects"].size(); x++) {
 			// Get each effect
 			Json::Value existing_effect = root["effects"][x];
 
@@ -1144,7 +1144,7 @@ void Timeline::ApplyJsonDiff(std::string value) {
 	try
 	{
 		// Process the JSON change array, loop through each item
-		for (int x = 0; x < root.size(); x++) {
+		for (Json::Value::ArrayIndex x = 0; x < root.size(); x++) {
 			// Get each change
 			Json::Value change = root[x];
 			std::string root_key = change["key"][(uint)0].asString();
@@ -1180,7 +1180,7 @@ void Timeline::apply_json_to_clips(Json::Value change) {
 	Clip *existing_clip = NULL;
 
 	// Find id of clip (if any)
-	for (int x = 0; x < change["key"].size(); x++) {
+	for (Json::Value::ArrayIndex x = 0; x < change["key"].size(); x++) {
 		// Get each change
 		Json::Value key_part = change["key"][x];
 
@@ -1308,7 +1308,7 @@ void Timeline::apply_json_to_effects(Json::Value change) {
 	EffectBase *existing_effect = NULL;
 
 	// Find id of an effect (if any)
-	for (int x = 0; x < change["key"].size(); x++) {
+	for (Json::Value::ArrayIndex x = 0; x < change["key"].size(); x++) {
 		// Get each change
 		Json::Value key_part = change["key"][x];
 

--- a/src/Timeline.cpp
+++ b/src/Timeline.cpp
@@ -79,15 +79,16 @@ Timeline::~Timeline() {
 		Close();
 
 	// Free all allocated frame mappers
-	std::set<FrameMapper *>::iterator frame_mapper_itr;
-	for (frame_mapper_itr = allocated_frame_mappers.begin(); frame_mapper_itr != allocated_frame_mappers.end(); ++frame_mapper_itr) {
-		// Get frame mapper object from the iterator
-		FrameMapper *frame_mapper = (*frame_mapper_itr);
-		frame_mapper->Reader(NULL);
-		frame_mapper->Close();
-		delete frame_mapper;
+	std::set<FrameMapper *>::iterator it;
+	for (it = allocated_frame_mappers.begin(); it != allocated_frame_mappers.end(); ) {
+		// Dereference and clean up FrameMapper object
+		FrameMapper *mapper = (*it);
+		mapper->Reader(NULL);
+		mapper->Close();
+		delete mapper;
+		// Remove reference and proceed to next element
+		it = allocated_frame_mappers.erase(it);
 	}
-	allocated_frame_mappers.clear();
 
 	// Destroy previous cache (if managed by timeline)
 	if (managed_cache && final_cache) {
@@ -169,12 +170,8 @@ void Timeline::ApplyMapperToClips()
 	ClearAllCache();
 
 	// Loop through all clips
-	std::list<Clip*>::iterator clip_itr;
-	for (clip_itr=clips.begin(); clip_itr != clips.end(); ++clip_itr)
+	for (auto clip : clips)
 	{
-		// Get clip object from the iterator
-		Clip *clip = (*clip_itr);
-
 		// Apply framemapper (or update existing framemapper)
 		apply_mapper_to_clip(clip);
 	}
@@ -197,12 +194,8 @@ std::shared_ptr<Frame> Timeline::apply_effects(std::shared_ptr<Frame> frame, int
 	ZmqLogger::Instance()->AppendDebugMethod("Timeline::apply_effects", "frame->number", frame->number, "timeline_frame_number", timeline_frame_number, "layer", layer);
 
 	// Find Effects at this position and layer
-	std::list<EffectBase*>::iterator effect_itr;
-	for (effect_itr=effects.begin(); effect_itr != effects.end(); ++effect_itr)
+	for (auto effect : effects)
 	{
-		// Get effect object from the iterator
-		EffectBase *effect = (*effect_itr);
-
 		// Does clip intersect the current requested time
 		long effect_start_position = round(effect->Position() * info.fps.ToDouble()) + 1;
 		long effect_end_position = round((effect->Position() + (effect->Duration())) * info.fps.ToDouble()) + 1;
@@ -692,12 +685,8 @@ void Timeline::Close()
 	ZmqLogger::Instance()->AppendDebugMethod("Timeline::Close");
 
 	// Close all open clips
-	std::list<Clip*>::iterator clip_itr;
-	for (clip_itr=clips.begin(); clip_itr != clips.end(); ++clip_itr)
+	for (auto clip : clips)
 	{
-		// Get clip object from the iterator
-		Clip *clip = (*clip_itr);
-
 		// Open or Close this clip, based on if it's intersecting or not
 		update_open_clips(clip, false);
 	}
@@ -780,10 +769,8 @@ std::shared_ptr<Frame> Timeline::GetFrame(int64_t requested_frame)
 		for (int64_t frame_number = requested_frame; frame_number < requested_frame + minimum_frames; frame_number++)
 		{
 			// Loop through clips
-			for (std::vector<Clip>::size_type clip_index = 0; clip_index < nearby_clips.size(); clip_index++)
+			for (auto clip : nearby_clips)
 			{
-				// Get clip object from the iterator
-				Clip *clip = nearby_clips[clip_index];
                 long clip_start_position = round(clip->Position() * info.fps.ToDouble()) + 1;
                 long clip_end_position = round((clip->Position() + clip->Duration()) * info.fps.ToDouble()) + 1;
 
@@ -832,10 +819,8 @@ std::shared_ptr<Frame> Timeline::GetFrame(int64_t requested_frame)
 				ZmqLogger::Instance()->AppendDebugMethod("Timeline::GetFrame (Loop through clips)", "frame_number", frame_number, "clips.size()", clips.size(), "nearby_clips.size()", nearby_clips.size());
 
 				// Find Clips near this time
-				for (std::vector<Clip>::size_type clip_index = 0; clip_index < nearby_clips.size(); clip_index++)
+				for (auto clip : nearby_clips)
 				{
-					// Get clip object from the iterator
-					Clip *clip = nearby_clips[clip_index];
                     long clip_start_position = round(clip->Position() * info.fps.ToDouble()) + 1;
                     long clip_end_position = round((clip->Position() + clip->Duration()) * info.fps.ToDouble()) + 1;
 
@@ -850,9 +835,8 @@ std::shared_ptr<Frame> Timeline::GetFrame(int64_t requested_frame)
 						// Determine if clip is "top" clip on this layer (only happens when multiple clips are overlapping)
 						bool is_top_clip = true;
 						float max_volume = 0.0;
-						for (std::vector<Clip>::size_type top_clip_index = 0; top_clip_index < nearby_clips.size(); top_clip_index++)
+						for (auto nearby_clip : nearby_clips)
 						{
-							Clip *nearby_clip = nearby_clips[top_clip_index];
                             long nearby_clip_start_position = round(nearby_clip->Position() * info.fps.ToDouble()) + 1;
                             long nearby_clip_end_position = round((nearby_clip->Position() + nearby_clip->Duration()) * info.fps.ToDouble()) + 1;
 							long nearby_clip_start_frame = (nearby_clip->Start() * info.fps.ToDouble()) + 1;
@@ -927,12 +911,8 @@ std::vector<Clip*> Timeline::find_intersecting_clips(int64_t requested_frame, in
 	sort_clips();
 
 	// Find Clips at this time
-	std::list<Clip*>::iterator clip_itr;
-	for (clip_itr=clips.begin(); clip_itr != clips.end(); ++clip_itr)
+	for (auto clip : clips)
 	{
-		// Get clip object from the iterator
-		Clip *clip = (*clip_itr);
-
 		// Does clip intersect the current requested time
 		long clip_start_position = round(clip->Position() * info.fps.ToDouble()) + 1;
 		long clip_end_position = round((clip->Position() + clip->Duration()) * info.fps.ToDouble()) + 1;
@@ -998,11 +978,8 @@ Json::Value Timeline::JsonValue() {
 	root["clips"] = Json::Value(Json::arrayValue);
 
 	// Find Clips at this time
-	std::list<Clip*>::iterator clip_itr;
-	for (clip_itr=clips.begin(); clip_itr != clips.end(); ++clip_itr)
+	for (auto existing_clip : clips)
 	{
-		// Get clip object from the iterator
-		Clip *existing_clip = (*clip_itr);
 		root["clips"].append(existing_clip->JsonValue());
 	}
 
@@ -1010,11 +987,8 @@ Json::Value Timeline::JsonValue() {
 	root["effects"] = Json::Value(Json::arrayValue);
 
 	// loop through effects
-	std::list<EffectBase*>::iterator effect_itr;
-	for (effect_itr=effects.begin(); effect_itr != effects.end(); ++effect_itr)
+	for (auto existing_effect: effects)
 	{
-		// Get clip object from the iterator
-		EffectBase *existing_effect = (*effect_itr);
 		root["effects"].append(existing_effect->JsonValue());
 	}
 
@@ -1069,10 +1043,7 @@ void Timeline::SetJsonValue(Json::Value root) {
 		clips.clear();
 
 		// loop through clips
-		for (Json::Value::ArrayIndex x = 0; x < root["clips"].size(); x++) {
-			// Get each clip
-			Json::Value existing_clip = root["clips"][x];
-
+		for (const Json::Value existing_clip : root["clips"]) {
 			// Create Clip
 			Clip *c = new Clip();
 
@@ -1089,10 +1060,7 @@ void Timeline::SetJsonValue(Json::Value root) {
 		effects.clear();
 
 		// loop through effects
-		for (Json::Value::ArrayIndex x = 0; x < root["effects"].size(); x++) {
-			// Get each effect
-			Json::Value existing_effect = root["effects"][x];
-
+		for (const Json::Value existing_effect :root["effects"]) {
 			// Create Effect
 			EffectBase *e = NULL;
 
@@ -1144,17 +1112,15 @@ void Timeline::ApplyJsonDiff(std::string value) {
 	try
 	{
 		// Process the JSON change array, loop through each item
-		for (Json::Value::ArrayIndex x = 0; x < root.size(); x++) {
-			// Get each change
-			Json::Value change = root[x];
-			std::string root_key = change["key"][(uint)0].asString();
+		for (const Json::Value change : root) {
+			std::string change_key = change["key"][(uint)0].asString();
 
 			// Process each type of change
-			if (root_key == "clips")
+			if (change_key == "clips")
 				// Apply to CLIPS
 				apply_json_to_clips(change);
 
-			else if (root_key == "effects")
+			else if (change_key == "effects")
 				// Apply to EFFECTS
 				apply_json_to_effects(change);
 
@@ -1180,10 +1146,8 @@ void Timeline::apply_json_to_clips(Json::Value change) {
 	Clip *existing_clip = NULL;
 
 	// Find id of clip (if any)
-	for (Json::Value::ArrayIndex x = 0; x < change["key"].size(); x++) {
+	for (auto key_part : change["key"]) {
 		// Get each change
-		Json::Value key_part = change["key"][x];
-
 		if (key_part.isObject()) {
 			// Check for id
 			if (!key_part["id"].isNull()) {
@@ -1191,11 +1155,8 @@ void Timeline::apply_json_to_clips(Json::Value change) {
 				clip_id = key_part["id"].asString();
 
 				// Find matching clip in timeline (if any)
-				std::list<Clip*>::iterator clip_itr;
-				for (clip_itr=clips.begin(); clip_itr != clips.end(); ++clip_itr)
+				for (auto c : clips)
 				{
-					// Get clip object from the iterator
-					Clip *c = (*clip_itr);
 					if (c->Id() == clip_id) {
 						existing_clip = c;
 						break; // clip found, exit loop
@@ -1222,11 +1183,8 @@ void Timeline::apply_json_to_clips(Json::Value change) {
 
 				// Find matching effect in timeline (if any)
 				std::list<EffectBase*> effect_list = existing_clip->Effects();
-				std::list<EffectBase*>::iterator effect_itr;
-				for (effect_itr=effect_list.begin(); effect_itr != effect_list.end(); ++effect_itr)
+				for (auto e : effect_list)
 				{
-					// Get effect object from the iterator
-					EffectBase *e = (*effect_itr);
 					if (e->Id() == effect_id) {
 						// Apply the change to the effect directly
 						apply_json_to_effects(change, e);
@@ -1308,9 +1266,7 @@ void Timeline::apply_json_to_effects(Json::Value change) {
 	EffectBase *existing_effect = NULL;
 
 	// Find id of an effect (if any)
-	for (Json::Value::ArrayIndex x = 0; x < change["key"].size(); x++) {
-		// Get each change
-		Json::Value key_part = change["key"][x];
+	for (auto key_part : change["key"]) {
 
 		if (key_part.isObject()) {
 			// Check for id
@@ -1320,11 +1276,8 @@ void Timeline::apply_json_to_effects(Json::Value change) {
 				std::string effect_id = key_part["id"].asString();
 
 				// Find matching effect in timeline (if any)
-				std::list<EffectBase*>::iterator effect_itr;
-				for (effect_itr=effects.begin(); effect_itr != effects.end(); ++effect_itr)
+				for (auto e : effects)
 				{
-					// Get effect object from the iterator
-					EffectBase *e = (*effect_itr);
 					if (e->Id() == effect_id) {
 						existing_effect = e;
 						break; // effect found, exit loop
@@ -1533,12 +1486,8 @@ void Timeline::ClearAllCache() {
     final_cache->Clear();
 
     // Loop through all clips
-    std::list<Clip*>::iterator clip_itr;
-    for (clip_itr=clips.begin(); clip_itr != clips.end(); ++clip_itr)
+    for (auto clip : clips)
     {
-        // Get clip object from the iterator
-        Clip *clip = (*clip_itr);
-
         // Clear cache on clip
         clip->Reader()->GetCache()->Clear();
 

--- a/src/effects/Wave.cpp
+++ b/src/effects/Wave.cpp
@@ -95,7 +95,7 @@ std::shared_ptr<Frame> Wave::GetFrame(std::shared_ptr<Frame> frame, int64_t fram
 		float waveformVal = sin((Y * wavelength_value) + (time * speed_y_value)); // Waveform algorithm on y-axis
 		float waveVal = (waveformVal + shift_x_value) * noiseAmp; // Shifts pixels on the x-axis
 
-		int source_X = round(pixel + waveVal) * 4;
+		long unsigned int source_X = round(pixel + waveVal) * 4;
 		if (source_X < 0)
 			source_X = 0;
 		if (source_X > frame_image->width() * frame_image->height() * 4 * sizeof(char))

--- a/tests/Cache_Tests.cpp
+++ b/tests/Cache_Tests.cpp
@@ -395,31 +395,31 @@ TEST(CacheDisk_JSON)
 	// Add some frames (out of order)
 	std::shared_ptr<Frame> f3(new Frame(3, 1280, 720, "Blue", 500, 2));
 	c.Add(f3);
-	CHECK_EQUAL(1, c.JsonValue()["ranges"].size());
+	CHECK_EQUAL(1, (int)c.JsonValue()["ranges"].size());
 	CHECK_EQUAL("1", c.JsonValue()["version"].asString());
 
 	// Add some frames (out of order)
 	std::shared_ptr<Frame> f1(new Frame(1, 1280, 720, "Blue", 500, 2));
 	c.Add(f1);
-	CHECK_EQUAL(2, c.JsonValue()["ranges"].size());
+	CHECK_EQUAL(2, (int)c.JsonValue()["ranges"].size());
 	CHECK_EQUAL("2", c.JsonValue()["version"].asString());
 
 	// Add some frames (out of order)
 	std::shared_ptr<Frame> f2(new Frame(2, 1280, 720, "Blue", 500, 2));
 	c.Add(f2);
-	CHECK_EQUAL(1, c.JsonValue()["ranges"].size());
+	CHECK_EQUAL(1, (int)c.JsonValue()["ranges"].size());
 	CHECK_EQUAL("3", c.JsonValue()["version"].asString());
 
 	// Add some frames (out of order)
 	std::shared_ptr<Frame> f5(new Frame(5, 1280, 720, "Blue", 500, 2));
 	c.Add(f5);
-	CHECK_EQUAL(2, c.JsonValue()["ranges"].size());
+	CHECK_EQUAL(2, (int)c.JsonValue()["ranges"].size());
 	CHECK_EQUAL("4", c.JsonValue()["version"].asString());
 
 	// Add some frames (out of order)
 	std::shared_ptr<Frame> f4(new Frame(4, 1280, 720, "Blue", 500, 2));
 	c.Add(f4);
-	CHECK_EQUAL(1, c.JsonValue()["ranges"].size());
+	CHECK_EQUAL(1, (int)c.JsonValue()["ranges"].size());
 	CHECK_EQUAL("5", c.JsonValue()["version"].asString());
 
 	// Delete cache directory
@@ -435,31 +435,31 @@ TEST(CacheMemory_JSON)
 	// Add some frames (out of order)
 	std::shared_ptr<Frame> f3(new Frame(3, 1280, 720, "Blue", 500, 2));
 	c.Add(f3);
-	CHECK_EQUAL(1, c.JsonValue()["ranges"].size());
+	CHECK_EQUAL(1, (int)c.JsonValue()["ranges"].size());
 	CHECK_EQUAL("1", c.JsonValue()["version"].asString());
 
 	// Add some frames (out of order)
 	std::shared_ptr<Frame> f1(new Frame(1, 1280, 720, "Blue", 500, 2));
 	c.Add(f1);
-	CHECK_EQUAL(2, c.JsonValue()["ranges"].size());
+	CHECK_EQUAL(2, (int)c.JsonValue()["ranges"].size());
 	CHECK_EQUAL("2", c.JsonValue()["version"].asString());
 
 	// Add some frames (out of order)
 	std::shared_ptr<Frame> f2(new Frame(2, 1280, 720, "Blue", 500, 2));
 	c.Add(f2);
-	CHECK_EQUAL(1, c.JsonValue()["ranges"].size());
+	CHECK_EQUAL(1, (int)c.JsonValue()["ranges"].size());
 	CHECK_EQUAL("3", c.JsonValue()["version"].asString());
 
 	// Add some frames (out of order)
 	std::shared_ptr<Frame> f5(new Frame(5, 1280, 720, "Blue", 500, 2));
 	c.Add(f5);
-	CHECK_EQUAL(2, c.JsonValue()["ranges"].size());
+	CHECK_EQUAL(2, (int)c.JsonValue()["ranges"].size());
 	CHECK_EQUAL("4", c.JsonValue()["version"].asString());
 
 	// Add some frames (out of order)
 	std::shared_ptr<Frame> f4(new Frame(4, 1280, 720, "Blue", 500, 2));
 	c.Add(f4);
-	CHECK_EQUAL(1, c.JsonValue()["ranges"].size());
+	CHECK_EQUAL(1, (int)c.JsonValue()["ranges"].size());
 	CHECK_EQUAL("5", c.JsonValue()["version"].asString());
 
 }

--- a/tests/Clip_Tests.cpp
+++ b/tests/Clip_Tests.cpp
@@ -241,7 +241,7 @@ TEST(Clip_Effects)
 	CHECK_EQUAL(255, (int)pixels[pixel_index + 3]);
 
 	// Check the # of Effects
-	CHECK_EQUAL(1, c10.Effects().size());
+	CHECK_EQUAL(1, (int)c10.Effects().size());
 
 
 	// Add a 2nd negate effect
@@ -262,5 +262,5 @@ TEST(Clip_Effects)
 	CHECK_EQUAL(255, (int)pixels[pixel_index + 3]);
 
 	// Check the # of Effects
-	CHECK_EQUAL(2, c10.Effects().size());
+	CHECK_EQUAL(2, (int)c10.Effects().size());
 }


### PR DESCRIPTION
A frequent cause of complaining from `gcc -Wall` is comparison between types with different signedness. For instance, both of these will produce a warning:

```c++
std::vector<openshot::Point> points = {};
for (int i = 0; i < points.size(); i++) {
  // stuff
}

Json::Value root = {};
for (int j = 0; j < root["clips"].size(); j++) {
  // json stuff
}
```

Fortunately, both are easily solved:
```c++
std::vector<openshot::Point> points = {};
for (std::vector<openshot::Point>::size_type i = 0; i < points.size(); i++) {
  // stuff
}

Json::Value root = {};
for (Json::Value::ArrayIndex j = 0; j < root["clips"].size(); j++) {
  // json stuff
}
```

This PR applies similar solutions to all comparisons which cause a warning to be emitted.
