### PR TITLE
EffectBase: Remove unused short_name

### DIFF
--- a/include/EffectBase.h
+++ b/include/EffectBase.h
@@ -50,7 +50,6 @@ namespace openshot
 	struct EffectInfoStruct
 	{
 		std::string class_name; ///< The class name of the effect
-		std::string short_name; ///< A short name of the effect, commonly used for icon names, etc...
 		std::string name; ///< The name of the effect
 		std::string description; ///< The description of this effect and what it does
 		bool has_video;	///< Determines if this effect manipulates the image of a frame

--- a/src/EffectBase.cpp
+++ b/src/EffectBase.cpp
@@ -87,7 +87,6 @@ Json::Value EffectBase::JsonValue() {
 	Json::Value root = ClipBase::JsonValue(); // get parent properties
 	root["name"] = info.name;
 	root["class_name"] = info.class_name;
-	root["short_name"] = info.short_name;
 	root["description"] = info.description;
 	root["has_video"] = info.has_video;
 	root["has_audio"] = info.has_audio;
@@ -144,7 +143,6 @@ Json::Value EffectBase::JsonInfo() {
 	Json::Value root;
 	root["name"] = info.name;
 	root["class_name"] = info.class_name;
-	root["short_name"] = info.short_name;
 	root["description"] = info.description;
 	root["has_video"] = info.has_video;
 	root["has_audio"] = info.has_audio;


### PR DESCRIPTION
Not a single effect uses `info.short_name`, it is _always_ set to the empty string. And not a single consumer of the class or its derived classes (in either libopenshot or OpenShot) ever looks at it.