### PR TITLE
Behind-the-scenes code tidying for Json data handling

### DIFF
--- a/include/CacheBase.h
+++ b/include/CacheBase.h
@@ -110,9 +110,9 @@ namespace openshot {
 
 		/// Get and Set JSON methods
 		virtual std::string Json() = 0; ///< Generate JSON string of this object
-		virtual void SetJson(std::string value) = 0; ///< Load JSON string into this object
-		virtual Json::Value JsonValue() = 0; ///< Generate Json::JsonValue for this object
-		virtual void SetJsonValue(Json::Value root) = 0; ///< Load Json::JsonValue into this object
+		virtual void SetJson(const std::string value) = 0; ///< Load JSON string into this object
+		virtual Json::Value JsonValue() = 0; ///< Generate Json::Value for this object
+		virtual void SetJsonValue(const Json::Value root) = 0; ///< Load Json::Value into this object
 		virtual ~CacheBase() = default;
 
 	};

--- a/include/CacheDisk.h
+++ b/include/CacheDisk.h
@@ -129,9 +129,9 @@ namespace openshot {
 
 		/// Get and Set JSON methods
 		std::string Json(); ///< Generate JSON string of this object
-		void SetJson(std::string value); ///< Load JSON string into this object
-		Json::Value JsonValue(); ///< Generate Json::JsonValue for this object
-		void SetJsonValue(Json::Value root); ///< Load Json::JsonValue into this object
+		void SetJson(const std::string value); ///< Load JSON string into this object
+		Json::Value JsonValue(); ///< Generate Json::Value for this object
+		void SetJsonValue(const Json::Value root); ///< Load Json::Value into this object
 	};
 
 }

--- a/include/CacheMemory.h
+++ b/include/CacheMemory.h
@@ -111,9 +111,9 @@ namespace openshot {
 
 		/// Get and Set JSON methods
 		std::string Json(); ///< Generate JSON string of this object
-		void SetJson(std::string value); ///< Load JSON string into this object
-		Json::Value JsonValue(); ///< Generate Json::JsonValue for this object
-		void SetJsonValue(Json::Value root); ///< Load Json::JsonValue into this object
+		void SetJson(const std::string value); ///< Load JSON string into this object
+		Json::Value JsonValue(); ///< Generate Json::Value for this object
+		void SetJsonValue(const Json::Value root); ///< Load Json::Value into this object
 	};
 
 }

--- a/include/ChunkReader.h
+++ b/include/ChunkReader.h
@@ -157,10 +157,10 @@ namespace openshot
 		std::string Name() { return "ChunkReader"; };
 
 		/// Get and Set JSON methods
-		std::string Json(); ///< Generate JSON string of this object
-		void SetJson(std::string value); ///< Load JSON string into this object
-		Json::Value JsonValue(); ///< Generate Json::JsonValue for this object
-		void SetJsonValue(Json::Value root); ///< Load Json::JsonValue into this object
+		std::string Json() const override; ///< Generate JSON string of this object
+		void SetJson(const std::string value); ///< Load JSON string into this object
+		Json::Value JsonValue() const override; ///< Generate Json::Value for this object
+		void SetJsonValue(const Json::Value root); ///< Load Json::Value into this object
 
 		/// Open the reader. This is required before you can access frames or data from the reader.
 		void Open();

--- a/include/Clip.h
+++ b/include/Clip.h
@@ -192,18 +192,18 @@ namespace openshot {
 		openshot::ReaderBase* Reader();
 
 		/// Override End() method
-		float End(); ///< Get end position (in seconds) of clip (trim end of video), which can be affected by the time curve.
+		float End() const; ///< Get end position (in seconds) of clip (trim end of video), which can be affected by the time curve.
 		void End(float value) { end = value; } ///< Set end position (in seconds) of clip (trim end of video)
 
 		/// Get and Set JSON methods
-		std::string Json(); ///< Generate JSON string of this object
-		void SetJson(std::string value); ///< Load JSON string into this object
-		Json::Value JsonValue(); ///< Generate Json::JsonValue for this object
-		void SetJsonValue(Json::Value root); ///< Load Json::JsonValue into this object
+		std::string Json() const override; ///< Generate JSON string of this object
+		void SetJson(const std::string value); ///< Load JSON string into this object
+		Json::Value JsonValue() const override; ///< Generate Json::Value for this object
+		void SetJsonValue(const Json::Value root); ///< Load Json::Value into this object
 
 		/// Get all properties for a specific frame (perfect for a UI to display the current state
 		/// of all properties at any time)
-		std::string PropertiesJSON(int64_t requested_frame);
+		std::string PropertiesJSON(int64_t requested_frame) const override;
 
 		/// @brief Remove an effect from the clip
 		/// @param effect Remove an effect from the clip.

--- a/include/ClipBase.h
+++ b/include/ClipBase.h
@@ -61,10 +61,10 @@ namespace openshot {
 		std::string previous_properties; ///< This string contains the previous JSON properties
 
 		/// Generate JSON for a property
-		Json::Value add_property_json(std::string name, float value, std::string type, std::string memo, Keyframe* keyframe, float min_value, float max_value, bool readonly, int64_t requested_frame);
+		Json::Value add_property_json(std::string name, float value, std::string type, std::string memo, const Keyframe* keyframe, float min_value, float max_value, bool readonly, int64_t requested_frame) const;
 
 		/// Generate JSON choice for a property (dropdown properties)
-		Json::Value add_property_choice_json(std::string name, int value, int selected_value);
+		Json::Value add_property_choice_json(std::string name, int value, int selected_value) const;
 
 	public:
 
@@ -78,12 +78,12 @@ namespace openshot {
 		bool operator>= ( ClipBase& a) { return (Position() >= a.Position()); }
 
 		/// Get basic properties
-		std::string Id() { return id; } ///< Get the Id of this clip object
-		float Position() { return position; } ///< Get position on timeline (in seconds)
-		int Layer() { return layer; } ///< Get layer of clip on timeline (lower number is covered by higher numbers)
-		float Start() { return start; } ///< Get start position (in seconds) of clip (trim start of video)
-		float End() { return end; } ///< Get end position (in seconds) of clip (trim end of video)
-		float Duration() { return end - start; } ///< Get the length of this clip (in seconds)
+		std::string Id() const { return id; } ///< Get the Id of this clip object
+		float Position() const { return position; } ///< Get position on timeline (in seconds)
+		int Layer() const { return layer; } ///< Get layer of clip on timeline (lower number is covered by higher numbers)
+		float Start() const { return start; } ///< Get start position (in seconds) of clip (trim start of video)
+		float End() const { return end; } ///< Get end position (in seconds) of clip (trim end of video)
+		float Duration() const { return end - start; } ///< Get the length of this clip (in seconds)
 
 		/// Set basic properties
 		void Id(std::string value) { id = value; } ///> Set the Id of this clip object
@@ -93,14 +93,14 @@ namespace openshot {
 		void End(float value) { end = value; } ///< Set end position (in seconds) of clip (trim end of video)
 
 		/// Get and Set JSON methods
-		virtual std::string Json() = 0; ///< Generate JSON string of this object
-		virtual void SetJson(std::string value) = 0; ///< Load JSON string into this object
-		virtual Json::Value JsonValue() = 0; ///< Generate Json::JsonValue for this object
-		virtual void SetJsonValue(Json::Value root) = 0; ///< Load Json::JsonValue into this object
+		virtual std::string Json() const = 0; ///< Generate JSON string of this object
+		virtual void SetJson(const std::string value) = 0; ///< Load JSON string into this object
+		virtual Json::Value JsonValue() const = 0; ///< Generate Json::Value for this object
+		virtual void SetJsonValue(const Json::Value root) = 0; ///< Load Json::Value into this object
 
 		/// Get all properties for a specific frame (perfect for a UI to display the current state
 		/// of all properties at any time)
-		virtual std::string PropertiesJSON(int64_t requested_frame) = 0;
+		virtual std::string PropertiesJSON(int64_t requested_frame) const = 0;
 
 		virtual ~ClipBase() = default;
 	};

--- a/include/Color.h
+++ b/include/Color.h
@@ -69,10 +69,10 @@ namespace openshot {
 		static long GetDistance(long R1, long G1, long B1, long R2, long G2, long B2);
 
 		/// Get and Set JSON methods
-		std::string Json(); ///< Generate JSON string of this object
-		Json::Value JsonValue(); ///< Generate Json::JsonValue for this object
-		void SetJson(std::string value); ///< Load JSON string into this object
-		void SetJsonValue(Json::Value root); ///< Load Json::JsonValue into this object
+		std::string Json() const; ///< Generate JSON string of this object
+		Json::Value JsonValue() const; ///< Generate Json::Value for this object
+		void SetJson(const std::string value); ///< Load JSON string into this object
+		void SetJsonValue(const Json::Value root); ///< Load Json::Value into this object
 	};
 
 

--- a/include/Coordinate.h
+++ b/include/Coordinate.h
@@ -66,10 +66,10 @@ namespace openshot {
 		Coordinate(double x, double y);
 
 		/// Get and Set JSON methods
-		std::string Json(); ///< Generate JSON string of this object
-		Json::Value JsonValue(); ///< Generate Json::JsonValue for this object
-		void SetJson(std::string value); ///< Load JSON string into this object
-		void SetJsonValue(Json::Value root); ///< Load Json::JsonValue into this object
+		std::string Json() const; ///< Generate JSON string of this object
+		Json::Value JsonValue() const; ///< Generate Json::Value for this object
+		void SetJson(const std::string value); ///< Load JSON string into this object
+		void SetJsonValue(const Json::Value root); ///< Load Json::Value into this object
 	};
 
 }

--- a/include/DecklinkReader.h
+++ b/include/DecklinkReader.h
@@ -118,10 +118,10 @@ namespace openshot
 		std::string Name() { return "DecklinkReader"; };
 
 		/// Get and Set JSON methods
-		std::string Json(); ///< Generate JSON string of this object
-		void SetJson(std::string value); ///< Load JSON string into this object
-		Json::Value JsonValue(); ///< Generate Json::JsonValue for this object
-		void SetJsonValue(Json::Value root); ///< Load Json::JsonValue into this object
+		std::string Json() const override; ///< Generate JSON string of this object
+		void SetJson(const std::string value); ///< Load JSON string into this object
+		Json::Value JsonValue() const; ///< Generate Json::Value for this object
+		void SetJsonValue(const Json::Value root); ///< Load Json::Value into this object
 
 		/// Open device and video stream - which is called by the constructor automatically
 		void Open();

--- a/include/DummyReader.h
+++ b/include/DummyReader.h
@@ -87,10 +87,10 @@ namespace openshot
 		std::string Name() { return "DummyReader"; };
 
 		/// Get and Set JSON methods
-		std::string Json(); ///< Generate JSON string of this object
-		void SetJson(std::string value); ///< Load JSON string into this object
-		Json::Value JsonValue(); ///< Generate Json::JsonValue for this object
-		void SetJsonValue(Json::Value root); ///< Load Json::JsonValue into this object
+		std::string Json() const override; ///< Generate JSON string of this object
+		void SetJson(const std::string value); ///< Load JSON string into this object
+		Json::Value JsonValue() const override; ///< Generate Json::Value for this object
+		void SetJsonValue(const Json::Value root); ///< Load Json::Value into this object
 
 		/// Open File - which is called by the constructor automatically
 		void Open();

--- a/include/EffectBase.h
+++ b/include/EffectBase.h
@@ -95,14 +95,14 @@ namespace openshot
 		void InitEffectInfo();
 
 		/// Get and Set JSON methods
-		virtual std::string Json() = 0; ///< Generate JSON string of this object
-		virtual void SetJson(std::string value) = 0; ///< Load JSON string into this object
-		virtual Json::Value JsonValue() = 0; ///< Generate Json::JsonValue for this object
-		virtual void SetJsonValue(Json::Value root) = 0; ///< Load Json::JsonValue into this object
-		Json::Value JsonInfo(); ///< Generate JSON object of meta data / info
+		virtual std::string Json() const = 0; ///< Generate JSON string of this object
+		virtual void SetJson(const std::string value) = 0; ///< Load JSON string into this object
+		virtual Json::Value JsonValue() const = 0; ///< Generate Json::Value for this object
+		virtual void SetJsonValue(const Json::Value root) = 0; ///< Load Json::Value into this object
+		Json::Value JsonInfo() const; ///< Generate JSON object of meta data / info
 
 		/// Get the order that this effect should be executed.
-		int Order() { return order; }
+		int Order() const { return order; }
 
 		/// Set the order that this effect should be executed.
 		void Order(int new_order) { order = new_order; }

--- a/include/EffectInfo.h
+++ b/include/EffectInfo.h
@@ -51,7 +51,7 @@ namespace openshot
 
 		/// JSON methods
 		static std::string Json(); ///< Generate JSON string of this object
-		static Json::Value JsonValue(); ///< Generate Json::JsonValue for this object
+		static Json::Value JsonValue(); ///< Generate Json::Value for this object
 
 	};
 

--- a/include/FFmpegReader.h
+++ b/include/FFmpegReader.h
@@ -265,10 +265,10 @@ namespace openshot {
 		std::string Name() { return "FFmpegReader"; };
 
 		/// Get and Set JSON methods
-		std::string Json(); ///< Generate JSON string of this object
-		void SetJson(std::string value); ///< Load JSON string into this object
-		Json::Value JsonValue(); ///< Generate Json::JsonValue for this object
-		void SetJsonValue(Json::Value root); ///< Load Json::JsonValue into this object
+		std::string Json() const override; ///< Generate JSON string of this object
+		void SetJson(const std::string value); ///< Load JSON string into this object
+		Json::Value JsonValue() const override; ///< Generate Json::Value for this object
+		void SetJsonValue(const Json::Value root); ///< Load Json::Value into this object
 
 		/// Open File - which is called by the constructor automatically
 		void Open();

--- a/include/FrameMapper.h
+++ b/include/FrameMapper.h
@@ -199,10 +199,10 @@ namespace openshot
 		std::string Name() { return "FrameMapper"; };
 
 		/// Get and Set JSON methods
-		std::string Json(); ///< Generate JSON string of this object
-		void SetJson(std::string value); ///< Load JSON string into this object
-		Json::Value JsonValue(); ///< Generate Json::JsonValue for this object
-		void SetJsonValue(Json::Value root); ///< Load Json::JsonValue into this object
+		std::string Json() const override; ///< Generate JSON string of this object
+		void SetJson(const std::string value); ///< Load JSON string into this object
+		Json::Value JsonValue() const override; ///< Generate Json::Value for this object
+		void SetJsonValue(const Json::Value root); ///< Load Json::Value into this object
 
 		/// Open the internal reader
 		void Open();

--- a/include/ImageReader.h
+++ b/include/ImageReader.h
@@ -106,10 +106,10 @@ namespace openshot
 		std::string Name() { return "ImageReader"; };
 
 		/// Get and Set JSON methods
-		std::string Json(); ///< Generate JSON string of this object
-		void SetJson(std::string value); ///< Load JSON string into this object
-		Json::Value JsonValue(); ///< Generate Json::JsonValue for this object
-		void SetJsonValue(Json::Value root); ///< Load Json::JsonValue into this object
+		std::string Json() const override; ///< Generate JSON string of this object
+		void SetJson(const std::string value); ///< Load JSON string into this object
+		Json::Value JsonValue() const; ///< Generate Json::Value for this object
+		void SetJsonValue(const Json::Value root); ///< Load Json::Value into this object
 
 		/// Open File - which is called by the constructor automatically
 		void Open();

--- a/include/Json.h
+++ b/include/Json.h
@@ -31,6 +31,12 @@
 #ifndef OPENSHOT_JSON_H
 #define OPENSHOT_JSON_H
 
+#include <string>
 #include "json/json.h"
+#include "Exceptions.h"
+
+namespace openshot {
+    const Json::Value stringToJson(const std::string value);
+}
 
 #endif

--- a/include/KeyFrame.h
+++ b/include/KeyFrame.h
@@ -133,9 +133,9 @@ namespace openshot {
 
 		/// Get and Set JSON methods
 		std::string Json() const; ///< Generate JSON string of this object
-		Json::Value JsonValue() const; ///< Generate Json::JsonValue for this object
-		void SetJson(std::string value); ///< Load JSON string into this object
-		void SetJsonValue(Json::Value root); ///< Load Json::JsonValue into this object
+		Json::Value JsonValue() const; ///< Generate Json::Value for this object
+		void SetJson(const std::string value); ///< Load JSON string into this object
+		void SetJsonValue(const Json::Value root); ///< Load Json::Value into this object
 
 		/// Remove a point by matching a coordinate
 		void RemovePoint(Point p);

--- a/include/Point.h
+++ b/include/Point.h
@@ -119,10 +119,10 @@ namespace openshot
 		void Initialize_RightHandle(float x, float y);
 
 		/// Get and Set JSON methods
-		std::string Json(); ///< Generate JSON string of this object
-		Json::Value JsonValue(); ///< Generate Json::JsonValue for this object
-		void SetJson(std::string value); ///< Load JSON string into this object
-		void SetJsonValue(Json::Value root); ///< Load Json::JsonValue into this object
+		std::string Json() const; ///< Generate JSON string of this object
+		Json::Value JsonValue() const; ///< Generate Json::Value for this object
+		void SetJson(const std::string value); ///< Load JSON string into this object
+		void SetJsonValue(const Json::Value root); ///< Load Json::Value into this object
 
 	};
 

--- a/include/Profiles.h
+++ b/include/Profiles.h
@@ -90,10 +90,10 @@ namespace openshot
 		Profile(std::string path);
 
 		/// Get and Set JSON methods
-		std::string Json(); ///< Generate JSON string of this object
-		Json::Value JsonValue(); ///< Generate Json::JsonValue for this object
-		void SetJson(std::string value); ///< Load JSON string into this object
-		void SetJsonValue(Json::Value root); ///< Load Json::JsonValue into this object
+		std::string Json() const; ///< Generate JSON string of this object
+		Json::Value JsonValue() const; ///< Generate Json::Value for this object
+		void SetJson(const std::string value); ///< Load JSON string into this object
+		void SetJsonValue(const Json::Value root); ///< Load Json::Value into this object
 	};
 
 }

--- a/include/QtHtmlReader.h
+++ b/include/QtHtmlReader.h
@@ -131,10 +131,10 @@ namespace openshot
 		std::string Name() { return "QtHtmlReader"; };
 
 		/// Get and Set JSON methods
-		std::string Json(); ///< Generate JSON string of this object
-		void SetJson(std::string value); ///< Load JSON string into this object
-		Json::Value JsonValue(); ///< Generate Json::JsonValue for this object
-		void SetJsonValue(Json::Value root); ///< Load Json::JsonValue into this object
+		std::string Json() const override; ///< Generate JSON string of this object
+		void SetJson(const std::string value); ///< Load JSON string into this object
+		Json::Value JsonValue() const override; ///< Generate Json::Value for this object
+		void SetJsonValue(const Json::Value root); ///< Load Json::Value into this object
 
 		/// Open Reader - which is called by the constructor automatically
 		void Open();

--- a/include/QtImageReader.h
+++ b/include/QtImageReader.h
@@ -104,10 +104,10 @@ namespace openshot
 		std::string Name() { return "QtImageReader"; };
 
 		/// Get and Set JSON methods
-		std::string Json(); ///< Generate JSON string of this object
-		void SetJson(std::string value); ///< Load JSON string into this object
-		Json::Value JsonValue(); ///< Generate Json::JsonValue for this object
-		void SetJsonValue(Json::Value root); ///< Load Json::JsonValue into this object
+		std::string Json() const override; ///< Generate JSON string of this object
+		void SetJson(const std::string value); ///< Load JSON string into this object
+		Json::Value JsonValue() const override; ///< Generate Json::Value for this object
+		void SetJsonValue(const Json::Value root); ///< Load Json::Value into this object
 
 		/// Open File - which is called by the constructor automatically
 		void Open();

--- a/include/QtTextReader.h
+++ b/include/QtTextReader.h
@@ -142,10 +142,10 @@ namespace openshot
 		std::string Name() { return "QtTextReader"; };
 
 		/// Get and Set JSON methods
-		std::string Json(); ///< Generate JSON string of this object
-		void SetJson(std::string value); ///< Load JSON string into this object
-		Json::Value JsonValue(); ///< Generate Json::JsonValue for this object
-		void SetJsonValue(Json::Value root); ///< Load Json::JsonValue into this object
+		std::string Json() const override; ///< Generate JSON string of this object
+		void SetJson(const std::string value); ///< Load JSON string into this object
+		Json::Value JsonValue() const override; ///< Generate Json::Value for this object
+		void SetJsonValue(const Json::Value root); ///< Load Json::Value into this object
 
 		/// Open Reader - which is called by the constructor automatically
 		void Open();

--- a/include/ReaderBase.h
+++ b/include/ReaderBase.h
@@ -140,10 +140,10 @@ namespace openshot
 		virtual std::string Name() = 0;
 
 		/// Get and Set JSON methods
-		virtual std::string Json() = 0; ///< Generate JSON string of this object
-		virtual void SetJson(std::string value) = 0; ///< Load JSON string into this object
-		virtual Json::Value JsonValue() = 0; ///< Generate Json::JsonValue for this object
-		virtual void SetJsonValue(Json::Value root) = 0; ///< Load Json::JsonValue into this object
+		virtual std::string Json() const = 0; ///< Generate JSON string of this object
+		virtual void SetJson(const std::string value) = 0; ///< Load JSON string into this object
+		virtual Json::Value JsonValue() const = 0; ///< Generate Json::Value for this object
+		virtual void SetJsonValue(const Json::Value root) = 0; ///< Load Json::Value into this object
 
 		/// Open the reader (and start consuming resources, such as images or video files)
 		virtual void Open() = 0;

--- a/include/TextReader.h
+++ b/include/TextReader.h
@@ -142,10 +142,10 @@ namespace openshot
 		std::string Name() { return "TextReader"; };
 
 		/// Get and Set JSON methods
-		std::string Json(); ///< Generate JSON string of this object
-		void SetJson(std::string value); ///< Load JSON string into this object
-		Json::Value JsonValue(); ///< Generate Json::JsonValue for this object
-		void SetJsonValue(Json::Value root); ///< Load Json::JsonValue into this object
+		std::string Json() const override; ///< Generate JSON string of this object
+		void SetJson(const std::string value); ///< Load JSON string into this object
+		Json::Value JsonValue() const override; ///< Generate Json::Value for this object
+		void SetJsonValue(const Json::Value root); ///< Load Json::Value into this object
 
 		/// Open Reader - which is called by the constructor automatically
 		void Open();

--- a/include/Timeline.h
+++ b/include/Timeline.h
@@ -268,10 +268,10 @@ namespace openshot {
 		std::string Name() { return "Timeline"; };
 
 		/// Get and Set JSON methods
-		std::string Json(); ///< Generate JSON string of this object
-		void SetJson(std::string value); ///< Load JSON string into this object
-		Json::Value JsonValue(); ///< Generate Json::JsonValue for this object
-		void SetJsonValue(Json::Value root); ///< Load Json::JsonValue into this object
+		std::string Json() const override; ///< Generate JSON string of this object
+		void SetJson(const std::string value); ///< Load JSON string into this object
+		Json::Value JsonValue() const override; ///< Generate Json::Value for this object
+		void SetJsonValue(const Json::Value root); ///< Load Json::Value into this object
 
 		/// Set Max Image Size (used for performance optimization). Convenience function for setting
 		/// Settings::Instance()->MAX_WIDTH and Settings::Instance()->MAX_HEIGHT.

--- a/include/WriterBase.h
+++ b/include/WriterBase.h
@@ -107,10 +107,10 @@ namespace openshot
 		virtual void WriteFrame(openshot::ReaderBase* reader, int64_t start, int64_t length) = 0;
 
 		/// Get and Set JSON methods
-		std::string Json(); ///< Generate JSON string of this object
-		Json::Value JsonValue(); ///< Generate Json::JsonValue for this object
-		void SetJson(std::string value); ///< Load JSON string into this object
-		void SetJsonValue(Json::Value root); ///< Load Json::JsonValue into this object
+		std::string Json() const; ///< Generate JSON string of this object
+		Json::Value JsonValue() const; ///< Generate Json::Value for this object
+		void SetJson(const std::string value); ///< Load JSON string into this object
+		void SetJsonValue(const Json::Value root); ///< Load Json::Value into this object
 
 		/// Display file information in the standard output stream (stdout)
 		void DisplayInfo();

--- a/include/effects/Bars.h
+++ b/include/effects/Bars.h
@@ -89,14 +89,14 @@ namespace openshot
 		std::shared_ptr<Frame> GetFrame(std::shared_ptr<Frame> frame, int64_t frame_number);
 
 		/// Get and Set JSON methods
-		std::string Json(); ///< Generate JSON string of this object
-		void SetJson(std::string value); ///< Load JSON string into this object
-		Json::Value JsonValue(); ///< Generate Json::JsonValue for this object
-		void SetJsonValue(Json::Value root); ///< Load Json::JsonValue into this object
+		std::string Json() const override; ///< Generate JSON string of this object
+		void SetJson(const std::string value); ///< Load JSON string into this object
+		Json::Value JsonValue() const override; ///< Generate Json::Value for this object
+		void SetJsonValue(const Json::Value root); ///< Load Json::Value into this object
 
 		/// Get all properties for a specific frame (perfect for a UI to display the current state
 		/// of all properties at any time)
-		std::string PropertiesJSON(int64_t requested_frame);
+		std::string PropertiesJSON(int64_t requested_frame) const override;
 	};
 
 }

--- a/include/effects/Blur.h
+++ b/include/effects/Blur.h
@@ -102,14 +102,14 @@ namespace openshot
 		std::shared_ptr<Frame> GetFrame(std::shared_ptr<Frame> frame, int64_t frame_number);
 
 		/// Get and Set JSON methods
-		std::string Json(); ///< Generate JSON string of this object
-		void SetJson(std::string value); ///< Load JSON string into this object
-		Json::Value JsonValue(); ///< Generate Json::JsonValue for this object
-		void SetJsonValue(Json::Value root); ///< Load Json::JsonValue into this object
+		std::string Json() const override; ///< Generate JSON string of this object
+		void SetJson(const std::string value); ///< Load JSON string into this object
+		Json::Value JsonValue() const override; ///< Generate Json::Value for this object
+		void SetJsonValue(const Json::Value root); ///< Load Json::Value into this object
 
 		/// Get all properties for a specific frame (perfect for a UI to display the current state
 		/// of all properties at any time)
-		std::string PropertiesJSON(int64_t requested_frame);
+		std::string PropertiesJSON(int64_t requested_frame) const override;
 	};
 
 }

--- a/include/effects/Brightness.h
+++ b/include/effects/Brightness.h
@@ -89,14 +89,14 @@ namespace openshot
 		std::shared_ptr<Frame> GetFrame(std::shared_ptr<Frame> frame, int64_t frame_number);
 
 		/// Get and Set JSON methods
-		std::string Json(); ///< Generate JSON string of this object
-		void SetJson(std::string value); ///< Load JSON string into this object
-		Json::Value JsonValue(); ///< Generate Json::JsonValue for this object
-		void SetJsonValue(Json::Value root); ///< Load Json::JsonValue into this object
+		std::string Json() const override; ///< Generate JSON string of this object
+		void SetJson(const std::string value); ///< Load JSON string into this object
+		Json::Value JsonValue() const override; ///< Generate Json::Value for this object
+		void SetJsonValue(const Json::Value root); ///< Load Json::Value into this object
 
 		/// Get all properties for a specific frame (perfect for a UI to display the current state
 		/// of all properties at any time)
-		std::string PropertiesJSON(int64_t requested_frame);
+		std::string PropertiesJSON(int64_t requested_frame) const override;
 	};
 
 }

--- a/include/effects/ChromaKey.h
+++ b/include/effects/ChromaKey.h
@@ -86,13 +86,13 @@ namespace openshot
 		std::shared_ptr<Frame> GetFrame(std::shared_ptr<Frame> frame, int64_t frame_number);
 
 		/// Get and Set JSON methods
-		std::string Json(); ///< Generate JSON string of this object
-		void SetJson(std::string value); ///< Load JSON string into this object
-		Json::Value JsonValue(); ///< Generate Json::JsonValue for this object
-		void SetJsonValue(Json::Value root); ///< Load Json::JsonValue into this object
+		std::string Json() const override; ///< Generate JSON string of this object
+		void SetJson(const std::string value); ///< Load JSON string into this object
+		Json::Value JsonValue() const override; ///< Generate Json::Value for this object
+		void SetJsonValue(const Json::Value root); ///< Load Json::Value into this object
 
 		// Get all properties for a specific frame
-		std::string PropertiesJSON(int64_t requested_frame);
+		std::string PropertiesJSON(int64_t requested_frame) const override;
 	};
 
 }

--- a/include/effects/ColorShift.h
+++ b/include/effects/ColorShift.h
@@ -93,14 +93,14 @@ namespace openshot
 		std::shared_ptr<Frame> GetFrame(std::shared_ptr<Frame> frame, int64_t frame_number);
 
 		/// Get and Set JSON methods
-		std::string Json(); ///< Generate JSON string of this object
-		void SetJson(std::string value); ///< Load JSON string into this object
-		Json::Value JsonValue(); ///< Generate Json::JsonValue for this object
-		void SetJsonValue(Json::Value root); ///< Load Json::JsonValue into this object
+		std::string Json() const override; ///< Generate JSON string of this object
+		void SetJson(const std::string value); ///< Load JSON string into this object
+		Json::Value JsonValue() const override; ///< Generate Json::Value for this object
+		void SetJsonValue(const Json::Value root); ///< Load Json::Value into this object
 
 		/// Get all properties for a specific frame (perfect for a UI to display the current state
 		/// of all properties at any time)
-		std::string PropertiesJSON(int64_t requested_frame);
+		std::string PropertiesJSON(int64_t requested_frame) const override;
 	};
 
 }

--- a/include/effects/Crop.h
+++ b/include/effects/Crop.h
@@ -88,14 +88,14 @@ namespace openshot
 		std::shared_ptr<Frame> GetFrame(std::shared_ptr<Frame> frame, int64_t frame_number);
 
 		/// Get and Set JSON methods
-		std::string Json(); ///< Generate JSON string of this object
-		void SetJson(std::string value); ///< Load JSON string into this object
-		Json::Value JsonValue(); ///< Generate Json::JsonValue for this object
-		void SetJsonValue(Json::Value root); ///< Load Json::JsonValue into this object
+		std::string Json() const override; ///< Generate JSON string of this object
+		void SetJson(const std::string value); ///< Load JSON string into this object
+		Json::Value JsonValue() const override; ///< Generate Json::Value for this object
+		void SetJsonValue(const Json::Value root); ///< Load Json::Value into this object
 
 		/// Get all properties for a specific frame (perfect for a UI to display the current state
 		/// of all properties at any time)
-		std::string PropertiesJSON(int64_t requested_frame);
+		std::string PropertiesJSON(int64_t requested_frame) const override;
 	};
 
 }

--- a/include/effects/Deinterlace.h
+++ b/include/effects/Deinterlace.h
@@ -82,13 +82,13 @@ namespace openshot
 		std::shared_ptr<Frame> GetFrame(std::shared_ptr<Frame> frame, int64_t frame_number);
 
 		/// Get and Set JSON methods
-		std::string Json(); ///< Generate JSON string of this object
-		void SetJson(std::string value); ///< Load JSON string into this object
-		Json::Value JsonValue(); ///< Generate Json::JsonValue for this object
-		void SetJsonValue(Json::Value root); ///< Load Json::JsonValue into this object
+		std::string Json() const override; ///< Generate JSON string of this object
+		void SetJson(const std::string value); ///< Load JSON string into this object
+		Json::Value JsonValue() const override; ///< Generate Json::Value for this object
+		void SetJsonValue(const Json::Value root); ///< Load Json::Value into this object
 
 		// Get all properties for a specific frame
-		std::string PropertiesJSON(int64_t requested_frame);
+		std::string PropertiesJSON(int64_t requested_frame) const override;
 	};
 
 }

--- a/include/effects/Hue.h
+++ b/include/effects/Hue.h
@@ -79,14 +79,14 @@ namespace openshot
 		std::shared_ptr<Frame> GetFrame(std::shared_ptr<Frame> frame, int64_t frame_number);
 
 		/// Get and Set JSON methods
-		std::string Json(); ///< Generate JSON string of this object
-		void SetJson(std::string value); ///< Load JSON string into this object
-		Json::Value JsonValue(); ///< Generate Json::JsonValue for this object
-		void SetJsonValue(Json::Value root); ///< Load Json::JsonValue into this object
+		std::string Json() const override; ///< Generate JSON string of this object
+		void SetJson(const std::string value); ///< Load JSON string into this object
+		Json::Value JsonValue() const override; ///< Generate Json::Value for this object
+		void SetJsonValue(const Json::Value root); ///< Load Json::Value into this object
 
 		/// Get all properties for a specific frame (perfect for a UI to display the current state
 		/// of all properties at any time)
-		std::string PropertiesJSON(int64_t requested_frame);
+		std::string PropertiesJSON(int64_t requested_frame) const override;
 	};
 
 }

--- a/include/effects/Mask.h
+++ b/include/effects/Mask.h
@@ -101,14 +101,14 @@ namespace openshot
 		std::shared_ptr<Frame> GetFrame(std::shared_ptr<Frame> frame, int64_t frame_number);
 
 		/// Get and Set JSON methods
-		std::string Json(); ///< Generate JSON string of this object
-		void SetJson(std::string value); ///< Load JSON string into this object
-		Json::Value JsonValue(); ///< Generate Json::JsonValue for this object
-		void SetJsonValue(Json::Value root); ///< Load Json::JsonValue into this object
+		std::string Json() const override; ///< Generate JSON string of this object
+		void SetJson(const std::string value); ///< Load JSON string into this object
+		Json::Value JsonValue() const override; ///< Generate Json::Value for this object
+		void SetJsonValue(const Json::Value root); ///< Load Json::Value into this object
 
 		/// Get all properties for a specific frame (perfect for a UI to display the current state
 		/// of all properties at any time)
-		std::string PropertiesJSON(int64_t requested_frame);
+		std::string PropertiesJSON(int64_t requested_frame) const override;
 
 		/// Get the reader object of the mask grayscale image
 		ReaderBase* Reader() { return reader; };

--- a/include/effects/Negate.h
+++ b/include/effects/Negate.h
@@ -70,13 +70,13 @@ namespace openshot
 		std::shared_ptr<Frame> GetFrame(std::shared_ptr<Frame> frame, int64_t frame_number);
 
 		/// Get and Set JSON methods
-		std::string Json(); ///< Generate JSON string of this object
-		void SetJson(std::string value); ///< Load JSON string into this object
-		Json::Value JsonValue(); ///< Generate Json::JsonValue for this object
-		void SetJsonValue(Json::Value root); ///< Load Json::JsonValue into this object
+		std::string Json() const override; ///< Generate JSON string of this object
+		void SetJson(const std::string value); ///< Load JSON string into this object
+		Json::Value JsonValue() const override; ///< Generate Json::Value for this object
+		void SetJsonValue(const Json::Value root); ///< Load Json::Value into this object
 
 		// Get all properties for a specific frame
-		std::string PropertiesJSON(int64_t requested_frame);
+		std::string PropertiesJSON(int64_t requested_frame) const override;
 	};
 
 }

--- a/include/effects/Pixelate.h
+++ b/include/effects/Pixelate.h
@@ -88,14 +88,14 @@ namespace openshot
 		std::shared_ptr<Frame> GetFrame(std::shared_ptr<Frame> frame, int64_t frame_number);
 
 		/// Get and Set JSON methods
-		std::string Json(); ///< Generate JSON string of this object
-		void SetJson(std::string value); ///< Load JSON string into this object
-		Json::Value JsonValue(); ///< Generate Json::JsonValue for this object
-		void SetJsonValue(Json::Value root); ///< Load Json::JsonValue into this object
+		std::string Json() const override; ///< Generate JSON string of this object
+		void SetJson(const std::string value); ///< Load JSON string into this object
+		Json::Value JsonValue() const override; ///< Generate Json::Value for this object
+		void SetJsonValue(const Json::Value root); ///< Load Json::Value into this object
 
 		/// Get all properties for a specific frame (perfect for a UI to display the current state
 		/// of all properties at any time)
-		std::string PropertiesJSON(int64_t requested_frame);
+		std::string PropertiesJSON(int64_t requested_frame) const override;
 	};
 
 }

--- a/include/effects/Saturation.h
+++ b/include/effects/Saturation.h
@@ -86,14 +86,14 @@ namespace openshot
 		std::shared_ptr<Frame> GetFrame(std::shared_ptr<Frame> frame, int64_t frame_number);
 
 		/// Get and Set JSON methods
-		std::string Json(); ///< Generate JSON string of this object
-		void SetJson(std::string value); ///< Load JSON string into this object
-		Json::Value JsonValue(); ///< Generate Json::JsonValue for this object
-		void SetJsonValue(Json::Value root); ///< Load Json::JsonValue into this object
+		std::string Json() const override; ///< Generate JSON string of this object
+		void SetJson(const std::string value); ///< Load JSON string into this object
+		Json::Value JsonValue() const override; ///< Generate Json::Value for this object
+		void SetJsonValue(const Json::Value root); ///< Load Json::Value into this object
 
 		/// Get all properties for a specific frame (perfect for a UI to display the current state
 		/// of all properties at any time)
-		std::string PropertiesJSON(int64_t requested_frame);
+		std::string PropertiesJSON(int64_t requested_frame) const override;
 	};
 
 }

--- a/include/effects/Shift.h
+++ b/include/effects/Shift.h
@@ -82,14 +82,14 @@ namespace openshot
 		std::shared_ptr<Frame> GetFrame(std::shared_ptr<Frame> frame, int64_t frame_number);
 
 		/// Get and Set JSON methods
-		std::string Json(); ///< Generate JSON string of this object
-		void SetJson(std::string value); ///< Load JSON string into this object
-		Json::Value JsonValue(); ///< Generate Json::JsonValue for this object
-		void SetJsonValue(Json::Value root); ///< Load Json::JsonValue into this object
+		std::string Json() const override; ///< Generate JSON string of this object
+		void SetJson(const std::string value); ///< Load JSON string into this object
+		Json::Value JsonValue() const override; ///< Generate Json::Value for this object
+		void SetJsonValue(const Json::Value root); ///< Load Json::Value into this object
 
 		/// Get all properties for a specific frame (perfect for a UI to display the current state
 		/// of all properties at any time)
-		std::string PropertiesJSON(int64_t requested_frame);
+		std::string PropertiesJSON(int64_t requested_frame) const override;
 	};
 
 }

--- a/include/effects/Wave.h
+++ b/include/effects/Wave.h
@@ -88,14 +88,14 @@ namespace openshot
 		std::shared_ptr<Frame> GetFrame(std::shared_ptr<Frame> frame, int64_t frame_number);
 
 		/// Get and Set JSON methods
-		std::string Json(); ///< Generate JSON string of this object
-		void SetJson(std::string value); ///< Load JSON string into this object
-		Json::Value JsonValue(); ///< Generate Json::JsonValue for this object
-		void SetJsonValue(Json::Value root); ///< Load Json::JsonValue into this object
+		std::string Json() const override; ///< Generate JSON string of this object
+		void SetJson(const std::string value); ///< Load JSON string into this object
+		Json::Value JsonValue() const override; ///< Generate Json::Value for this object
+		void SetJsonValue(const Json::Value root); ///< Load Json::Value into this object
 
 		/// Get all properties for a specific frame (perfect for a UI to display the current state
 		/// of all properties at any time)
-		std::string PropertiesJSON(int64_t requested_frame);
+		std::string PropertiesJSON(int64_t requested_frame) const override;
 	};
 
 }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -164,6 +164,7 @@ set(OPENSHOT_SOURCES
   Fraction.cpp
   Frame.cpp
   FrameMapper.cpp
+	Json.cpp
   KeyFrame.cpp
   OpenShotVersion.cpp
   ZmqLogger.cpp

--- a/src/CacheBase.cpp
+++ b/src/CacheBase.cpp
@@ -53,7 +53,7 @@ void CacheBase::SetMaxBytesFromInfo(int64_t number_of_frames, int width, int hei
 	SetMaxBytes(bytes);
 }
 
-// Generate Json::JsonValue for this object
+// Generate Json::Value for this object
 Json::Value CacheBase::JsonValue() {
 
 	// Create root json object
@@ -66,8 +66,8 @@ Json::Value CacheBase::JsonValue() {
 	return root;
 }
 
-// Load Json::JsonValue into this object
-void CacheBase::SetJsonValue(Json::Value root) {
+// Load Json::Value into this object
+void CacheBase::SetJsonValue(const Json::Value root) {
 
 	// Set data from Json (if key is found)
 	if (!root["max_bytes"].isNull())

--- a/src/CacheDisk.cpp
+++ b/src/CacheDisk.cpp
@@ -116,12 +116,8 @@ void CacheDisk::CalculateRanges() {
 
 				// Add JSON object with start/end attributes
 				// Use strings, since int64_ts are supported in JSON
-				std::stringstream start_str;
-				start_str << starting_frame;
-				std::stringstream end_str;
-				end_str << ending_frame;
-				range["start"] = start_str.str();
-				range["end"] = end_str.str();
+				range["start"] = std::to_string(starting_frame);
+				range["end"] = std::to_string(ending_frame);
 				ranges.append(range);
 
 				// Set new starting range
@@ -137,12 +133,8 @@ void CacheDisk::CalculateRanges() {
 
 		// Add JSON object with start/end attributes
 		// Use strings, since int64_ts are supported in JSON
-		std::stringstream start_str;
-		start_str << starting_frame;
-		std::stringstream end_str;
-		end_str << ending_frame;
-		range["start"] = start_str.str();
-		range["end"] = end_str.str();
+		range["start"] = std::to_string(starting_frame);
+		range["end"] = std::to_string(ending_frame);
 		ranges.append(range);
 
 		// Cache range JSON as string
@@ -471,7 +463,7 @@ std::string CacheDisk::Json() {
 	return JsonValue().toStyledString();
 }
 
-// Generate Json::JsonValue for this object
+// Generate Json::Value for this object
 Json::Value CacheDisk::JsonValue() {
 
 	// Process range data (if anything has changed)
@@ -488,41 +480,23 @@ Json::Value CacheDisk::JsonValue() {
 	root["version"] = range_version_str.str();
 
 	// Parse and append range data (if any)
-	Json::Value ranges;
-	Json::CharReaderBuilder rbuilder;
-	Json::CharReader* reader(rbuilder.newCharReader());
-
-	std::string errors;
-	bool success = reader->parse( json_ranges.c_str(),
-	                 json_ranges.c_str() + json_ranges.size(), &ranges, &errors );
-	delete reader;
-
-	if (success)
+	// Parse and append range data (if any)
+	try {
+		const Json::Value ranges = openshot::stringToJson(json_ranges);
 		root["ranges"] = ranges;
+	} catch (...) { }
 
 	// return JsonValue
 	return root;
 }
 
 // Load JSON string into this object
-void CacheDisk::SetJson(std::string value) {
+void CacheDisk::SetJson(const std::string value) {
 
 	// Parse JSON string into JSON objects
-	Json::Value root;
-	Json::CharReaderBuilder rbuilder;
-	Json::CharReader* reader(rbuilder.newCharReader());
-
-	std::string errors;
-	bool success = reader->parse( value.c_str(),
-	               value.c_str() + value.size(), &root, &errors );
- 	delete reader;
-
-	if (!success)
-		// Raise exception
-		throw InvalidJSON("JSON could not be parsed (or is invalid)");
-
 	try
 	{
+		const Json::Value root = openshot::stringToJson(value);
 		// Set all values that match
 		SetJsonValue(root);
 	}
@@ -533,8 +507,8 @@ void CacheDisk::SetJson(std::string value) {
 	}
 }
 
-// Load Json::JsonValue into this object
-void CacheDisk::SetJsonValue(Json::Value root) {
+// Load Json::Value into this object
+void CacheDisk::SetJsonValue(const Json::Value root) {
 
 	// Close timeline before we do anything (this also removes all open and closing clips)
 	Clear();

--- a/src/CacheMemory.cpp
+++ b/src/CacheMemory.cpp
@@ -92,12 +92,8 @@ void CacheMemory::CalculateRanges() {
 
 				// Add JSON object with start/end attributes
 				// Use strings, since int64_ts are supported in JSON
-				std::stringstream start_str;
-				start_str << starting_frame;
-				std::stringstream end_str;
-				end_str << ending_frame;
-				range["start"] = start_str.str();
-				range["end"] = end_str.str();
+				range["start"] = std::to_string(starting_frame);
+				range["end"] = std::to_string(ending_frame);
 				ranges.append(range);
 
 				// Set new starting range
@@ -113,12 +109,8 @@ void CacheMemory::CalculateRanges() {
 
 		// Add JSON object with start/end attributes
 		// Use strings, since int64_ts are not supported in JSON
-		std::stringstream start_str;
-		start_str << starting_frame;
-		std::stringstream end_str;
-		end_str << ending_frame;
-		range["start"] = start_str.str();
-		range["end"] = end_str.str();
+		range["start"] = std::to_string(starting_frame);
+		range["end"] = std::to_string(ending_frame);
 		ranges.append(range);
 
 		// Cache range JSON as string
@@ -327,7 +319,7 @@ std::string CacheMemory::Json() {
 	return JsonValue().toStyledString();
 }
 
-// Generate Json::JsonValue for this object
+// Generate Json::Value for this object
 Json::Value CacheMemory::JsonValue() {
 
 	// Process range data (if anything has changed)
@@ -337,45 +329,25 @@ Json::Value CacheMemory::JsonValue() {
 	Json::Value root = CacheBase::JsonValue(); // get parent properties
 	root["type"] = cache_type;
 
-	std::stringstream range_version_str;
-	range_version_str << range_version;
-	root["version"] = range_version_str.str();
+	root["version"] = std::to_string(range_version);
 
 	// Parse and append range data (if any)
-	Json::Value ranges;
-	Json::CharReaderBuilder rbuilder;
-	Json::CharReader* reader(rbuilder.newCharReader());
-
-	std::string errors;
-	bool success = reader->parse( json_ranges.c_str(),
-	                 json_ranges.c_str() + json_ranges.size(), &ranges, &errors );
-	delete reader;
-
-	if (success)
+	try {
+		const Json::Value ranges = openshot::stringToJson(json_ranges);
 		root["ranges"] = ranges;
+	} catch (...) { }
 
 	// return JsonValue
 	return root;
 }
 
 // Load JSON string into this object
-void CacheMemory::SetJson(std::string value) {
-
-	// Parse JSON string into JSON objects
-	Json::Value root;
-	Json::CharReaderBuilder rbuilder;
-	Json::CharReader* reader(rbuilder.newCharReader());
-
-	std::string errors;
-	bool success = reader->parse( value.c_str(),
-                 value.c_str() + value.size(), &root, &errors );
-	delete reader;
-	if (!success)
-		// Raise exception
-		throw InvalidJSON("JSON could not be parsed (or is invalid)");
+void CacheMemory::SetJson(const std::string value) {
 
 	try
 	{
+		// Parse string to Json::Value
+		const Json::Value root = openshot::stringToJson(value);
 		// Set all values that match
 		SetJsonValue(root);
 	}
@@ -386,8 +358,8 @@ void CacheMemory::SetJson(std::string value) {
 	}
 }
 
-// Load Json::JsonValue into this object
-void CacheMemory::SetJsonValue(Json::Value root) {
+// Load Json::Value into this object
+void CacheMemory::SetJsonValue(const Json::Value root) {
 
 	// Close timeline before we do anything (this also removes all open and closing clips)
 	Clear();

--- a/src/ChunkReader.cpp
+++ b/src/ChunkReader.cpp
@@ -256,14 +256,14 @@ std::shared_ptr<Frame> ChunkReader::GetFrame(int64_t requested_frame)
 }
 
 // Generate JSON string of this object
-std::string ChunkReader::Json() {
+std::string ChunkReader::Json() const {
 
 	// Return formatted string
 	return JsonValue().toStyledString();
 }
 
-// Generate Json::JsonValue for this object
-Json::Value ChunkReader::JsonValue() {
+// Generate Json::Value for this object
+Json::Value ChunkReader::JsonValue() const {
 
 	// Create root json object
 	Json::Value root = ReaderBase::JsonValue(); // get parent properties
@@ -279,23 +279,11 @@ Json::Value ChunkReader::JsonValue() {
 }
 
 // Load JSON string into this object
-void ChunkReader::SetJson(std::string value) {
-
-	// Parse JSON string into JSON objects
-	Json::Value root;
-	Json::CharReaderBuilder rbuilder;
-	Json::CharReader* reader(rbuilder.newCharReader());
-
-	std::string errors;
-	bool success = reader->parse( value.c_str(),
-	                 value.c_str() + value.size(), &root, &errors );
-	delete reader;
-	if (!success)
-		// Raise exception
-		throw InvalidJSON("JSON could not be parsed (or is invalid)");
+void ChunkReader::SetJson(const std::string value) {
 
 	try
 	{
+		const Json::Value root = openshot::stringToJson(value);
 		// Set all values that match
 		SetJsonValue(root);
 	}
@@ -306,8 +294,8 @@ void ChunkReader::SetJson(std::string value) {
 	}
 }
 
-// Load Json::JsonValue into this object
-void ChunkReader::SetJsonValue(Json::Value root) {
+// Load Json::Value into this object
+void ChunkReader::SetJsonValue(const Json::Value root) {
 
 	// Set parent data
 	ReaderBase::SetJsonValue(root);

--- a/src/Clip.cpp
+++ b/src/Clip.cpp
@@ -270,7 +270,7 @@ void Clip::Close()
 }
 
 // Get end position of clip (trim end of video), which can be affected by the time curve.
-float Clip::End()
+float Clip::End() const
 {
 	// if a time curve is present, use its length
 	if (time.GetCount() > 1)
@@ -645,14 +645,14 @@ std::shared_ptr<Frame> Clip::GetOrCreateFrame(int64_t number)
 }
 
 // Generate JSON string of this object
-std::string Clip::Json() {
+std::string Clip::Json() const {
 
 	// Return formatted string
 	return JsonValue().toStyledString();
 }
 
 // Get all properties for a specific frame
-std::string Clip::PropertiesJSON(int64_t requested_frame) {
+std::string Clip::PropertiesJSON(int64_t requested_frame) const {
 
 	// Generate JSON properties list
 	Json::Value root;
@@ -739,8 +739,8 @@ std::string Clip::PropertiesJSON(int64_t requested_frame) {
 	return root.toStyledString();
 }
 
-// Generate Json::JsonValue for this object
-Json::Value Clip::JsonValue() {
+// Generate Json::Value for this object
+Json::Value Clip::JsonValue() const {
 
 	// Create root json object
 	Json::Value root = ClipBase::JsonValue(); // get parent properties
@@ -782,7 +782,7 @@ Json::Value Clip::JsonValue() {
 	root["effects"] = Json::Value(Json::arrayValue);
 
 	// loop through effects
-	std::list<EffectBase*>::iterator effect_itr;
+	std::list<EffectBase*>::const_iterator effect_itr;
 	for (effect_itr=effects.begin(); effect_itr != effects.end(); ++effect_itr)
 	{
 		// Get clip object from the iterator
@@ -798,24 +798,12 @@ Json::Value Clip::JsonValue() {
 }
 
 // Load JSON string into this object
-void Clip::SetJson(std::string value) {
+void Clip::SetJson(const std::string value) {
 
 	// Parse JSON string into JSON objects
-	Json::Value root;
-	Json::CharReaderBuilder rbuilder;
-	Json::CharReader* reader(rbuilder.newCharReader());
-
-	std::string errors;
-	bool success = reader->parse( value.c_str(),
-                 value.c_str() + value.size(), &root, &errors );
-	delete reader;
-
-	if (!success)
-		// Raise exception
-		throw InvalidJSON("JSON could not be parsed (or is invalid)");
-
 	try
 	{
+		const Json::Value root = openshot::stringToJson(value);
 		// Set all values that match
 		SetJsonValue(root);
 	}
@@ -826,8 +814,8 @@ void Clip::SetJson(std::string value) {
 	}
 }
 
-// Load Json::JsonValue into this object
-void Clip::SetJsonValue(Json::Value root) {
+// Load Json::Value into this object
+void Clip::SetJsonValue(const Json::Value root) {
 
 	// Set parent data
 	ClipBase::SetJsonValue(root);

--- a/src/ClipBase.cpp
+++ b/src/ClipBase.cpp
@@ -32,8 +32,8 @@
 
 using namespace openshot;
 
-// Generate Json::JsonValue for this object
-Json::Value ClipBase::JsonValue() {
+// Generate Json::Value for this object
+Json::Value ClipBase::JsonValue() const {
 
 	// Create root json object
 	Json::Value root;
@@ -48,8 +48,8 @@ Json::Value ClipBase::JsonValue() {
 	return root;
 }
 
-// Load Json::JsonValue into this object
-void ClipBase::SetJsonValue(Json::Value root) {
+// Load Json::Value into this object
+void ClipBase::SetJsonValue(const Json::Value root) {
 
 	// Set data from Json (if key is found)
 	if (!root["id"].isNull())
@@ -65,10 +65,10 @@ void ClipBase::SetJsonValue(Json::Value root) {
 }
 
 // Generate JSON for a property
-Json::Value ClipBase::add_property_json(std::string name, float value, std::string type, std::string memo, Keyframe* keyframe, float min_value, float max_value, bool readonly, int64_t requested_frame) {
+Json::Value ClipBase::add_property_json(std::string name, float value, std::string type, std::string memo, const Keyframe* keyframe, float min_value, float max_value, bool readonly, int64_t requested_frame) const {
 
 	// Requested Point
-	Point requested_point(requested_frame, requested_frame);
+	const Point requested_point(requested_frame, requested_frame);
 
 	// Create JSON Object
 	Json::Value prop = Json::Value(Json::objectValue);
@@ -101,7 +101,7 @@ Json::Value ClipBase::add_property_json(std::string name, float value, std::stri
 	return prop;
 }
 
-Json::Value ClipBase::add_property_choice_json(std::string name, int value, int selected_value) {
+Json::Value ClipBase::add_property_choice_json(std::string name, int value, int selected_value) const {
 
 	// Create choice
 	Json::Value new_choice = Json::Value(Json::objectValue);

--- a/src/Color.cpp
+++ b/src/Color.cpp
@@ -85,14 +85,14 @@ long Color::GetDistance(long R1, long G1, long B1, long R2, long G2, long B2)
 }
 
 // Generate JSON string of this object
-std::string Color::Json() {
+std::string Color::Json() const {
 
 	// Return formatted string
 	return JsonValue().toStyledString();
 }
 
-// Generate Json::JsonValue for this object
-Json::Value Color::JsonValue() {
+// Generate Json::Value for this object
+Json::Value Color::JsonValue() const {
 
 	// Create root json object
 	Json::Value root;
@@ -106,24 +106,12 @@ Json::Value Color::JsonValue() {
 }
 
 // Load JSON string into this object
-void Color::SetJson(std::string value) {
+void Color::SetJson(const std::string value) {
 
 	// Parse JSON string into JSON objects
-	Json::Value root;
-	Json::CharReaderBuilder rbuilder;
-	Json::CharReader* reader(rbuilder.newCharReader());
-
-	std::string errors;
-	bool success = reader->parse( value.c_str(),
-	                 value.c_str() + value.size(), &root, &errors );
-	 delete reader;
-
-	if (!success)
-		// Raise exception
-		throw InvalidJSON("JSON could not be parsed (or is invalid)");
-
 	try
 	{
+		const Json::Value root = openshot::stringToJson(value);
 		// Set all values that match
 		SetJsonValue(root);
 	}
@@ -134,8 +122,8 @@ void Color::SetJson(std::string value) {
 	}
 }
 
-// Load Json::JsonValue into this object
-void Color::SetJsonValue(Json::Value root) {
+// Load Json::Value into this object
+void Color::SetJsonValue(const Json::Value root) {
 
 	// Set data from Json (if key is found)
 	if (!root["red"].isNull())

--- a/src/Coordinate.cpp
+++ b/src/Coordinate.cpp
@@ -45,14 +45,14 @@ Coordinate::Coordinate(double x, double y) :
 
 
 // Generate JSON string of this object
-std::string Coordinate::Json() {
+std::string Coordinate::Json() const {
 
 	// Return formatted string
 	return JsonValue().toStyledString();
 }
 
-// Generate Json::JsonValue for this object
-Json::Value Coordinate::JsonValue() {
+// Generate Json::Value for this object
+Json::Value Coordinate::JsonValue() const {
 
 	// Create root json object
 	Json::Value root;
@@ -69,24 +69,12 @@ Json::Value Coordinate::JsonValue() {
 }
 
 // Load JSON string into this object
-void Coordinate::SetJson(std::string value) {
+void Coordinate::SetJson(const std::string value) {
 
 	// Parse JSON string into JSON objects
-	Json::Value root;
-	Json::CharReaderBuilder rbuilder;
-	Json::CharReader* reader(rbuilder.newCharReader());
-
-	std::string errors;
-	bool success = reader->parse( value.c_str(),
-                 value.c_str() + value.size(), &root, &errors );
-	delete reader;
-
-	if (!success)
-		// Raise exception
-		throw InvalidJSON("JSON could not be parsed (or is invalid)");
-
 	try
 	{
+		const Json::Value root = openshot::stringToJson(value);
 		// Set all values that match
 		SetJsonValue(root);
 	}
@@ -97,8 +85,8 @@ void Coordinate::SetJson(std::string value) {
 	}
 }
 
-// Load Json::JsonValue into this object
-void Coordinate::SetJsonValue(Json::Value root) {
+// Load Json::Value into this object
+void Coordinate::SetJsonValue(const Json::Value root) {
 
 	// Set data from Json (if key is found)
 	if (!root["X"].isNull())

--- a/src/DecklinkReader.cpp
+++ b/src/DecklinkReader.cpp
@@ -246,14 +246,14 @@ std::shared_ptr<Frame> DecklinkReader::GetFrame(int64_t requested_frame)
 
 
 // Generate JSON string of this object
-std::string DecklinkReader::Json() {
+std::string DecklinkReader::Json() const {
 
 	// Return formatted string
 	return JsonValue().toStyledString();
 }
 
-// Generate Json::JsonValue for this object
-Json::Value DecklinkReader::JsonValue() {
+// Generate Json::Value for this object
+Json::Value DecklinkReader::JsonValue() const {
 
 	// Create root json object
 	Json::Value root = ReaderBase::JsonValue(); // get parent properties
@@ -264,24 +264,12 @@ Json::Value DecklinkReader::JsonValue() {
 }
 
 // Load JSON string into this object
-void DecklinkReader::SetJson(std::string value) {
+void DecklinkReader::SetJson(const std::string value) {
 
 	// Parse JSON string into JSON objects
-	Json::Value root;
-	Json::CharReaderBuilder rbuilder;
-	Json::CharReader* reader(rbuilder.newCharReader());
-
-	std::string errors;
-	bool success = reader->parse( value.c_str(),
-                 value.c_str() + value.size(), &root, &errors );
-	delete reader;
-
-	if (!success)
-		// Raise exception
-		throw InvalidJSON("JSON could not be parsed (or is invalid)");
-
 	try
 	{
+		const Json::Value root = openshot::stringToJson(value);
 		// Set all values that match
 		SetJsonValue(root);
 	}
@@ -292,8 +280,8 @@ void DecklinkReader::SetJson(std::string value) {
 	}
 }
 
-// Load Json::JsonValue into this object
-void DecklinkReader::SetJsonValue(Json::Value root) {
+// Load Json::Value into this object
+void DecklinkReader::SetJsonValue(const Json::Value root) {
 
 	// Set parent data
 	ReaderBase::SetJsonValue(root);

--- a/src/DummyReader.cpp
+++ b/src/DummyReader.cpp
@@ -124,14 +124,14 @@ std::shared_ptr<Frame> DummyReader::GetFrame(int64_t requested_frame)
 }
 
 // Generate JSON string of this object
-std::string DummyReader::Json() {
+std::string DummyReader::Json() const {
 
 	// Return formatted string
 	return JsonValue().toStyledString();
 }
 
-// Generate Json::JsonValue for this object
-Json::Value DummyReader::JsonValue() {
+// Generate Json::Value for this object
+Json::Value DummyReader::JsonValue() const {
 
 	// Create root json object
 	Json::Value root = ReaderBase::JsonValue(); // get parent properties
@@ -142,24 +142,12 @@ Json::Value DummyReader::JsonValue() {
 }
 
 // Load JSON string into this object
-void DummyReader::SetJson(std::string value) {
+void DummyReader::SetJson(const std::string value) {
 
 	// Parse JSON string into JSON objects
-	Json::Value root;
-	Json::CharReaderBuilder rbuilder;
-	Json::CharReader* reader(rbuilder.newCharReader());
-
-	std::string errors;
-	bool success = reader->parse( value.c_str(),
-                 value.c_str() + value.size(), &root, &errors );
-	delete reader;
-
-	if (!success)
-		// Raise exception
-		throw InvalidJSON("JSON could not be parsed (or is invalid)");
-
 	try
 	{
+		const Json::Value root = openshot::stringToJson(value);
 		// Set all values that match
 		SetJsonValue(root);
 	}
@@ -170,8 +158,8 @@ void DummyReader::SetJson(std::string value) {
 	}
 }
 
-// Load Json::JsonValue into this object
-void DummyReader::SetJsonValue(Json::Value root) {
+// Load Json::Value into this object
+void DummyReader::SetJsonValue(const Json::Value root) {
 
 	// Set parent data
 	ReaderBase::SetJsonValue(root);

--- a/src/EffectBase.cpp
+++ b/src/EffectBase.cpp
@@ -74,14 +74,14 @@ int EffectBase::constrain(int color_value)
 }
 
 // Generate JSON string of this object
-std::string EffectBase::Json() {
+std::string EffectBase::Json() const {
 
 	// Return formatted string
 	return JsonValue().toStyledString();
 }
 
-// Generate Json::JsonValue for this object
-Json::Value EffectBase::JsonValue() {
+// Generate Json::Value for this object
+Json::Value EffectBase::JsonValue() const {
 
 	// Create root json object
 	Json::Value root = ClipBase::JsonValue(); // get parent properties
@@ -98,24 +98,12 @@ Json::Value EffectBase::JsonValue() {
 }
 
 // Load JSON string into this object
-void EffectBase::SetJson(std::string value) {
+void EffectBase::SetJson(const std::string value) {
 
 	// Parse JSON string into JSON objects
-	Json::Value root;
-	Json::CharReaderBuilder rbuilder;
-	Json::CharReader* reader(rbuilder.newCharReader());
-
-	std::string errors;
-	bool success = reader->parse( value.c_str(),
-                 value.c_str() + value.size(), &root, &errors );
-	delete reader;
-
-	if (!success)
-		// Raise exception
-		throw InvalidJSON("JSON could not be parsed (or is invalid)");
-
 	try
 	{
+		const Json::Value root = openshot::stringToJson(value);
 		// Set all values that match
 		SetJsonValue(root);
 	}
@@ -126,8 +114,8 @@ void EffectBase::SetJson(std::string value) {
 	}
 }
 
-// Load Json::JsonValue into this object
-void EffectBase::SetJsonValue(Json::Value root) {
+// Load Json::Value into this object
+void EffectBase::SetJsonValue(const Json::Value root) {
 
 	// Set parent data
 	ClipBase::SetJsonValue(root);
@@ -137,8 +125,8 @@ void EffectBase::SetJsonValue(Json::Value root) {
 		Order(root["order"].asInt());
 }
 
-// Generate Json::JsonValue for this object
-Json::Value EffectBase::JsonInfo() {
+// Generate Json::Value for this object
+Json::Value EffectBase::JsonInfo() const {
 
 	// Create root json object
 	Json::Value root;

--- a/src/EffectInfo.cpp
+++ b/src/EffectInfo.cpp
@@ -88,7 +88,7 @@ EffectBase* EffectInfo::CreateEffect(std::string effect_type) {
 	return NULL;
 }
 
-// Generate Json::JsonValue for this object
+// Generate Json::Value for this object
 Json::Value EffectInfo::JsonValue() {
 
 	// Create root json object

--- a/src/FFmpegReader.cpp
+++ b/src/FFmpegReader.cpp
@@ -2424,14 +2424,14 @@ int64_t FFmpegReader::GetSmallestAudioFrame() {
 }
 
 // Generate JSON string of this object
-std::string FFmpegReader::Json() {
+std::string FFmpegReader::Json() const {
 
 	// Return formatted string
 	return JsonValue().toStyledString();
 }
 
-// Generate Json::JsonValue for this object
-Json::Value FFmpegReader::JsonValue() {
+// Generate Json::Value for this object
+Json::Value FFmpegReader::JsonValue() const {
 
 	// Create root json object
 	Json::Value root = ReaderBase::JsonValue(); // get parent properties
@@ -2443,23 +2443,11 @@ Json::Value FFmpegReader::JsonValue() {
 }
 
 // Load JSON string into this object
-void FFmpegReader::SetJson(std::string value) {
+void FFmpegReader::SetJson(const std::string value) {
 
 	// Parse JSON string into JSON objects
-	Json::Value root;
-	Json::CharReaderBuilder rbuilder;
-	Json::CharReader* reader(rbuilder.newCharReader());
-
-	std::string errors;
-	bool success = reader->parse(value.c_str(), value.c_str() + value.size(),
-	                 &root, &errors);
-	delete reader;
-
-	if (!success)
-		// Raise exception
-		throw InvalidJSON("JSON could not be parsed (or is invalid)");
-
 	try {
+		const Json::Value root = openshot::stringToJson(value);
 		// Set all values that match
 		SetJsonValue(root);
 	}
@@ -2469,8 +2457,8 @@ void FFmpegReader::SetJson(std::string value) {
 	}
 }
 
-// Load Json::JsonValue into this object
-void FFmpegReader::SetJsonValue(Json::Value root) {
+// Load Json::Value into this object
+void FFmpegReader::SetJsonValue(const Json::Value root) {
 
 	// Set parent data
 	ReaderBase::SetJsonValue(root);

--- a/src/FrameMapper.cpp
+++ b/src/FrameMapper.cpp
@@ -675,14 +675,14 @@ void FrameMapper::Close()
 
 
 // Generate JSON string of this object
-std::string FrameMapper::Json() {
+std::string FrameMapper::Json() const {
 
 	// Return formatted string
 	return JsonValue().toStyledString();
 }
 
-// Generate Json::JsonValue for this object
-Json::Value FrameMapper::JsonValue() {
+// Generate Json::Value for this object
+Json::Value FrameMapper::JsonValue() const {
 
 	// Create root json object
 	Json::Value root = ReaderBase::JsonValue(); // get parent properties
@@ -693,24 +693,12 @@ Json::Value FrameMapper::JsonValue() {
 }
 
 // Load JSON string into this object
-void FrameMapper::SetJson(std::string value) {
+void FrameMapper::SetJson(const std::string value) {
 
 	// Parse JSON string into JSON objects
-	Json::Value root;
-	Json::CharReaderBuilder rbuilder;
-	Json::CharReader* reader(rbuilder.newCharReader());
-
-	std::string errors;
-	bool success = reader->parse( value.c_str(),
-                 value.c_str() + value.size(), &root, &errors );
-	delete reader;
-
-	if (!success)
-		// Raise exception
-		throw InvalidJSON("JSON could not be parsed (or is invalid)");
-
 	try
 	{
+		const Json::Value root = openshot::stringToJson(value);
 		// Set all values that match
 		SetJsonValue(root);
 	}
@@ -721,8 +709,8 @@ void FrameMapper::SetJson(std::string value) {
 	}
 }
 
-// Load Json::JsonValue into this object
-void FrameMapper::SetJsonValue(Json::Value root) {
+// Load Json::Value into this object
+void FrameMapper::SetJsonValue(const Json::Value root) {
 
 	// Set parent data
 	ReaderBase::SetJsonValue(root);

--- a/src/ImageReader.cpp
+++ b/src/ImageReader.cpp
@@ -136,14 +136,14 @@ std::shared_ptr<Frame> ImageReader::GetFrame(int64_t requested_frame)
 }
 
 // Generate JSON string of this object
-std::string ImageReader::Json() {
+std::string ImageReader::Json() const {
 
 	// Return formatted string
 	return JsonValue().toStyledString();
 }
 
-// Generate Json::JsonValue for this object
-Json::Value ImageReader::JsonValue() {
+// Generate Json::Value for this object
+Json::Value ImageReader::JsonValue() const {
 
 	// Create root json object
 	Json::Value root = ReaderBase::JsonValue(); // get parent properties
@@ -155,24 +155,12 @@ Json::Value ImageReader::JsonValue() {
 }
 
 // Load JSON string into this object
-void ImageReader::SetJson(std::string value) {
+void ImageReader::SetJson(const std::string value) {
 
 	// Parse JSON string into JSON objects
-	Json::Value root;
-	Json::CharReaderBuilder rbuilder;
-	Json::CharReader* reader(rbuilder.newCharReader());
-
-	std::string errors;
-	bool success = reader->parse( value.c_str(),
-                 value.c_str() + value.size(), &root, &errors );
-	delete reader;
-
-	if (!success)
-		// Raise exception
-		throw InvalidJSON("JSON could not be parsed (or is invalid)");
-
 	try
 	{
+		const Json::Value root = openshot::stringToJson(value);
 		// Set all values that match
 		SetJsonValue(root);
 	}
@@ -183,8 +171,8 @@ void ImageReader::SetJson(std::string value) {
 	}
 }
 
-// Load Json::JsonValue into this object
-void ImageReader::SetJsonValue(Json::Value root) {
+// Load Json::Value into this object
+void ImageReader::SetJsonValue(const Json::Value root) {
 
 	// Set parent data
 	ReaderBase::SetJsonValue(root);

--- a/src/Json.cpp
+++ b/src/Json.cpp
@@ -1,0 +1,50 @@
+/**
+ * @file
+ * @brief Helper functions for Json parsing
+ * @author FeRD (Frank Dana) <ferdnyc@gmail.com>
+ *
+ * @ref License
+ */
+
+/* LICENSE
+ *
+ * Copyright (c) 2008-2019 OpenShot Studios, LLC
+ * <http://www.openshotstudios.com/>. This file is part of
+ * OpenShot Library (libopenshot), an open-source project dedicated to
+ * delivering high quality video editing and animation solutions to the
+ * world. For more information visit <http://www.openshot.org/>.
+ *
+ * OpenShot Library (libopenshot) is free software: you can redistribute it
+ * and/or modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * OpenShot Library (libopenshot) is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with OpenShot Library. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "../include/Json.h"
+
+const Json::Value openshot::stringToJson(const std::string value) {
+
+	// Parse JSON string into JSON objects
+	Json::Value root;
+	Json::CharReaderBuilder rbuilder;
+	Json::CharReader* reader(rbuilder.newCharReader());
+
+	std::string errors;
+	bool success = reader->parse( value.c_str(), value.c_str() + value.size(),
+	                              &root, &errors );
+	delete reader;
+
+	if (!success)
+		// Raise exception
+		throw openshot::InvalidJSON("JSON could not be parsed (or is invalid)");
+
+	return root;
+}

--- a/src/KeyFrame.cpp
+++ b/src/KeyFrame.cpp
@@ -325,17 +325,15 @@ std::string Keyframe::Json() const {
 	return JsonValue().toStyledString();
 }
 
-// Generate Json::JsonValue for this object
+// Generate Json::Value for this object
 Json::Value Keyframe::JsonValue() const {
 
 	// Create root json object
 	Json::Value root;
 	root["Points"] = Json::Value(Json::arrayValue);
 
-	// loop through points, and find a matching coordinate
-	for (int x = 0; x < Points.size(); x++) {
-		// Get each point
-		Point existing_point = Points[x];
+	// loop through points
+	for (const auto existing_point : Points) {
 		root["Points"].append(existing_point.JsonValue());
 	}
 
@@ -344,24 +342,12 @@ Json::Value Keyframe::JsonValue() const {
 }
 
 // Load JSON string into this object
-void Keyframe::SetJson(std::string value) {
+void Keyframe::SetJson(const std::string value) {
 
 	// Parse JSON string into JSON objects
-	Json::Value root;
-	Json::CharReaderBuilder rbuilder;
-	Json::CharReader* reader(rbuilder.newCharReader());
-
-	std::string errors;
-	bool success = reader->parse( value.c_str(),
-                 value.c_str() + value.size(), &root, &errors );
-	delete reader;
-
-	if (!success)
-		// Raise exception
-		throw InvalidJSON("JSON could not be parsed (or is invalid)");
-
 	try
 	{
+		const Json::Value root = openshot::stringToJson(value);
 		// Set all values that match
 		SetJsonValue(root);
 	}
@@ -372,17 +358,14 @@ void Keyframe::SetJson(std::string value) {
 	}
 }
 
-// Load Json::JsonValue into this object
-void Keyframe::SetJsonValue(Json::Value root) {
+// Load Json::Value into this object
+void Keyframe::SetJsonValue(const Json::Value root) {
 	// Clear existing points
 	Points.clear();
 
 	if (!root["Points"].isNull())
 		// loop through points
-		for (int64_t x = 0; x < root["Points"].size(); x++) {
-			// Get each point
-			Json::Value existing_point = root["Points"][(Json::UInt) x];
-
+		for (const auto existing_point : root["Points"]) {
 			// Create Point
 			Point p;
 

--- a/src/Point.cpp
+++ b/src/Point.cpp
@@ -108,14 +108,14 @@ void Point::Initialize_RightHandle(float x, float y) {
 }
 
 // Generate JSON string of this object
-std::string Point::Json() {
+std::string Point::Json() const {
 
 	// Return formatted string
 	return JsonValue().toStyledString();
 }
 
-// Generate Json::JsonValue for this object
-Json::Value Point::JsonValue() {
+// Generate Json::Value for this object
+Json::Value Point::JsonValue() const {
 
 	// Create root json object
 	Json::Value root;
@@ -132,24 +132,12 @@ Json::Value Point::JsonValue() {
 }
 
 // Load JSON string into this object
-void Point::SetJson(std::string value) {
+void Point::SetJson(const std::string value) {
 
 	// Parse JSON string into JSON objects
-	Json::Value root;
-	Json::CharReaderBuilder rbuilder;
-	Json::CharReader* reader(rbuilder.newCharReader());
-
-	std::string errors;
-	bool success = reader->parse( value.c_str(),
-                 value.c_str() + value.size(), &root, &errors );
-	delete reader;
-
-	if (!success)
-		// Raise exception
-		throw InvalidJSON("JSON could not be parsed (or is invalid)");
-
 	try
 	{
+		const Json::Value root = openshot::stringToJson(value);
 		// Set all values that match
 		SetJsonValue(root);
 	}
@@ -160,8 +148,8 @@ void Point::SetJson(std::string value) {
 	}
 }
 
-// Load Json::JsonValue into this object
-void Point::SetJsonValue(Json::Value root) {
+// Load Json::Value into this object
+void Point::SetJsonValue(const Json::Value root) {
 
 	if (!root["co"].isNull())
 		co.SetJsonValue(root["co"]); // update coordinate

--- a/src/Profiles.cpp
+++ b/src/Profiles.cpp
@@ -133,14 +133,14 @@ Profile::Profile(std::string path) {
 }
 
 // Generate JSON string of this object
-std::string Profile::Json() {
+std::string Profile::Json() const {
 
 	// Return formatted string
 	return JsonValue().toStyledString();
 }
 
-// Generate Json::JsonValue for this object
-Json::Value Profile::JsonValue() {
+// Generate Json::Value for this object
+Json::Value Profile::JsonValue() const {
 
 	// Create root json object
 	Json::Value root;
@@ -163,24 +163,12 @@ Json::Value Profile::JsonValue() {
 }
 
 // Load JSON string into this object
-void Profile::SetJson(std::string value) {
+void Profile::SetJson(const std::string value) {
 
 	// Parse JSON string into JSON objects
-	Json::Value root;
-	Json::CharReaderBuilder rbuilder;
-	Json::CharReader* reader(rbuilder.newCharReader());
-
-	std::string errors;
-	bool success = reader->parse( value.c_str(),
-                 value.c_str() + value.size(), &root, &errors );
-	delete reader;
-
-	if (!success)
-		// Raise exception
-		throw InvalidJSON("JSON could not be parsed (or is invalid)");
-
 	try
 	{
+		const Json::Value root = openshot::stringToJson(value);
 		// Set all values that match
 		SetJsonValue(root);
 	}
@@ -191,8 +179,8 @@ void Profile::SetJson(std::string value) {
 	}
 }
 
-// Load Json::JsonValue into this object
-void Profile::SetJsonValue(Json::Value root) {
+// Load Json::Value into this object
+void Profile::SetJsonValue(const Json::Value root) {
 
 	if (!root["height"].isNull())
 		info.height = root["height"].asInt();

--- a/src/QtHtmlReader.cpp
+++ b/src/QtHtmlReader.cpp
@@ -180,14 +180,14 @@ std::shared_ptr<Frame> QtHtmlReader::GetFrame(int64_t requested_frame)
 }
 
 // Generate JSON string of this object
-std::string QtHtmlReader::Json() {
+std::string QtHtmlReader::Json() const {
 
 	// Return formatted string
 	return JsonValue().toStyledString();
 }
 
-// Generate Json::JsonValue for this object
-Json::Value QtHtmlReader::JsonValue() {
+// Generate Json::Value for this object
+Json::Value QtHtmlReader::JsonValue() const {
 
 	// Create root json object
 	Json::Value root = ReaderBase::JsonValue(); // get parent properties
@@ -206,24 +206,12 @@ Json::Value QtHtmlReader::JsonValue() {
 }
 
 // Load JSON string into this object
-void QtHtmlReader::SetJson(std::string value) {
+void QtHtmlReader::SetJson(const std::string value) {
 
 	// Parse JSON string into JSON objects
-	Json::Value root;
-	Json::CharReaderBuilder rbuilder;
-	Json::CharReader* reader(rbuilder.newCharReader());
-
-	std::string errors;
-	bool success = reader->parse( value.c_str(),
-                 value.c_str() + value.size(), &root, &errors );
-	delete reader;
-	
-	if (!success)
-		// Raise exception
-		throw InvalidJSON("JSON could not be parsed (or is invalid)");
-
 	try
 	{
+		const Json::Value root = openshot::stringToJson(value);
 		// Set all values that match
 		SetJsonValue(root);
 	}
@@ -234,8 +222,8 @@ void QtHtmlReader::SetJson(std::string value) {
 	}
 }
 
-// Load Json::JsonValue into this object
-void QtHtmlReader::SetJsonValue(Json::Value root) {
+// Load Json::Value into this object
+void QtHtmlReader::SetJsonValue(const Json::Value root) {
 
 	// Set parent data
 	ReaderBase::SetJsonValue(root);

--- a/src/QtImageReader.cpp
+++ b/src/QtImageReader.cpp
@@ -277,14 +277,14 @@ std::shared_ptr<Frame> QtImageReader::GetFrame(int64_t requested_frame)
 }
 
 // Generate JSON string of this object
-std::string QtImageReader::Json() {
+std::string QtImageReader::Json() const {
 
 	// Return formatted string
 	return JsonValue().toStyledString();
 }
 
-// Generate Json::JsonValue for this object
-Json::Value QtImageReader::JsonValue() {
+// Generate Json::Value for this object
+Json::Value QtImageReader::JsonValue() const {
 
 	// Create root json object
 	Json::Value root = ReaderBase::JsonValue(); // get parent properties
@@ -296,24 +296,12 @@ Json::Value QtImageReader::JsonValue() {
 }
 
 // Load JSON string into this object
-void QtImageReader::SetJson(std::string value) {
+void QtImageReader::SetJson(const std::string value) {
 
 	// Parse JSON string into JSON objects
-	Json::Value root;
-	Json::CharReaderBuilder rbuilder;
-	Json::CharReader* reader(rbuilder.newCharReader());
-
-	std::string errors;
-	bool success = reader->parse( value.c_str(),
-                 value.c_str() + value.size(), &root, &errors );
-	delete reader;
-
-	if (!success)
-		// Raise exception
-		throw InvalidJSON("JSON could not be parsed (or is invalid)");
-
 	try
 	{
+		const Json::Value root = openshot::stringToJson(value);
 		// Set all values that match
 		SetJsonValue(root);
 	}
@@ -324,8 +312,8 @@ void QtImageReader::SetJson(std::string value) {
 	}
 }
 
-// Load Json::JsonValue into this object
-void QtImageReader::SetJsonValue(Json::Value root) {
+// Load Json::Value into this object
+void QtImageReader::SetJsonValue(const Json::Value root) {
 
 	// Set parent data
 	ReaderBase::SetJsonValue(root);

--- a/src/QtTextReader.cpp
+++ b/src/QtTextReader.cpp
@@ -197,14 +197,14 @@ std::shared_ptr<Frame> QtTextReader::GetFrame(int64_t requested_frame)
 }
 
 // Generate JSON string of this object
-std::string QtTextReader::Json() {
+std::string QtTextReader::Json() const {
 
 	// Return formatted string
 	return JsonValue().toStyledString();
 }
 
-// Generate Json::JsonValue for this object
-Json::Value QtTextReader::JsonValue() {
+// Generate Json::Value for this object
+Json::Value QtTextReader::JsonValue() const {
 
 	// Create root json object
 	Json::Value root = ReaderBase::JsonValue(); // get parent properties
@@ -225,24 +225,12 @@ Json::Value QtTextReader::JsonValue() {
 }
 
 // Load JSON string into this object
-void QtTextReader::SetJson(std::string value) {
+void QtTextReader::SetJson(const std::string value) {
 
 	// Parse JSON string into JSON objects
-	Json::Value root;
-	Json::CharReaderBuilder rbuilder;
-	Json::CharReader* reader(rbuilder.newCharReader());
-
-	std::string errors;
-	bool success = reader->parse( value.c_str(),
-                 value.c_str() + value.size(), &root, &errors );
-	delete reader;
-
-	if (!success)
-		// Raise exception
-		throw InvalidJSON("JSON could not be parsed (or is invalid)");
-
 	try
 	{
+		const Json::Value root = openshot::stringToJson(value);
 		// Set all values that match
 		SetJsonValue(root);
 	}
@@ -253,8 +241,8 @@ void QtTextReader::SetJson(std::string value) {
 	}
 }
 
-// Load Json::JsonValue into this object
-void QtTextReader::SetJsonValue(Json::Value root) {
+// Load Json::Value into this object
+void QtTextReader::SetJsonValue(const Json::Value root) {
 
 	// Set parent data
 	ReaderBase::SetJsonValue(root);

--- a/src/ReaderBase.cpp
+++ b/src/ReaderBase.cpp
@@ -113,8 +113,8 @@ void ReaderBase::DisplayInfo() {
 		std::cout << "--> " << it->first << ": " << it->second << std::endl;
 }
 
-// Generate Json::JsonValue for this object
-Json::Value ReaderBase::JsonValue() {
+// Generate Json::Value for this object
+Json::Value ReaderBase::JsonValue() const {
 
 	// Create root json object
 	Json::Value root;
@@ -160,7 +160,7 @@ Json::Value ReaderBase::JsonValue() {
 
 	// Append metadata map
 	root["metadata"] = Json::Value(Json::objectValue);
-	std::map<std::string, std::string>::iterator it;
+	std::map<std::string, std::string>::const_iterator it;
 	for (it = info.metadata.begin(); it != info.metadata.end(); it++)
 		root["metadata"][it->first] = it->second;
 
@@ -168,8 +168,8 @@ Json::Value ReaderBase::JsonValue() {
 	return root;
 }
 
-// Load Json::JsonValue into this object
-void ReaderBase::SetJsonValue(Json::Value root) {
+// Load Json::Value into this object
+void ReaderBase::SetJsonValue(const Json::Value root) {
 
 	// Set data from Json (if key is found)
 	if (!root["has_video"].isNull())
@@ -244,7 +244,7 @@ void ReaderBase::SetJsonValue(Json::Value root) {
 			info.audio_timebase.den = root["audio_timebase"]["den"].asInt();
 	}
 	if (!root["metadata"].isNull() && root["metadata"].isObject()) {
-		for( Json::Value::iterator itr = root["metadata"].begin() ; itr != root["metadata"].end() ; itr++ ) {
+		for( Json::Value::const_iterator itr = root["metadata"].begin() ; itr != root["metadata"].end() ; itr++ ) {
 			std::string key = itr.key().asString();
 			info.metadata[key] = root["metadata"][key].asString();
 		}

--- a/src/TextReader.cpp
+++ b/src/TextReader.cpp
@@ -187,14 +187,14 @@ std::shared_ptr<Frame> TextReader::GetFrame(int64_t requested_frame)
 }
 
 // Generate JSON string of this object
-std::string TextReader::Json() {
+std::string TextReader::Json() const {
 
 	// Return formatted string
 	return JsonValue().toStyledString();
 }
 
-// Generate Json::JsonValue for this object
-Json::Value TextReader::JsonValue() {
+// Generate Json::Value for this object
+Json::Value TextReader::JsonValue() const {
 
 	// Create root json object
 	Json::Value root = ReaderBase::JsonValue(); // get parent properties
@@ -216,24 +216,10 @@ Json::Value TextReader::JsonValue() {
 }
 
 // Load JSON string into this object
-void TextReader::SetJson(std::string value) {
-
-	// Parse JSON string into JSON objects
-	Json::Value root;
-	Json::CharReaderBuilder rbuilder;
-	Json::CharReader* reader(rbuilder.newCharReader());
-
-	std::string errors;
-	bool success = reader->parse( value.c_str(),
-                 value.c_str() + value.size(), &root, &errors );
-	delete reader;
-
-	if (!success)
-		// Raise exception
-		throw InvalidJSON("JSON could not be parsed (or is invalid)");
-
+void TextReader::SetJson(const std::string value) {
 	try
 	{
+		Json::Value root = openshot::stringToJson(value);
 		// Set all values that match
 		SetJsonValue(root);
 	}
@@ -244,8 +230,8 @@ void TextReader::SetJson(std::string value) {
 	}
 }
 
-// Load Json::JsonValue into this object
-void TextReader::SetJsonValue(Json::Value root) {
+// Load Json::Value into this object
+void TextReader::SetJsonValue(const Json::Value root) {
 
 	// Set parent data
 	ReaderBase::SetJsonValue(root);

--- a/src/WriterBase.cpp
+++ b/src/WriterBase.cpp
@@ -139,14 +139,14 @@ void WriterBase::DisplayInfo() {
 }
 
 // Generate JSON string of this object
-std::string WriterBase::Json() {
+std::string WriterBase::Json() const {
 
 	// Return formatted string
 	return JsonValue().toStyledString();
 }
 
-// Generate Json::JsonValue for this object
-Json::Value WriterBase::JsonValue() {
+// Generate Json::Value for this object
+Json::Value WriterBase::JsonValue() const {
 
 	// Create root json object
 	Json::Value root;
@@ -195,24 +195,12 @@ Json::Value WriterBase::JsonValue() {
 }
 
 // Load JSON string into this object
-void WriterBase::SetJson(std::string value) {
+void WriterBase::SetJson(const std::string value) {
 
 	// Parse JSON string into JSON objects
-	Json::Value root;
-	Json::CharReaderBuilder rbuilder;
-	Json::CharReader* reader(rbuilder.newCharReader());
-
-	std::string errors;
-	bool success = reader->parse( value.c_str(),
-                 value.c_str() + value.size(), &root, &errors );
-	delete reader;
-
-	if (!success)
-		// Raise exception
-		throw InvalidJSON("JSON could not be parsed (or is invalid)");
-
 	try
 	{
+		const Json::Value root = openshot::stringToJson(value);
 		// Set all values that match
 		SetJsonValue(root);
 	}
@@ -223,8 +211,8 @@ void WriterBase::SetJson(std::string value) {
 	}
 }
 
-// Load Json::JsonValue into this object
-void WriterBase::SetJsonValue(Json::Value root) {
+// Load Json::Value into this object
+void WriterBase::SetJsonValue(const Json::Value root) {
 
 	// Set data from Json (if key is found)
 	if (!root["has_video"].isNull())

--- a/src/effects/Bars.cpp
+++ b/src/effects/Bars.cpp
@@ -114,14 +114,14 @@ std::shared_ptr<Frame> Bars::GetFrame(std::shared_ptr<Frame> frame, int64_t fram
 }
 
 // Generate JSON string of this object
-std::string Bars::Json() {
+std::string Bars::Json() const {
 
 	// Return formatted string
 	return JsonValue().toStyledString();
 }
 
-// Generate Json::JsonValue for this object
-Json::Value Bars::JsonValue() {
+// Generate Json::Value for this object
+Json::Value Bars::JsonValue() const {
 
 	// Create root json object
 	Json::Value root = EffectBase::JsonValue(); // get parent properties
@@ -137,24 +137,12 @@ Json::Value Bars::JsonValue() {
 }
 
 // Load JSON string into this object
-void Bars::SetJson(std::string value) {
+void Bars::SetJson(const std::string value) {
 
 	// Parse JSON string into JSON objects
-	Json::Value root;
-	Json::CharReaderBuilder rbuilder;
-	Json::CharReader* reader(rbuilder.newCharReader());
-
-	std::string errors;
-	bool success = reader->parse( value.c_str(),
-                 value.c_str() + value.size(), &root, &errors );
-	delete reader;
-
-	if (!success)
-		// Raise exception
-		throw InvalidJSON("JSON could not be parsed (or is invalid)");
-
 	try
 	{
+		const Json::Value root = openshot::stringToJson(value);
 		// Set all values that match
 		SetJsonValue(root);
 	}
@@ -165,8 +153,8 @@ void Bars::SetJson(std::string value) {
 	}
 }
 
-// Load Json::JsonValue into this object
-void Bars::SetJsonValue(Json::Value root) {
+// Load Json::Value into this object
+void Bars::SetJsonValue(const Json::Value root) {
 
 	// Set parent data
 	EffectBase::SetJsonValue(root);
@@ -185,7 +173,7 @@ void Bars::SetJsonValue(Json::Value root) {
 }
 
 // Get all properties for a specific frame
-std::string Bars::PropertiesJSON(int64_t requested_frame) {
+std::string Bars::PropertiesJSON(int64_t requested_frame) const {
 
 	// Generate JSON properties list
 	Json::Value root;

--- a/src/effects/Blur.cpp
+++ b/src/effects/Blur.cpp
@@ -252,14 +252,14 @@ void Blur::boxBlurT(unsigned char *scl, unsigned char *tcl, int w, int h, int r)
 }
 
 // Generate JSON string of this object
-std::string Blur::Json() {
+std::string Blur::Json() const {
 
 	// Return formatted string
 	return JsonValue().toStyledString();
 }
 
-// Generate Json::JsonValue for this object
-Json::Value Blur::JsonValue() {
+// Generate Json::Value for this object
+Json::Value Blur::JsonValue() const {
 
 	// Create root json object
 	Json::Value root = EffectBase::JsonValue(); // get parent properties
@@ -274,24 +274,12 @@ Json::Value Blur::JsonValue() {
 }
 
 // Load JSON string into this object
-void Blur::SetJson(std::string value) {
+void Blur::SetJson(const std::string value) {
 
 	// Parse JSON string into JSON objects
-	Json::Value root;
-	Json::CharReaderBuilder rbuilder;
-	Json::CharReader* reader(rbuilder.newCharReader());
-
-	std::string errors;
-	bool success = reader->parse( value.c_str(),
-                 value.c_str() + value.size(), &root, &errors );
-	delete reader;
-
-	if (!success)
-		// Raise exception
-		throw InvalidJSON("JSON could not be parsed (or is invalid)");
-
 	try
 	{
+		const Json::Value root = openshot::stringToJson(value);
 		// Set all values that match
 		SetJsonValue(root);
 	}
@@ -302,8 +290,8 @@ void Blur::SetJson(std::string value) {
 	}
 }
 
-// Load Json::JsonValue into this object
-void Blur::SetJsonValue(Json::Value root) {
+// Load Json::Value into this object
+void Blur::SetJsonValue(const Json::Value root) {
 
 	// Set parent data
 	EffectBase::SetJsonValue(root);
@@ -320,7 +308,7 @@ void Blur::SetJsonValue(Json::Value root) {
 }
 
 // Get all properties for a specific frame
-std::string Blur::PropertiesJSON(int64_t requested_frame) {
+std::string Blur::PropertiesJSON(int64_t requested_frame) const {
 
 	// Generate JSON properties list
 	Json::Value root;

--- a/src/effects/Brightness.cpp
+++ b/src/effects/Brightness.cpp
@@ -108,14 +108,14 @@ std::shared_ptr<Frame> Brightness::GetFrame(std::shared_ptr<Frame> frame, int64_
 }
 
 // Generate JSON string of this object
-std::string Brightness::Json() {
+std::string Brightness::Json() const {
 
 	// Return formatted string
 	return JsonValue().toStyledString();
 }
 
-// Generate Json::JsonValue for this object
-Json::Value Brightness::JsonValue() {
+// Generate Json::Value for this object
+Json::Value Brightness::JsonValue() const {
 
 	// Create root json object
 	Json::Value root = EffectBase::JsonValue(); // get parent properties
@@ -128,24 +128,12 @@ Json::Value Brightness::JsonValue() {
 }
 
 // Load JSON string into this object
-void Brightness::SetJson(std::string value) {
+void Brightness::SetJson(const std::string value) {
 
 	// Parse JSON string into JSON objects
-	Json::Value root;
-	Json::CharReaderBuilder rbuilder;
-	Json::CharReader* reader(rbuilder.newCharReader());
-
-	std::string errors;
-	bool success = reader->parse( value.c_str(),
-                 value.c_str() + value.size(), &root, &errors );
-	delete reader;
-
-	if (!success)
-		// Raise exception
-		throw InvalidJSON("JSON could not be parsed (or is invalid)");
-
 	try
 	{
+		const Json::Value root = openshot::stringToJson(value);
 		// Set all values that match
 		SetJsonValue(root);
 	}
@@ -156,8 +144,8 @@ void Brightness::SetJson(std::string value) {
 	}
 }
 
-// Load Json::JsonValue into this object
-void Brightness::SetJsonValue(Json::Value root) {
+// Load Json::Value into this object
+void Brightness::SetJsonValue(const Json::Value root) {
 
 	// Set parent data
 	EffectBase::SetJsonValue(root);
@@ -170,7 +158,7 @@ void Brightness::SetJsonValue(Json::Value root) {
 }
 
 // Get all properties for a specific frame
-std::string Brightness::PropertiesJSON(int64_t requested_frame) {
+std::string Brightness::PropertiesJSON(int64_t requested_frame) const {
 
 	// Generate JSON properties list
 	Json::Value root;

--- a/src/effects/ChromaKey.cpp
+++ b/src/effects/ChromaKey.cpp
@@ -101,14 +101,14 @@ std::shared_ptr<Frame> ChromaKey::GetFrame(std::shared_ptr<Frame> frame, int64_t
 }
 
 // Generate JSON string of this object
-std::string ChromaKey::Json() {
+std::string ChromaKey::Json() const {
 
 	// Return formatted string
 	return JsonValue().toStyledString();
 }
 
-// Generate Json::JsonValue for this object
-Json::Value ChromaKey::JsonValue() {
+// Generate Json::Value for this object
+Json::Value ChromaKey::JsonValue() const {
 
 	// Create root json object
 	Json::Value root = EffectBase::JsonValue(); // get parent properties
@@ -121,24 +121,12 @@ Json::Value ChromaKey::JsonValue() {
 }
 
 // Load JSON string into this object
-void ChromaKey::SetJson(std::string value) {
+void ChromaKey::SetJson(const std::string value) {
 
 	// Parse JSON string into JSON objects
-	Json::Value root;
-	Json::CharReaderBuilder rbuilder;
-	Json::CharReader* reader(rbuilder.newCharReader());
-
-	std::string errors;
-	bool success = reader->parse( value.c_str(),
-                 value.c_str() + value.size(), &root, &errors );
-	delete reader;
-
-	if (!success)
-		// Raise exception
-		throw InvalidJSON("JSON could not be parsed (or is invalid)");
-
 	try
 	{
+		const Json::Value root = openshot::stringToJson(value);
 		// Set all values that match
 		SetJsonValue(root);
 	}
@@ -149,8 +137,8 @@ void ChromaKey::SetJson(std::string value) {
 	}
 }
 
-// Load Json::JsonValue into this object
-void ChromaKey::SetJsonValue(Json::Value root) {
+// Load Json::Value into this object
+void ChromaKey::SetJsonValue(const Json::Value root) {
 
 	// Set parent data
 	EffectBase::SetJsonValue(root);
@@ -163,7 +151,7 @@ void ChromaKey::SetJsonValue(Json::Value root) {
 }
 
 // Get all properties for a specific frame
-std::string ChromaKey::PropertiesJSON(int64_t requested_frame) {
+std::string ChromaKey::PropertiesJSON(int64_t requested_frame) const {
 
 	// Generate JSON properties list
 	Json::Value root;

--- a/src/effects/ColorShift.cpp
+++ b/src/effects/ColorShift.cpp
@@ -194,14 +194,14 @@ std::shared_ptr<Frame> ColorShift::GetFrame(std::shared_ptr<Frame> frame, int64_
 }
 
 // Generate JSON string of this object
-std::string ColorShift::Json() {
+std::string ColorShift::Json() const {
 
 	// Return formatted string
 	return JsonValue().toStyledString();
 }
 
-// Generate Json::JsonValue for this object
-Json::Value ColorShift::JsonValue() {
+// Generate Json::Value for this object
+Json::Value ColorShift::JsonValue() const {
 
 	// Create root json object
 	Json::Value root = EffectBase::JsonValue(); // get parent properties
@@ -220,24 +220,12 @@ Json::Value ColorShift::JsonValue() {
 }
 
 // Load JSON string into this object
-void ColorShift::SetJson(std::string value) {
+void ColorShift::SetJson(const std::string value) {
 
 	// Parse JSON string into JSON objects
-	Json::Value root;
-	Json::CharReaderBuilder rbuilder;
-	Json::CharReader* reader(rbuilder.newCharReader());
-
-	std::string errors;
-	bool success = reader->parse( value.c_str(),
-                 value.c_str() + value.size(), &root, &errors );
-	delete reader;
-
-	if (!success)
-		// Raise exception
-		throw InvalidJSON("JSON could not be parsed (or is invalid)");
-
 	try
 	{
+		const Json::Value root = openshot::stringToJson(value);
 		// Set all values that match
 		SetJsonValue(root);
 	}
@@ -248,8 +236,8 @@ void ColorShift::SetJson(std::string value) {
 	}
 }
 
-// Load Json::JsonValue into this object
-void ColorShift::SetJsonValue(Json::Value root) {
+// Load Json::Value into this object
+void ColorShift::SetJsonValue(const Json::Value root) {
 
 	// Set parent data
 	EffectBase::SetJsonValue(root);
@@ -274,7 +262,7 @@ void ColorShift::SetJsonValue(Json::Value root) {
 }
 
 // Get all properties for a specific frame
-std::string ColorShift::PropertiesJSON(int64_t requested_frame) {
+std::string ColorShift::PropertiesJSON(int64_t requested_frame) const {
 
 	// Generate JSON properties list
 	Json::Value root;

--- a/src/effects/Crop.cpp
+++ b/src/effects/Crop.cpp
@@ -114,14 +114,14 @@ std::shared_ptr<Frame> Crop::GetFrame(std::shared_ptr<Frame> frame, int64_t fram
 }
 
 // Generate JSON string of this object
-std::string Crop::Json() {
+std::string Crop::Json() const {
 
 	// Return formatted string
 	return JsonValue().toStyledString();
 }
 
-// Generate Json::JsonValue for this object
-Json::Value Crop::JsonValue() {
+// Generate Json::Value for this object
+Json::Value Crop::JsonValue() const {
 
 	// Create root json object
 	Json::Value root = EffectBase::JsonValue(); // get parent properties
@@ -136,24 +136,12 @@ Json::Value Crop::JsonValue() {
 }
 
 // Load JSON string into this object
-void Crop::SetJson(std::string value) {
+void Crop::SetJson(const std::string value) {
 
 	// Parse JSON string into JSON objects
-	Json::Value root;
-	Json::CharReaderBuilder rbuilder;
-	Json::CharReader* reader(rbuilder.newCharReader());
-
-	std::string errors;
-	bool success = reader->parse( value.c_str(),
-	                 value.c_str() + value.size(), &root, &errors );
-	delete reader;
-
-	if (!success)
-		// Raise exception
-		throw InvalidJSON("JSON could not be parsed (or is invalid)");
-
 	try
 	{
+		const Json::Value root = openshot::stringToJson(value);
 		// Set all values that match
 		SetJsonValue(root);
 	}
@@ -164,8 +152,8 @@ void Crop::SetJson(std::string value) {
 	}
 }
 
-// Load Json::JsonValue into this object
-void Crop::SetJsonValue(Json::Value root) {
+// Load Json::Value into this object
+void Crop::SetJsonValue(const Json::Value root) {
 
 	// Set parent data
 	EffectBase::SetJsonValue(root);
@@ -182,7 +170,7 @@ void Crop::SetJsonValue(Json::Value root) {
 }
 
 // Get all properties for a specific frame
-std::string Crop::PropertiesJSON(int64_t requested_frame) {
+std::string Crop::PropertiesJSON(int64_t requested_frame) const {
 
 	// Generate JSON properties list
 	Json::Value root;

--- a/src/effects/Deinterlace.cpp
+++ b/src/effects/Deinterlace.cpp
@@ -96,14 +96,14 @@ std::shared_ptr<Frame> Deinterlace::GetFrame(std::shared_ptr<Frame> frame, int64
 }
 
 // Generate JSON string of this object
-std::string Deinterlace::Json() {
+std::string Deinterlace::Json() const {
 
 	// Return formatted string
 	return JsonValue().toStyledString();
 }
 
-// Generate Json::JsonValue for this object
-Json::Value Deinterlace::JsonValue() {
+// Generate Json::Value for this object
+Json::Value Deinterlace::JsonValue() const {
 
 	// Create root json object
 	Json::Value root = EffectBase::JsonValue(); // get parent properties
@@ -115,24 +115,12 @@ Json::Value Deinterlace::JsonValue() {
 }
 
 // Load JSON string into this object
-void Deinterlace::SetJson(std::string value) {
+void Deinterlace::SetJson(const std::string value) {
 
 	// Parse JSON string into JSON objects
-	Json::Value root;
-	Json::CharReaderBuilder rbuilder;
-	Json::CharReader* reader(rbuilder.newCharReader());
-
-	std::string errors;
-	bool success = reader->parse( value.c_str(),
-                 value.c_str() + value.size(), &root, &errors );
-	delete reader;
-
-	if (!success)
-		// Raise exception
-		throw InvalidJSON("JSON could not be parsed (or is invalid)");
-
 	try
 	{
+		const Json::Value root = openshot::stringToJson(value);
 		// Set all values that match
 		SetJsonValue(root);
 	}
@@ -143,8 +131,8 @@ void Deinterlace::SetJson(std::string value) {
 	}
 }
 
-// Load Json::JsonValue into this object
-void Deinterlace::SetJsonValue(Json::Value root) {
+// Load Json::Value into this object
+void Deinterlace::SetJsonValue(const Json::Value root) {
 
 	// Set parent data
 	EffectBase::SetJsonValue(root);
@@ -155,7 +143,7 @@ void Deinterlace::SetJsonValue(Json::Value root) {
 }
 
 // Get all properties for a specific frame
-std::string Deinterlace::PropertiesJSON(int64_t requested_frame) {
+std::string Deinterlace::PropertiesJSON(int64_t requested_frame) const {
 
 	// Generate JSON properties list
 	Json::Value root;

--- a/src/effects/Hue.cpp
+++ b/src/effects/Hue.cpp
@@ -103,14 +103,14 @@ std::shared_ptr<Frame> Hue::GetFrame(std::shared_ptr<Frame> frame, int64_t frame
 }
 
 // Generate JSON string of this object
-std::string Hue::Json() {
+std::string Hue::Json() const {
 
 	// Return formatted string
 	return JsonValue().toStyledString();
 }
 
-// Generate Json::JsonValue for this object
-Json::Value Hue::JsonValue() {
+// Generate Json::Value for this object
+Json::Value Hue::JsonValue() const {
 
 	// Create root json object
 	Json::Value root = EffectBase::JsonValue(); // get parent properties
@@ -122,24 +122,12 @@ Json::Value Hue::JsonValue() {
 }
 
 // Load JSON string into this object
-void Hue::SetJson(std::string value) {
+void Hue::SetJson(const std::string value) {
 
 	// Parse JSON string into JSON objects
-	Json::Value root;
-	Json::CharReaderBuilder rbuilder;
-	Json::CharReader* reader(rbuilder.newCharReader());
-
-	std::string errors;
-	bool success = reader->parse( value.c_str(),
-                 value.c_str() + value.size(), &root, &errors );
-	delete reader;
-
-	if (!success)
-		// Raise exception
-		throw InvalidJSON("JSON could not be parsed (or is invalid)");
-
 	try
 	{
+		const Json::Value root = openshot::stringToJson(value);
 		// Set all values that match
 		SetJsonValue(root);
 	}
@@ -150,8 +138,8 @@ void Hue::SetJson(std::string value) {
 	}
 }
 
-// Load Json::JsonValue into this object
-void Hue::SetJsonValue(Json::Value root) {
+// Load Json::Value into this object
+void Hue::SetJsonValue(const Json::Value root) {
 
 	// Set parent data
 	EffectBase::SetJsonValue(root);
@@ -162,7 +150,7 @@ void Hue::SetJsonValue(Json::Value root) {
 }
 
 // Get all properties for a specific frame
-std::string Hue::PropertiesJSON(int64_t requested_frame) {
+std::string Hue::PropertiesJSON(int64_t requested_frame) const {
 
 	// Generate JSON properties list
 	Json::Value root;

--- a/src/effects/Mask.cpp
+++ b/src/effects/Mask.cpp
@@ -150,14 +150,14 @@ std::shared_ptr<Frame> Mask::GetFrame(std::shared_ptr<Frame> frame, int64_t fram
 }
 
 // Generate JSON string of this object
-std::string Mask::Json() {
+std::string Mask::Json() const {
 
 	// Return formatted string
 	return JsonValue().toStyledString();
 }
 
-// Generate Json::JsonValue for this object
-Json::Value Mask::JsonValue() {
+// Generate Json::Value for this object
+Json::Value Mask::JsonValue() const {
 
 	// Create root json object
 	Json::Value root = EffectBase::JsonValue(); // get parent properties
@@ -175,24 +175,12 @@ Json::Value Mask::JsonValue() {
 }
 
 // Load JSON string into this object
-void Mask::SetJson(std::string value) {
+void Mask::SetJson(const std::string value) {
 
 	// Parse JSON string into JSON objects
-	Json::Value root;
-	Json::CharReaderBuilder rbuilder;
-	Json::CharReader* reader(rbuilder.newCharReader());
-
-	std::string errors;
-	bool success = reader->parse( value.c_str(),
-                 value.c_str() + value.size(), &root, &errors );
-	delete reader;
-
-	if (!success)
-		// Raise exception
-		throw InvalidJSON("JSON could not be parsed (or is invalid)");
-
 	try
 	{
+		const Json::Value root = openshot::stringToJson(value);
 		// Set all values that match
 		SetJsonValue(root);
 	}
@@ -203,8 +191,8 @@ void Mask::SetJson(std::string value) {
 	}
 }
 
-// Load Json::JsonValue into this object
-void Mask::SetJsonValue(Json::Value root) {
+// Load Json::Value into this object
+void Mask::SetJsonValue(const Json::Value root) {
 
 	// Set parent data
 	EffectBase::SetJsonValue(root);
@@ -271,7 +259,7 @@ void Mask::SetJsonValue(Json::Value root) {
 }
 
 // Get all properties for a specific frame
-std::string Mask::PropertiesJSON(int64_t requested_frame) {
+std::string Mask::PropertiesJSON(int64_t requested_frame) const {
 
 	// Generate JSON properties list
 	Json::Value root;

--- a/src/effects/Negate.cpp
+++ b/src/effects/Negate.cpp
@@ -58,14 +58,14 @@ std::shared_ptr<Frame> Negate::GetFrame(std::shared_ptr<Frame> frame, int64_t fr
 }
 
 // Generate JSON string of this object
-std::string Negate::Json() {
+std::string Negate::Json() const {
 
 	// Return formatted string
 	return JsonValue().toStyledString();
 }
 
-// Generate Json::JsonValue for this object
-Json::Value Negate::JsonValue() {
+// Generate Json::Value for this object
+Json::Value Negate::JsonValue() const {
 
 	// Create root json object
 	Json::Value root = EffectBase::JsonValue(); // get parent properties
@@ -76,24 +76,12 @@ Json::Value Negate::JsonValue() {
 }
 
 // Load JSON string into this object
-void Negate::SetJson(std::string value) {
+void Negate::SetJson(const std::string value) {
 
 	// Parse JSON string into JSON objects
-	Json::Value root;
-	Json::CharReaderBuilder rbuilder;
-	Json::CharReader* reader(rbuilder.newCharReader());
-
-	std::string errors;
-	bool success = reader->parse( value.c_str(),
-                 value.c_str() + value.size(), &root, &errors );
-	delete reader;
-
-	if (!success)
-		// Raise exception
-		throw InvalidJSON("JSON could not be parsed (or is invalid)");
-
 	try
 	{
+		const Json::Value root = openshot::stringToJson(value);
 		// Set all values that match
 		SetJsonValue(root);
 	}
@@ -104,8 +92,8 @@ void Negate::SetJson(std::string value) {
 	}
 }
 
-// Load Json::JsonValue into this object
-void Negate::SetJsonValue(Json::Value root) {
+// Load Json::Value into this object
+void Negate::SetJsonValue(const Json::Value root) {
 
 	// Set parent data
 	EffectBase::SetJsonValue(root);
@@ -113,7 +101,7 @@ void Negate::SetJsonValue(Json::Value root) {
 }
 
 // Get all properties for a specific frame
-std::string Negate::PropertiesJSON(int64_t requested_frame) {
+std::string Negate::PropertiesJSON(int64_t requested_frame) const {
 
 	// Generate JSON properties list
 	Json::Value root;

--- a/src/effects/Pixelate.cpp
+++ b/src/effects/Pixelate.cpp
@@ -110,14 +110,14 @@ std::shared_ptr<Frame> Pixelate::GetFrame(std::shared_ptr<Frame> frame, int64_t 
 }
 
 // Generate JSON string of this object
-std::string Pixelate::Json() {
+std::string Pixelate::Json() const {
 
 	// Return formatted string
 	return JsonValue().toStyledString();
 }
 
-// Generate Json::JsonValue for this object
-Json::Value Pixelate::JsonValue() {
+// Generate Json::Value for this object
+Json::Value Pixelate::JsonValue() const {
 
 	// Create root json object
 	Json::Value root = EffectBase::JsonValue(); // get parent properties
@@ -133,24 +133,12 @@ Json::Value Pixelate::JsonValue() {
 }
 
 // Load JSON string into this object
-void Pixelate::SetJson(std::string value) {
+void Pixelate::SetJson(const std::string value) {
 
 	// Parse JSON string into JSON objects
-	Json::Value root;
-	Json::CharReaderBuilder rbuilder;
-	Json::CharReader* reader(rbuilder.newCharReader());
-
-	std::string errors;
-	bool success = reader->parse( value.c_str(),
-                 value.c_str() + value.size(), &root, &errors );
-	delete reader;
-
-	if (!success)
-		// Raise exception
-		throw InvalidJSON("JSON could not be parsed (or is invalid)");
-
 	try
 	{
+		const Json::Value root = openshot::stringToJson(value);
 		// Set all values that match
 		SetJsonValue(root);
 	}
@@ -161,8 +149,8 @@ void Pixelate::SetJson(std::string value) {
 	}
 }
 
-// Load Json::JsonValue into this object
-void Pixelate::SetJsonValue(Json::Value root) {
+// Load Json::Value into this object
+void Pixelate::SetJsonValue(const Json::Value root) {
 
 	// Set parent data
 	EffectBase::SetJsonValue(root);
@@ -181,7 +169,7 @@ void Pixelate::SetJsonValue(Json::Value root) {
 }
 
 // Get all properties for a specific frame
-std::string Pixelate::PropertiesJSON(int64_t requested_frame) {
+std::string Pixelate::PropertiesJSON(int64_t requested_frame) const {
 
 	// Generate JSON properties list
 	Json::Value root;

--- a/src/effects/Saturation.cpp
+++ b/src/effects/Saturation.cpp
@@ -114,14 +114,14 @@ std::shared_ptr<Frame> Saturation::GetFrame(std::shared_ptr<Frame> frame, int64_
 }
 
 // Generate JSON string of this object
-std::string Saturation::Json() {
+std::string Saturation::Json() const {
 
 	// Return formatted string
 	return JsonValue().toStyledString();
 }
 
-// Generate Json::JsonValue for this object
-Json::Value Saturation::JsonValue() {
+// Generate Json::Value for this object
+Json::Value Saturation::JsonValue() const {
 
 	// Create root json object
 	Json::Value root = EffectBase::JsonValue(); // get parent properties
@@ -133,24 +133,12 @@ Json::Value Saturation::JsonValue() {
 }
 
 // Load JSON string into this object
-void Saturation::SetJson(std::string value) {
+void Saturation::SetJson(const std::string value) {
 
 	// Parse JSON string into JSON objects
-	Json::Value root;
-	Json::CharReaderBuilder rbuilder;
-	Json::CharReader* reader(rbuilder.newCharReader());
-
-	std::string errors;
-	bool success = reader->parse( value.c_str(),
-                 value.c_str() + value.size(), &root, &errors );
-	delete reader;
-
-	if (!success)
-		// Raise exception
-		throw InvalidJSON("JSON could not be parsed (or is invalid)");
-
 	try
 	{
+		const Json::Value root = openshot::stringToJson(value);
 		// Set all values that match
 		SetJsonValue(root);
 	}
@@ -161,8 +149,8 @@ void Saturation::SetJson(std::string value) {
 	}
 }
 
-// Load Json::JsonValue into this object
-void Saturation::SetJsonValue(Json::Value root) {
+// Load Json::Value into this object
+void Saturation::SetJsonValue(const Json::Value root) {
 
 	// Set parent data
 	EffectBase::SetJsonValue(root);
@@ -173,7 +161,7 @@ void Saturation::SetJsonValue(Json::Value root) {
 }
 
 // Get all properties for a specific frame
-std::string Saturation::PropertiesJSON(int64_t requested_frame) {
+std::string Saturation::PropertiesJSON(int64_t requested_frame) const {
 
 	// Generate JSON properties list
 	Json::Value root;

--- a/src/effects/Shift.cpp
+++ b/src/effects/Shift.cpp
@@ -133,14 +133,14 @@ std::shared_ptr<Frame> Shift::GetFrame(std::shared_ptr<Frame> frame, int64_t fra
 }
 
 // Generate JSON string of this object
-std::string Shift::Json() {
+std::string Shift::Json() const {
 
 	// Return formatted string
 	return JsonValue().toStyledString();
 }
 
-// Generate Json::JsonValue for this object
-Json::Value Shift::JsonValue() {
+// Generate Json::Value for this object
+Json::Value Shift::JsonValue() const {
 
 	// Create root json object
 	Json::Value root = EffectBase::JsonValue(); // get parent properties
@@ -153,24 +153,12 @@ Json::Value Shift::JsonValue() {
 }
 
 // Load JSON string into this object
-void Shift::SetJson(std::string value) {
+void Shift::SetJson(const std::string value) {
 
 	// Parse JSON string into JSON objects
-	Json::Value root;
-	Json::CharReaderBuilder rbuilder;
-	Json::CharReader* reader(rbuilder.newCharReader());
-
-	std::string errors;
-	bool success = reader->parse( value.c_str(),
-                 value.c_str() + value.size(), &root, &errors );
-	delete reader;
-
-	if (!success)
-		// Raise exception
-		throw InvalidJSON("JSON could not be parsed (or is invalid)");
-
 	try
 	{
+		const Json::Value root = openshot::stringToJson(value);
 		// Set all values that match
 		SetJsonValue(root);
 	}
@@ -181,8 +169,8 @@ void Shift::SetJson(std::string value) {
 	}
 }
 
-// Load Json::JsonValue into this object
-void Shift::SetJsonValue(Json::Value root) {
+// Load Json::Value into this object
+void Shift::SetJsonValue(const Json::Value root) {
 
 	// Set parent data
 	EffectBase::SetJsonValue(root);
@@ -195,7 +183,7 @@ void Shift::SetJsonValue(Json::Value root) {
 }
 
 // Get all properties for a specific frame
-std::string Shift::PropertiesJSON(int64_t requested_frame) {
+std::string Shift::PropertiesJSON(int64_t requested_frame) const {
 
 	// Generate JSON properties list
 	Json::Value root;

--- a/src/effects/Wave.cpp
+++ b/src/effects/Wave.cpp
@@ -113,14 +113,14 @@ std::shared_ptr<Frame> Wave::GetFrame(std::shared_ptr<Frame> frame, int64_t fram
 }
 
 // Generate JSON string of this object
-std::string Wave::Json() {
+std::string Wave::Json() const {
 
 	// Return formatted string
 	return JsonValue().toStyledString();
 }
 
-// Generate Json::JsonValue for this object
-Json::Value Wave::JsonValue() {
+// Generate Json::Value for this object
+Json::Value Wave::JsonValue() const {
 
 	// Create root json object
 	Json::Value root = EffectBase::JsonValue(); // get parent properties
@@ -136,24 +136,12 @@ Json::Value Wave::JsonValue() {
 }
 
 // Load JSON string into this object
-void Wave::SetJson(std::string value) {
+void Wave::SetJson(const std::string value) {
 
 	// Parse JSON string into JSON objects
-	Json::Value root;
-	Json::CharReaderBuilder rbuilder;
-	Json::CharReader* reader(rbuilder.newCharReader());
-
-	std::string errors;
-	bool success = reader->parse( value.c_str(),
-                 value.c_str() + value.size(), &root, &errors );
-	delete reader;
-
-	if (!success)
-		// Raise exception
-		throw InvalidJSON("JSON could not be parsed (or is invalid)");
-
 	try
 	{
+		const Json::Value root = openshot::stringToJson(value);
 		// Set all values that match
 		SetJsonValue(root);
 	}
@@ -164,8 +152,8 @@ void Wave::SetJson(std::string value) {
 	}
 }
 
-// Load Json::JsonValue into this object
-void Wave::SetJsonValue(Json::Value root) {
+// Load Json::Value into this object
+void Wave::SetJsonValue(const Json::Value root) {
 
 	// Set parent data
 	EffectBase::SetJsonValue(root);
@@ -184,7 +172,7 @@ void Wave::SetJsonValue(Json::Value root) {
 }
 
 // Get all properties for a specific frame
-std::string Wave::PropertiesJSON(int64_t requested_frame) {
+std::string Wave::PropertiesJSON(int64_t requested_frame) const {
 
 	// Generate JSON properties list
 	Json::Value root;

--- a/tests/ReaderBase_Tests.cpp
+++ b/tests/ReaderBase_Tests.cpp
@@ -49,9 +49,9 @@ TEST(ReaderBase_Derived_Class)
 		std::shared_ptr<Frame> GetFrame(int64_t number) { std::shared_ptr<Frame> f(new Frame()); return f; }
 		void Close() { };
 		void Open() { };
-		string Json() { return NULL; };
+		string Json() const { return NULL; };
 		void SetJson(string value) { };
-		Json::Value JsonValue() { return (int) NULL; };
+		Json::Value JsonValue() const { return (int) NULL; };
 		void SetJsonValue(Json::Value root) { };
 		bool IsOpen() { return true; };
 		string Name() { return "TestReader"; };


### PR DESCRIPTION
This PR makes several sweeping (but fairly minor) changes to the way Json data-passing is implemented across the codebase:

1. Parsing from `std::string` to `Json::Value` is now done by a new utility function `openshot::stringToJson()`, which in turn lives in a new source file `src/Json.cpp`. All `SetJson()` methods in the library now call that function instead of repeating the same parsing boilerplate everywhere.
   - `openshot::stringToJson()` is now the _only_ place **in the `src/` directory** where the `Json::Value::parse()` method is called, and the only place where the code builds a `Json::CharReader` object from `Json::CharReaderBuilder`. (There's one method in `src/ChunkReader.cpp` which parses an input file stream using a `Json::CharReaderBuilder` with `Json::parseFromStream()`.)
   - The "in the `src/` directory" qualifier above is because `tests/Clip_tests.cpp` still does its own parsing, rather than using `openshot::stringToJson()`, for sanity-checking purposes.
   - This greatly reduces copy-paste code duplication in the `SetJson()` methods, though not as much as I'd like. (It really feels like it should be possible to template them away completely, to be honest.)
1. Use of `const` member functions and args is greatly expanded where appropriate.
1. Code that was using `std::stringstream` solely to format numeric values as strings now does so directly, with C++11's `std::to_string()`.
1. Docstrings across the codebase referred to the nonexistent type `Json::JsonValue`, which has been corrected to `Json::Value`.

#### Abstract base class changes
Item 2 on the above list applies to (some of) the abstract base classes as well, like `ClipBase` and `ReaderBase`. Because the pure virtual class methods `Json()` and `JsonValue()` of the abstract base classes were changed to have a `const` signature, their derived classes have to declare the concrete overrides for those methods `const` as well or the signatures won't match.

This doesn't really affect _users_ of the code (I simply changed all of the relevant declarations in the derived classes as well), but it will impact any library consumers if they declare their own classes derived from the base classes. For instance, the only change  I had to make to any of the unit test files was in `tests/ReaderBase_tests.cpp`:
```diff
diff --git a/tests/ReaderBase_Tests.cpp b/tests/ReaderBase_Tests.cpp
index 8ac2832..e3062bc 100644
--- a/tests/ReaderBase_Tests.cpp
+++ b/tests/ReaderBase_Tests.cpp
@@ -44,19 +44,19 @@ TEST(ReaderBase_Derived_Class)
 	class TestReader : public ReaderBase
 	{
 	public:
 		TestReader() { };
 		CacheBase* GetCache() { return NULL; };
 		std::shared_ptr<Frame> GetFrame(int64_t number) { std::shared_ptr<Frame> f(new Frame()); return f; }
 		void Close() { };
 		void Open() { };
-		string Json() { return NULL; };
+		string Json() const { return NULL; };
 		void SetJson(string value) { };
-		Json::Value JsonValue() { return (int) NULL; };
+		Json::Value JsonValue() const { return (int) NULL; };
 		void SetJsonValue(Json::Value root) { };
 		bool IsOpen() { return true; };
 		string Name() { return "TestReader"; };
 	};
 
 	// Create an instance of the derived class
 	TestReader t1;
```

Without that change, the `ReaderBase_Derived_Class` test fails to compile, because the `TestReader` class fails to implement the pure virtual `const` methods in `ReaderBase`.

Like I said, this won't affect OpenShot, or normal consumers of the library, but it might affect @DylanC, @jeffski, or other users of `libopenshot` if they declare their own classes derived from our abstract base classes. That's kind of unfortunate, and if anyone knows a good way around that, so that derived classes will continue to compile without changes despite these changes to the base class definitions, I'd love to incorporate a fix.