### PR TITLE
Travis: Add coverage + uploading to Codacy, and un-failjail FFmpeg4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,8 @@ addons:
     - qtmultimedia5-dev
     - doxygen
     - graphviz
+    - curl
+    - jq
     packages: &ff_common  # Common set of FFmpeg packages
     - *p_common
     - libfdk-aac-dev
@@ -38,7 +40,7 @@ matrix:
       env:
         - BUILD_VERSION=ffmpeg2
         - CMAKE_EXTRA_ARGS=""
-        - MAKE_TARGET="os_test"
+        - TEST_TARGET="os_test"
       os: linux
       dist: xenial
       addons:
@@ -53,7 +55,7 @@ matrix:
       env:
         - BUILD_VERSION=ffmpeg3
         - CMAKE_EXTRA_ARGS=""
-        - MAKE_TARGET="test"
+        - TEST_TARGET=test
       os: linux
       dist: bionic
       addons:
@@ -69,7 +71,7 @@ matrix:
       env:
         - BUILD_VERSION=ffmpeg4
         - CMAKE_EXTRA_ARGS=""
-        - MAKE_TARGET="test"
+        - TEST_TARGET=test
       os: linux
       dist: bionic
       addons:
@@ -95,7 +97,7 @@ matrix:
       env:
         - BUILD_VERSION=clang_ffmpeg3
         - CMAKE_EXTRA_ARGS=""
-        - MAKE_TARGET="test"
+        - TEST_TARGET=test
       os: linux
       dist: bionic
       compiler: clang
@@ -112,9 +114,9 @@ matrix:
 
     - name: "Coverage (Ubuntu 18.04 Bionic)"
       env:
-        - BUILD_VERSION=coverage
+        - BUILD_VERSION=coverage_ffmpeg3
         - CMAKE_EXTRA_ARGS="-DENABLE_COVERAGE=1"
-        - MAKE_TARGET="coverage"
+        - TEST_TARGET=coverage
       os: linux
       dist: bionic
       addons:
@@ -125,13 +127,20 @@ matrix:
           packages:
           - *ff_common
           - qt5-default
-          - libomp-dev
           - lcov
           - binutils-common # For c++filt
+
+before_script:
+  - CODACY_VERSION="$(curl -Ls https://api.bintray.com/packages/codacy/Binaries/codacy-coverage-reporter/versions/_latest | jq -r .name)"
+  - if [ "x${TEST_TARGET}" = "xcoverage" ]; then curl -Ls -o codacy-coverage-reporter "https://dl.bintray.com/codacy/Binaries/${CODACY_VERSION}/codacy-coverage-reporter-linux"; chmod +x codacy-coverage-reporter; fi
 
 script:
   - mkdir -p build; cd build;
   - cmake -DCMAKE_BUILD_TYPE:STRING="Debug" ${CMAKE_EXTRA_ARGS} ../
   - make VERBOSE=1
-  - make ${MAKE_TARGET}
+  - make ${TEST_TARGET}
   - make install DESTDIR="$BUILD_VERSION"
+  - cd ..
+
+after_success:
+  - if [ "x${TEST_TARGET}" = "xcoverage" ]; then ./codacy-coverage-reporter report -l CPP -r build/coverage.info; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,13 +33,12 @@ addons:
 
 matrix:
 
-  # The FFmpeg4 PPA is currently down as a protest
-  allow_failures:
-  - env: BUILD_VERSION=ffmpeg4
-
   include:
     - name: "FFmpeg 2 GCC (Ubuntu 16.04 Xenial)"
-      env: BUILD_VERSION=ffmpeg2
+      env:
+        - BUILD_VERSION=ffmpeg2
+        - CMAKE_EXTRA_ARGS=""
+        - MAKE_TARGET="os_test"
       os: linux
       dist: xenial
       addons:
@@ -51,7 +50,10 @@ matrix:
           - *ff_common
 
     - name: "FFmpeg 3 GCC (Ubuntu 18.04 Bionic)"
-      env: BUILD_VERSION=ffmpeg3
+      env:
+        - BUILD_VERSION=ffmpeg3
+        - CMAKE_EXTRA_ARGS=""
+        - MAKE_TARGET="test"
       os: linux
       dist: bionic
       addons:
@@ -64,7 +66,10 @@ matrix:
           - qt5-default
 
     - name: "FFmpeg 4 GCC (Ubuntu 18.04 Bionic)"
-      env: BUILD_VERSION=ffmpeg4
+      env:
+        - BUILD_VERSION=ffmpeg4
+        - CMAKE_EXTRA_ARGS=""
+        - MAKE_TARGET="test"
       os: linux
       dist: bionic
       addons:
@@ -87,7 +92,10 @@ matrix:
           - libswresample3
 
     - name: "FFmpeg 3 Clang (Ubuntu 18.04 Bionic)"
-      env: BUILD_VERSION=ffmpeg3
+      env:
+        - BUILD_VERSION=clang_ffmpeg3
+        - CMAKE_EXTRA_ARGS=""
+        - MAKE_TARGET="test"
       os: linux
       dist: bionic
       compiler: clang
@@ -101,9 +109,29 @@ matrix:
           - qt5-default
           - libomp-dev
 
+
+    - name: "Coverage (Ubuntu 18.04 Bionic)"
+      env:
+        - BUILD_VERSION=coverage
+        - CMAKE_EXTRA_ARGS="-DENABLE_COVERAGE=1"
+        - MAKE_TARGET="coverage"
+      os: linux
+      dist: bionic
+      addons:
+        apt:
+          sources:
+          - sourceline: 'ppa:openshot.developers/libopenshot-daily'
+          - sourceline: 'ppa:beineri/opt-qt-5.12.3-bionic'
+          packages:
+          - *ff_common
+          - qt5-default
+          - libomp-dev
+          - lcov
+          - binutils-common # For c++filt
+
 script:
   - mkdir -p build; cd build;
-  - cmake -DCMAKE_BUILD_TYPE:STRING="Debug" ../
+  - cmake -DCMAKE_BUILD_TYPE:STRING="Debug" ${CMAKE_EXTRA_ARGS} ../
   - make VERBOSE=1
-  - make os_test
+  - make ${MAKE_TARGET}
   - make install DESTDIR="$BUILD_VERSION"


### PR DESCRIPTION
This builds on @musteresel 's work to get coverage-reporting working (#367), by adding a new Travis build instance that generates the coverage report. It will then upload the report to [the libopenshot project at Codacy](https://app.codacy.com/manual/OpenShot/libopenshot/dashboard) for analysis.

The `allow_fail` tag is also removed from our FFmpeg4 build, as it seems the PPA walkout has ended.