### PR TITLE
CMake: Add Features for docs, unit tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,7 +79,16 @@ option(ENABLE_DOCS "Build API documentation (requires Doxygen)" ON)
 
 # Legacy commandline override
 if (DISABLE_TESTS)
-  set(ENABLE_TESTS OFF CACHE BOOL "Build unit tests (requires UnitTest++)" FORCE)
+  if(ENABLE_COVERAGE)
+    message(WARNING "ENABLE_COVERAGE requires tests, overriding DISABLE_TESTS")
+    set(ENABLE_TESTS ON)
+  else()
+    set(ENABLE_TESTS OFF)
+  endif()
+endif()
+
+if(DEFINED ENABLE_TESTS)
+  set(ENABLE_TESTS ${ENABLE_TESTS} CACHE BOOL "Build unit tests (requires UnitTest++)" FORCE)
 endif()
 
 ########## Configure Version.h header ##############
@@ -120,7 +129,7 @@ if (ENABLE_COVERAGE)
     message(STATUS "Coverage enabled, setting build type to Debug")
   endif()
   include(CodeCoverage)
-  APPEND_COVERAGE_COMPILER_FLAGS()
+  append_coverage_compiler_flags()
 endif()
 add_feature_info("Coverage" ENABLE_COVERAGE "analyze test coverage and generate report")
 
@@ -152,9 +161,10 @@ add_feature_info("Documentation" DOCS_ENABLED "Build API documentation with 'mak
 
 ############# PROCESS tests/ DIRECTORY ##############
 if(ENABLE_TESTS)
+  set(TESTS_ENABLED TRUE) # May be overridden by tests/CMakeLists.txt
   add_subdirectory(tests)
 endif()
-add_feature_info("Unit tests" ENABLE_TESTS "Compile unit tests for library functions")
+add_feature_info("Unit tests" TESTS_ENABLED "Compile unit tests for library functions")
 
 ############## COVERAGE REPORTING #################
 if (ENABLE_COVERAGE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,9 +73,14 @@ include(FeatureSummary)
 # Optional build settings for libopenshot
 option(USE_SYSTEM_JSONCPP "Use system installed JsonCpp, if found" ON)
 option(DISABLE_BUNDLED_JSONCPP "Don't fall back to bundled JsonCpp" OFF)
-option(DISABLE_TESTS "Don't build unit tests" OFF)
 option(ENABLE_IWYU "Enable 'Include What You Use' scanner (CMake 3.3+)" OFF)
-option(ENABLE_COVERAGE "Enable coverage reporting" OFF)
+option(ENABLE_TESTS "Build unit tests (requires UnitTest++)" ON)
+option(ENABLE_DOCS "Build API documentation (requires Doxygen)" ON)
+
+# Legacy commandline override
+if (DISABLE_TESTS)
+  set(ENABLE_TESTS OFF CACHE BOOL "Build unit tests (requires UnitTest++)" FORCE)
+endif()
 
 ########## Configure Version.h header ##############
 configure_file(include/OpenShotVersion.h.in include/OpenShotVersion.h @ONLY)
@@ -124,27 +129,32 @@ add_subdirectory(src)
 
 ################### DOCUMENTATION ###################
 # Find Doxygen (used for documentation)
-include(cmake/Modules/UseDoxygen.cmake)
+set(DOCS_ENABLED FALSE) # Only set true if Doxygen is found and configured
+if (ENABLE_DOCS)
+  include(cmake/Modules/UseDoxygen.cmake)
 
-# Doxygen was found
-if (TARGET doc)
-	message(STATUS "Doxygen found, documentation target enabled")
-	message("\nTo compile documentation in doc/html, run: 'make doc'")
+  # Doxygen was found
+  if (TARGET doc)
+  	message(STATUS "Doxygen found, documentation target enabled")
+  	set(DOCS_ENABLED TRUE)
 
-  # Install docs, if the user builds them with `make doc`
-  install(CODE "MESSAGE(\"Checking for documentation files to install...\")")
-  install(CODE "MESSAGE(\"(Compile with 'make doc' command, requires Doxygen)\")")
+    # Install docs, if the user builds them with `make doc`
+    install(CODE "MESSAGE(\"Checking for documentation files to install...\")")
+    install(CODE "MESSAGE(\"(Compile with 'make doc' command, requires Doxygen)\")")
 
-  install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/doc/html/
-          DESTINATION ${CMAKE_INSTALL_DOCDIR}/API
-          MESSAGE_NEVER # Don't spew about file copies
-          OPTIONAL )    # No error if the docs aren't found
+    install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/doc/html/
+            DESTINATION ${CMAKE_INSTALL_DOCDIR}/API
+            MESSAGE_NEVER # Don't spew about file copies
+            OPTIONAL )    # No error if the docs aren't found
+  endif()
 endif()
+add_feature_info("Documentation" DOCS_ENABLED "Build API documentation with 'make doc'")
 
 ############# PROCESS tests/ DIRECTORY ##############
-if(NOT DISABLE_TESTS)
+if(ENABLE_TESTS)
   add_subdirectory(tests)
 endif()
+add_feature_info("Unit tests" ENABLE_TESTS "Compile unit tests for library functions")
 
 ############## COVERAGE REPORTING #################
 if (ENABLE_COVERAGE)

--- a/cmake/Modules/FindUnitTest++.cmake
+++ b/cmake/Modules/FindUnitTest++.cmake
@@ -1,43 +1,59 @@
-# Locate UNITTEST
+# Locate UnitTest++
 # This module defines
-# UNITTEST++_LIBRARY
-# UNITTEST++_FOUND, if false, do not try to link to gdal 
-# UNITTEST++_INCLUDE_DIR, where to find the headers
+# UnitTest++_FOUND, if successful
+# UnitTest++_LIBRARIES, the library path
+# UnitTest++_INCLUDE_DIRS, where to find the headers
 
-FIND_PATH(UNITTEST++_INCLUDE_DIR UnitTest++.h
-    ${UNITTEST_DIR}/include/unittest++
-    $ENV{UNITTEST_DIR}/include/unittest++
-	$ENV{UNITTEST_DIR}/src
+find_package(PkgConfig QUIET)
+if(PKG_CONFIG_FOUND)
+  pkg_check_modules(PC_UnitTest QUIET UnitTest++)
+  set(UnitTest++_VERSION ${PC_UnitTest_VERSION})
+endif()
+
+
+FIND_PATH(UnitTest++_INCLUDE_DIRS UnitTest++.h
+  DOC
+    "Location of UnitTest++ header files"
+  PATH_SUFFIXES
+    unittest++
+    UnitTest++  # Fedora, Arch
+    unittest-cpp  # openSUSE
+  HINTS
+    ${PC_UnitTest++_INCLUDEDIR}
+    ${PC_UnitTest++_INCLUDE_DIRS}
+  PATHS
+    ${UnitTest++_ROOT}
+    ${UNITTEST_DIR}
+    $ENV{UNITTEST_DIR}/src
     $ENV{UNITTEST_DIR}
     ~/Library/Frameworks
     /Library/Frameworks
-    /usr/local/include
-    /usr/include
-    /usr/include/unittest++
-    /usr/include/UnitTest++ # Fedora
-    /usr/include/unittest-cpp # openSUSE
-    /usr/local/include/UnitTest++/ # Arch
-    /sw/include # Fink
-    /opt/local/include # DarwinPorts
-    /opt/local/include/UnitTest++
-    /opt/csw/include # Blastwave
-    /opt/include
+    /usr/local
+    /sw  # Fink
+    /opt
+    /opt/local  # DarwinPorts
+    /opt/csw  # Blastwave
     [HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\Session\ Manager\\Environment]/include
-    /usr/freeware/include
+    /usr/freeware
 )
 
-FIND_LIBRARY(UNITTEST++_LIBRARY 
-    NAMES unittest++ UnitTest++
-    PATHS
-    ${UNITTEST_DIR}/lib
-    $ENV{UNITTEST_DIR}/lib
-	$ENV{UNITTEST_DIR}/build
+FIND_LIBRARY(UnitTest++_LIBRARIES 
+  NAMES unittest++ UnitTest++
+  DOC
+    "Location of UnitTest++ shared library"
+  HINTS
+    ${PC_UnitTest++_LIBDIR}
+    ${PC_UnitTest++_LIBRARY_DIRS}
+  PATHS
+    ${UnitTest++_ROOT}
+    ${UnitTest++_ROOT}/lib
+    ${UNITTEST_DIR}
     $ENV{UNITTEST_DIR}
+    $ENV{UNITTEST_DIR}/lib
+    $ENV{UNITTEST_DIR}/build
     ~/Library/Frameworks
     /Library/Frameworks
     /usr/local/lib
-    /usr/lib
-    /usr/lib64/ # Fedora
     /sw/lib
     /opt/local/lib
     /opt/csw/lib
@@ -46,13 +62,24 @@ FIND_LIBRARY(UNITTEST++_LIBRARY
     /usr/freeware/lib64
 )
 
-SET(UNITTEST++_FOUND "NO")
-IF(UNITTEST++_LIBRARY AND UNITTEST++_INCLUDE_DIR)
-    SET(UNITTEST++_FOUND "YES")
-ENDIF(UNITTEST++_LIBRARY AND UNITTEST++_INCLUDE_DIR)
+if(UnitTest++_LIBRARIES AND UnitTest++_INCLUDE_DIRS)
+  set(UnitTest++_FOUND TRUE)
+endif()
 
 include(FindPackageHandleStandardArgs)
-# handle the QUIETLY and REQUIRED arguments and set UNITTEST++_FOUND to TRUE
-# if all listed variables are TRUE
-find_package_handle_standard_args(UNITTEST++  DEFAULT_MSG
-                                  UNITTEST++_LIBRARY UNITTEST++_INCLUDE_DIR)
+find_package_handle_standard_args(UnitTest++
+  REQUIRED_VARS
+    UnitTest++_LIBRARIES
+    UnitTest++_INCLUDE_DIRS
+  VERSION_VAR
+    UnitTest++_VERSION
+)
+
+# Excessive backwards-compatibility paranoia
+set(UnitTest++_LIBRARY "${UnitTest++_LIBRARIES}" PARENT_SCOPE)
+set(UnitTest++_INCLUDE_DIR "${UnitTest++_INCLUDE_DIRS}" PARENT_SCOPE)
+# Even more excessive backwards-compatibility paranoia
+set(UNITTEST++_FOUND "${UnitTest++_FOUND}" PARENT_SCOPE)
+set(UNITTEST++_LIBRARY "${UnitTest++_LIBRARIES}" PARENT_SCOPE)
+set(UNITTEST++_INCLUDE_DIR "${UnitTest++_INCLUDE_DIRS}" PARENT_SCOPE)
+

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -24,107 +24,112 @@
 # along with OpenShot Library. If not, see <http://www.gnu.org/licenses/>.
 ################################################################################
 
-SET(TEST_MEDIA_PATH "${PROJECT_SOURCE_DIR}/src/examples/")
+# Test media path, used by unit tests for input data
+file(TO_NATIVE_PATH "${PROJECT_SOURCE_DIR}/src/examples/" TEST_MEDIA_PATH)
+add_definitions( -DTEST_MEDIA_PATH="${TEST_MEDIA_PATH}" )
 
 ################ WINDOWS ##################
 # Set some compiler options for Windows
 # required for libopenshot-audio headers
-IF (WIN32)
-	STRING(REPLACE "/" "\\\\" TEST_MEDIA_PATH TEST_MEDIA_PATH)
+if(WIN32)
 	add_definitions( -DIGNORE_JUCE_HYPOT=1 )
-	SET(CMAKE_CXX_FLAGS " ${CMAKE_CXX_FLAGS} -include cmath")
-ENDIF(WIN32)
-
-add_definitions( -DTEST_MEDIA_PATH="${TEST_MEDIA_PATH}" )
+	set(CMAKE_CXX_FLAGS " ${CMAKE_CXX_FLAGS} -include cmath")
+endif()
 
 ################### UNITTEST++ #####################
 # Find UnitTest++ libraries (used for unit testing)
-FIND_PACKAGE(UnitTest++ REQUIRED)
+find_package(UnitTest++)
+
+if (NOT UnitTest++_FOUND)
+  set(TESTS_ENABLED OFF PARENT_SCOPE)
+  return()
+endif()
 
 # Include UnitTest++ headers (needed for compile)
 include_directories(${UNITTEST++_INCLUDE_DIR})
 
 ################ IMAGE MAGICK ##################
 # Set the Quantum Depth that ImageMagick was built with (default to 16 bits)
-IF (MAGICKCORE_QUANTUM_DEPTH)
+if(MAGICKCORE_QUANTUM_DEPTH)
 	add_definitions( -DMAGICKCORE_QUANTUM_DEPTH=${MAGICKCORE_QUANTUM_DEPTH} )
-ELSE (MAGICKCORE_QUANTUM_DEPTH)
+else()
 	add_definitions( -DMAGICKCORE_QUANTUM_DEPTH=16 )
-ENDIF (MAGICKCORE_QUANTUM_DEPTH)
-IF (MAGICKCORE_HDRI_ENABLE)
+endif()
+
+if(MAGICKCORE_HDRI_ENABLE)
 	add_definitions( -DMAGICKCORE_HDRI_ENABLE=${MAGICKCORE_HDRI_ENABLE} )
-ELSE (MAGICKCORE_HDRI_ENABLE)
+else()
 	add_definitions( -DMAGICKCORE_HDRI_ENABLE=0 )
-ENDIF (MAGICKCORE_HDRI_ENABLE)
-IF (OPENSHOT_IMAGEMAGICK_COMPATIBILITY)
+endif()
+
+if(OPENSHOT_IMAGEMAGICK_COMPATIBILITY)
 	add_definitions( -DOPENSHOT_IMAGEMAGICK_COMPATIBILITY=${OPENSHOT_IMAGEMAGICK_COMPATIBILITY} )
-ELSE (OPENSHOT_IMAGEMAGICK_COMPATIBILITY)
+else()
 	add_definitions( -DOPENSHOT_IMAGEMAGICK_COMPATIBILITY=0 )
-ENDIF (OPENSHOT_IMAGEMAGICK_COMPATIBILITY)
+endif()
 
 # Find the ImageMagick++ library
-FIND_PACKAGE(ImageMagick COMPONENTS Magick++ MagickWand MagickCore)
-IF (ImageMagick_FOUND)
+find_package(ImageMagick COMPONENTS Magick++ MagickWand MagickCore)
+if(ImageMagick_FOUND)
 	# Include ImageMagick++ headers (needed for compile)
 	include_directories(${ImageMagick_INCLUDE_DIRS})
 
 	# define a global var (used in the C++)
 	add_definitions( -DUSE_IMAGEMAGICK=1 )
-	SET(CMAKE_SWIG_FLAGS "-DUSE_IMAGEMAGICK=1")
-
-ENDIF (ImageMagick_FOUND)
+	set(CMAKE_SWIG_FLAGS "-DUSE_IMAGEMAGICK=1")
+endif()
 
 ################# LIBOPENSHOT-AUDIO ###################
 # Find JUCE-based openshot Audio libraries
-FIND_PACKAGE(OpenShotAudio 0.1.9 REQUIRED)
+find_package(OpenShotAudio 0.1.9 REQUIRED)
 
 # Include Juce headers (needed for compile)
 include_directories(${LIBOPENSHOT_AUDIO_INCLUDE_DIRS})
 
 
 ################# BLACKMAGIC DECKLINK ###################
-IF (ENABLE_BLACKMAGIC)
+if(ENABLE_BLACKMAGIC)
 	# Find BlackMagic DeckLinkAPI libraries
-	FIND_PACKAGE(BlackMagic)
+	find_package(BlackMagic)
 
-	IF (BLACKMAGIC_FOUND)
+	if(BLACKMAGIC_FOUND)
 		# Include Blackmagic headers (needed for compile)
 		include_directories(${BLACKMAGIC_INCLUDE_DIR})
-	ENDIF (BLACKMAGIC_FOUND)
-ENDIF (ENABLE_BLACKMAGIC)
+	endif()
+endif()
 
 
 ###############  SET TEST SOURCE FILES  #################
-SET ( OPENSHOT_TEST_FILES
-	   Cache_Tests.cpp
-	   Clip_Tests.cpp
-	   Color_Tests.cpp
-	   Coordinate_Tests.cpp
-	   ReaderBase_Tests.cpp
-	   ImageWriter_Tests.cpp
-	   FFmpegReader_Tests.cpp
-	   FFmpegWriter_Tests.cpp
-	   Fraction_Tests.cpp
-     Frame_Tests.cpp
-	   FrameMapper_Tests.cpp
-	   KeyFrame_Tests.cpp
-	   Point_Tests.cpp
-	   Settings_Tests.cpp
-	   Timeline_Tests.cpp )
+set(OPENSHOT_TEST_FILES
+  Cache_Tests.cpp
+  Clip_Tests.cpp
+  Color_Tests.cpp
+  Coordinate_Tests.cpp
+  ReaderBase_Tests.cpp
+  ImageWriter_Tests.cpp
+  FFmpegReader_Tests.cpp
+  FFmpegWriter_Tests.cpp
+  Fraction_Tests.cpp
+  Frame_Tests.cpp
+  FrameMapper_Tests.cpp
+  KeyFrame_Tests.cpp
+  Point_Tests.cpp
+  Settings_Tests.cpp
+  Timeline_Tests.cpp )
 
 ################ TESTER EXECUTABLE #################
 # Create unit test executable (openshot-test)
 message (STATUS "Tests enabled, test executable will be built as tests/openshot-test")
 add_executable(openshot-test
-			   tests.cpp
-			   ${OPENSHOT_TEST_FILES} )
+  tests.cpp
+  ${OPENSHOT_TEST_FILES} )
 
 # Link libraries to the new executable
 target_link_libraries(openshot-test openshot ${UNITTEST++_LIBRARY})
 
 ##### RUNNING TESTS (make os_test / make test) #####
 # Hook up the 'make os_test' target to the 'openshot-test' executable
-ADD_CUSTOM_TARGET(os_test COMMAND openshot-test)
+add_custom_target(os_test COMMAND openshot-test)
 
 # Also hook up 'make test', if possible
 # This requires CMake 3.11+, where the CMP0037 policy

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -125,7 +125,6 @@ target_link_libraries(openshot-test openshot ${UNITTEST++_LIBRARY})
 ##### RUNNING TESTS (make os_test / make test) #####
 # Hook up the 'make os_test' target to the 'openshot-test' executable
 ADD_CUSTOM_TARGET(os_test COMMAND openshot-test)
-list(APPEND OS_TEST_CMDS "'make os_test'")
 
 # Also hook up 'make test', if possible
 # This requires CMake 3.11+, where the CMP0037 policy
@@ -137,8 +136,8 @@ endif()
 if (CMAKE_VERSION VERSION_GREATER 3.11)
 	message(STATUS "Cmake 3.11+ detected, enabling 'test' target")
 	add_custom_target(test COMMAND openshot-test)
-	list(APPEND OS_TEST_CMDS " or " "'make test'")
+	set(TEST_TARGET_NAME "test")
+else()
+  set(TEST_TARGET_NAME "os_test")
 endif()
-
-string(CONCAT t ${OS_TEST_CMDS})
-message("\nTo run unit tests, use: ${t}")
+add_feature_info("Testrunner" ENABLE_TESTS "Run unit tests with 'make ${TEST_TARGET_NAME}'")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -46,7 +46,11 @@ if (NOT UnitTest++_FOUND)
 endif()
 
 # Include UnitTest++ headers (needed for compile)
-include_directories(${UNITTEST++_INCLUDE_DIR})
+include_directories(${UnitTest++_INCLUDE_DIRS})
+
+set_package_properties(UnitTest++ PROPERTIES
+  TYPE RECOMMENDED
+  PURPOSE "Unit testing framework")
 
 ################ IMAGE MAGICK ##################
 # Set the Quantum Depth that ImageMagick was built with (default to 16 bits)
@@ -125,7 +129,7 @@ add_executable(openshot-test
   ${OPENSHOT_TEST_FILES} )
 
 # Link libraries to the new executable
-target_link_libraries(openshot-test openshot ${UNITTEST++_LIBRARY})
+target_link_libraries(openshot-test openshot ${UnitTest++_LIBRARIES})
 
 ##### RUNNING TESTS (make os_test / make test) #####
 # Hook up the 'make os_test' target to the 'openshot-test' executable


### PR DESCRIPTION
- A new CMake option, ENABLE_TESTS, is created and defaults ON; pass `-DENABLE_TESTS=0` to disable. (Legacy `-DDISABLE_TESTS=1` will also override)
- Target info for docs and tests is shown in the FeatureSummary
- UnitTest++ is now `RECOMMENDED`, not `REQUIRED`, since libopenshot can be built without running unit tests

I also briefly broke `FindUnitTest++.cmake`, at one point completely changed the name to `FindUnitTestCpp.cmake`, and then ended up restoring the original name.

(There's a bug in CMake that prevents certain features of `FindPackageHandleStandardArgs()` from being used with module names that contain regular expression special characters (like `+`) — I actually submitted a change to CMake that _fixes_ that issue, which [was merged](https://gitlab.kitware.com/cmake/cmake/merge_requests/4266) so in the future it won't be a concern. But since we support older releases, simplest solution is to just avoid making use of the feature (`FOUND_VARIABLE`) in question, which is what the new code does.)

By way of penance, when I restored the original module name I also added `pkg-config` support, so if UnitTest++ is installed in a standard system location (or if its `pkgconfig` directory location is added to the list of paths in the `PKG_CONFIG_PATH` environment variable) then `FindUnitTest++.cmake` will pick up a `UnitTest++.pc` file and import that info into the build environment.

No `IMPORTED` targets yet, though that's still on my goals list for this PR before merging. If it seems like it's just not gonna happen, I'll merge without and do that some time in the future.

The same old (environment,cache) variables will still work to set its path, but the PREFERRED way of specifying the location of UnitTest++ is by adding a `-DUnitTest++_ROOT=/path/to/unittest++` argument to the CMake command line. <code><var>pkgname</var>_ROOT</code> variables are handled with extra intelligence by CMake 3.12+, and the Find module (most, if not all, of our find modules now) now has forward-compatibility code that explicitly looks for those variables, so they'll work on older versions as well.