### PR TITLE
Copy max_audio_samples with Frame::DeepCopy

### DIFF
--- a/src/Frame.cpp
+++ b/src/Frame.cpp
@@ -114,6 +114,7 @@ void Frame::DeepCopy(const Frame& other)
 	sample_rate = other.sample_rate;
 	pixel_ratio = Fraction(other.pixel_ratio.num, other.pixel_ratio.den);
 	color = other.color;
+	max_audio_sample = other.max_audio_sample;
 
 	if (other.image)
 		image = std::shared_ptr<QImage>(new QImage(*(other.image)));


### PR DESCRIPTION
During a DeepCopy of a Frame instance, we don't copy our max_audio_samples variable... which is set when adding audio to the audio buffer. This is mostly an optimization, but with the side effect of needing to be copied to new frame object copies.

This should resolves issues with https://github.com/OpenShot/libopenshot/pull/397.