### PR TITLE
Remove JUCE defines

### DIFF
--- a/include/AudioBufferSource.h
+++ b/include/AudioBufferSource.h
@@ -31,14 +31,6 @@
 #ifndef OPENSHOT_AUDIOBUFFERSOURCE_H
 #define OPENSHOT_AUDIOBUFFERSOURCE_H
 
-/// Do not include the juce unittest headers, because it collides with unittest++
-#define __JUCE_UNITTEST_JUCEHEADER__
-
-#ifndef _NDEBUG
-	/// Define NO debug for JUCE on mac os
-	#define _NDEBUG
-#endif
-
 #include <iomanip>
 #include "JuceHeader.h"
 

--- a/include/AudioReaderSource.h
+++ b/include/AudioReaderSource.h
@@ -31,14 +31,6 @@
 #ifndef OPENSHOT_AUDIOREADERSOURCE_H
 #define OPENSHOT_AUDIOREADERSOURCE_H
 
-/// Do not include the juce unittest headers, because it collides with unittest++
-#define __JUCE_UNITTEST_JUCEHEADER__
-
-#ifndef _NDEBUG
-	/// Define NO debug for JUCE on mac os
-	#define _NDEBUG
-#endif
-
 #include <iomanip>
 #include "ReaderBase.h"
 #include "JuceHeader.h"

--- a/include/AudioResampler.h
+++ b/include/AudioResampler.h
@@ -31,16 +31,6 @@
 #ifndef OPENSHOT_RESAMPLER_H
 #define OPENSHOT_RESAMPLER_H
 
-/// Do not include the juce unittest headers, because it collides with unittest++
-#ifndef __JUCE_UNITTEST_JUCEHEADER__
-	#define __JUCE_UNITTEST_JUCEHEADER__
-#endif
-
-#ifndef _NDEBUG
-	// Define NO debug for JUCE on mac os
-	#define _NDEBUG
-#endif
-
 #include "AudioBufferSource.h"
 #include "Exceptions.h"
 #include "JuceHeader.h"

--- a/include/Clip.h
+++ b/include/Clip.h
@@ -31,11 +31,6 @@
 #ifndef OPENSHOT_CLIP_H
 #define OPENSHOT_CLIP_H
 
-/// Do not include the juce unittest headers, because it collides with unittest++
-#ifndef __JUCE_UNITTEST_JUCEHEADER__
-	#define __JUCE_UNITTEST_JUCEHEADER__
-#endif
-
 #include <memory>
 #include <string>
 #include <QtGui/QImage>

--- a/include/ClipBase.h
+++ b/include/ClipBase.h
@@ -31,11 +31,6 @@
 #ifndef OPENSHOT_CLIPBASE_H
 #define OPENSHOT_CLIPBASE_H
 
-/// Do not include the juce unittest headers, because it collides with unittest++
-#ifndef __JUCE_UNITTEST_JUCEHEADER__
-	#define __JUCE_UNITTEST_JUCEHEADER__
-#endif
-
 #include <memory>
 #include <sstream>
 #include "Exceptions.h"

--- a/include/Frame.h
+++ b/include/Frame.h
@@ -31,15 +31,6 @@
 #ifndef OPENSHOT_FRAME_H
 #define OPENSHOT_FRAME_H
 
-/// Do not include the juce unittest headers, because it collides with unittest++
-#ifndef __JUCE_UNITTEST_JUCEHEADER__
-	#define __JUCE_UNITTEST_JUCEHEADER__
-#endif
-#ifndef _NDEBUG
-	// Define NO debug for JUCE on mac os
-	#define _NDEBUG
-#endif
-
 #include <iomanip>
 #include <sstream>
 #include <queue>


### PR DESCRIPTION
As I mentioned in #352, a few of libopenshot's headers contain `#define`s that were intended to work around issues with the JUCE library headers. But those things are best handled in other ways.

This PR removes forced defines for:
`__JUCE_UNITTEST_JUCEHEADER__`
`_NDEBUG`
