### PR TITLE
Skip painter transform for the Clip when video disabled

### DIFF
--- a/src/Timeline.cpp
+++ b/src/Timeline.cpp
@@ -379,8 +379,9 @@ void Timeline::add_layer(std::shared_ptr<Frame> new_frame, Clip* source_clip, in
 
 	}
 
-	// Skip out if only an audio frame
-	if (!source_clip->Waveform() && !source_clip->Reader()->info.has_video)
+	// Skip out if video was disabled or only an audio frame (no visualisation in use)
+	if (source_clip->has_video.GetInt(clip_frame_number) == 0 ||
+	    (!source_clip->Waveform() && !source_clip->Reader()->info.has_video))
 		// Skip the rest of the image processing for performance reasons
 		return;
 


### PR DESCRIPTION
Attempt to fix the: https://github.com/OpenShot/openshot-qt/issues/2882

**Edit:** as soon as PR was updated the info below is not actual anymore.

It is hard to read it as git differences/changed but I have added only:
```	// Clip that forced no video should has zero size output
	if (source_clip->has_video.GetInt(clip_frame_number) == 0) {
		source_size = QSize(0, 0);

		// Debug output
		ZmqLogger::Instance()->AppendDebugMethod("Timeline::add_layer (has_video = 0)", "source_frame->number", source_frame->number, "source_width", source_size.width(), "source_height", source_size.height());
	}
	else

```
before the `switch()`. I tried other formatting as well, but git changes still shown apart...