### PR TITLE
Fix Resvg image format

### DIFF
--- a/cmake/Modules/FindRESVG.cmake
+++ b/cmake/Modules/FindRESVG.cmake
@@ -94,13 +94,17 @@ find_package_handle_standard_args(RESVG
 # Export target
 if(RESVG_FOUND AND NOT TARGET RESVG::resvg)
   message(STATUS "Creating IMPORTED target RESVG::resvg")
-  add_library(RESVG::resvg UNKNOWN IMPORTED)
+  add_library(RESVG::resvg SHARED IMPORTED)
 
   set_target_properties(RESVG::resvg PROPERTIES
     INTERFACE_INCLUDE_DIRECTORIES "${RESVG_INCLUDE_DIRS}")
 
   set_property(TARGET RESVG::resvg APPEND PROPERTY
     INTERFACE_COMPILE_DEFINITIONS "${RESVG_DEFINITIONS}")
+
+  # libresvg.so doesn't have a SONAME
+  set_property(TARGET RESVG::resvg APPEND PROPERTY
+    IMPORTED_NO_SONAME TRUE)
 
   set_property(TARGET RESVG::resvg APPEND PROPERTY
     IMPORTED_LOCATION "${RESVG_LIBRARIES}")

--- a/cmake/Modules/FindRESVG.cmake
+++ b/cmake/Modules/FindRESVG.cmake
@@ -1,28 +1,107 @@
-# - Try to find RESVG
-# Once done this will define
-# RESVG_FOUND - System has RESVG
-# RESVG_INCLUDE_DIRS - The RESVG include directories
-# RESVG_LIBRARIES - The libraries needed to use RESVG
-find_path ( RESVG_INCLUDE_DIR ResvgQt.h
-            PATHS ${RESVGDIR}/include/resvg
-                  $ENV{RESVGDIR}/include/resvg
-                  $ENV{RESVGDIR}/include
-                  /usr/include/resvg
-                  /usr/include
-                  /usr/local/include/resvg
-                  /usr/local/include )
+# vim: ts=2 sw=2
+#[=======================================================================[.rst:
+FindRESVG
+---------
+Try to find the shared-library build of resvg, the Rust SVG library
 
-find_library ( RESVG_LIBRARY NAMES resvg
-               PATHS /usr/lib
-                    /usr/local/lib
-                    $ENV{RESVGDIR}
-                    $ENV{RESVGDIR}/lib )
+IMPORTED targets
+^^^^^^^^^^^^^^^^
 
-set ( RESVG_LIBRARIES ${RESVG_LIBRARY} )
-set ( RESVG_INCLUDE_DIRS ${RESVG_INCLUDE_DIR} )
+This module defines :prop_tgt:`IMPORTED` target ``RESVG::resvg`` when
+the library and headers are found.
 
-include ( FindPackageHandleStandardArgs )
-# handle the QUIETLY and REQUIRED arguments and set RESVG_FOUND to TRUE
-# if all listed variables are TRUE
-find_package_handle_standard_args ( RESVG "Could NOT find RESVG, using Qt SVG parsing instead" RESVG_LIBRARY RESVG_INCLUDE_DIR )
-mark_as_advanced( RESVG_LIBRARY RESVG_INCLUDE_DIR )
+Result Variables
+^^^^^^^^^^^^^^^^
+
+This module defines the following variables:
+
+::
+
+  RESVG_FOUND         - Library and header files found
+  RESVG_INCLUDE_DIRS  - Include directory path
+  RESVG_LIBRARIES     - Link path to the library
+  RESVG_DEFINITIONS   - Compiler switches (currently unused)
+
+Backwards compatibility
+^^^^^^^^^^^^^^^^^^^^^^^
+
+For compatibility with previous versions of this module, uppercase names
+for FFmpeg and for all components are also recognized, and all-uppercase
+versions of the cache variables are also created.
+
+Control variables
+^^^^^^^^^^^^^^^^^
+
+The following variables can be used to provide path hints to the module:
+
+RESVGDIR      - Set in the calling CMakeLists.txt or on the command line
+ENV{RESVGDIR} - An environment variable in the cmake process context
+
+Copyright (c) 2020, FeRD (Frank Dana) <ferdnyc@gmail.com>
+#]=======================================================================]
+include(FindPackageHandleStandardArgs)
+
+# CMake 3.4+ only: Convert relative paths to absolute
+if(CMAKE_VERSION VERSION_GREATER 3.4)
+  get_filename_component(RESVGDIR ${RESVGDIR} ABSOLUTE
+    BASE_DIR ${CMAKE_CURRENT_BINARY_DIR})
+endif()
+
+find_path(RESVG_INCLUDE_DIRS
+  ResvgQt.h
+  PATHS
+    ${RESVGDIR}
+    ${RESVGDIR}/include
+    $ENV{RESVGDIR}
+    $ENV{RESVGDIR}/include
+    /usr/include
+    /usr/local/include
+  PATH_SUFFIXES
+    resvg
+    capi/include
+    resvg/capi/include
+)
+
+find_library(RESVG_LIBRARIES
+  NAMES resvg
+  PATHS
+    ${RESVGDIR}
+    ${RESVGDIR}/lib
+    $ENV{RESVGDIR}
+    $ENV{RESVGDIR}/lib
+    /usr/lib
+    /usr/local/lib
+  PATH_SUFFIXES
+    resvg
+    target/release
+    resvg/target/release
+)
+
+if (RESVG_INCLUDE_DIRS AND RESVG_LIBRARIES)
+  set(RESVG_FOUND TRUE)
+endif()
+set(RESVG_LIBRARIES ${RESVG_LIBRARIES} CACHE STRING "The Resvg library link path")
+set(RESVG_INCLUDE_DIRS ${RESVG_INCLUDE_DIRS} CACHE STRING "The Resvg include directories")
+set(RESVG_DEFINITIONS "" CACHE STRING "The Resvg CFLAGS")
+
+mark_as_advanced(RESVG_LIBRARIES RESVG_INCLUDE_DIRS RESVG_DEFINITIONS)
+
+# Give a nice error message if some of the required vars are missing.
+find_package_handle_standard_args(RESVG
+  "Could NOT find RESVG, using Qt SVG parsing instead"
+  RESVG_LIBRARIES RESVG_INCLUDE_DIRS )
+
+# Export target
+if(RESVG_FOUND AND NOT TARGET RESVG::resvg)
+  message(STATUS "Creating IMPORTED target RESVG::resvg")
+  add_library(RESVG::resvg UNKNOWN IMPORTED)
+
+  set_target_properties(RESVG::resvg PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES "${RESVG_INCLUDE_DIRS}")
+
+  set_property(TARGET RESVG::resvg APPEND PROPERTY
+    INTERFACE_COMPILE_DEFINITIONS "${RESVG_DEFINITIONS}")
+
+  set_property(TARGET RESVG::resvg APPEND PROPERTY
+    IMPORTED_LOCATION "${RESVG_LIBRARIES}")
+endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -100,20 +100,6 @@ IF (ENABLE_BLACKMAGIC)
 	ENDIF (BLACKMAGIC_FOUND)
 ENDIF (ENABLE_BLACKMAGIC)
 
-
-################### RESVG #####################
-# Find resvg library (used for rendering svg files)
-FIND_PACKAGE(RESVG)
-
-# Include resvg headers (optional SVG library)
-if (RESVG_FOUND)
-   include_directories(${RESVG_INCLUDE_DIRS})
-
-   # define a global var (used in the C++)
-   add_definitions( -DUSE_RESVG=1 )
-   SET(CMAKE_SWIG_FLAGS "-DUSE_RESVG=1")
-endif(RESVG_FOUND)
-
 ###############  PROFILING  #################
 #set(PROFILER "/usr/lib/libprofiler.so.0.3.2")
 #set(PROFILER "/usr/lib/libtcmalloc.so.4")
@@ -357,6 +343,27 @@ if (TARGET cppzmq)
   target_link_libraries(openshot PUBLIC cppzmq)
 endif()
 
+################### RESVG #####################
+# Migrate some legacy variable names
+if(DEFINED RESVGDIR AND NOT DEFINED RESVG_ROOT)
+  set(RESVG_ROOT ${RESVGDIR})
+endif()
+if(DEFINED ENV{RESVGDIR} AND NOT DEFINED RESVG_ROOT)
+  set(RESVG_ROOT $ENV{RESVGDIR})
+endif()
+
+# Find resvg library (used for rendering svg files)
+FIND_PACKAGE(RESVG)
+
+# Include resvg headers (optional SVG library)
+if (TARGET RESVG::resvg)
+  #include_directories(${RESVG_INCLUDE_DIRS})
+  target_link_libraries(openshot PUBLIC RESVG::resvg)
+
+  # define a global var (used in the C++)
+  add_definitions( -DUSE_RESVG=1 )
+  set(CMAKE_SWIG_FLAGS "-DUSE_RESVG=1")
+endif()
 
 ###############  LINK LIBRARY  #################
 # Link remaining dependency libraries
@@ -366,10 +373,6 @@ target_link_libraries(openshot PUBLIC
 
 if(ImageMagick_FOUND)
   target_link_libraries(openshot PUBLIC ${ImageMagick_LIBRARIES})
-endif()
-
-if(RESVG_FOUND)
-  target_link_libraries(openshot PUBLIC ${RESVG_LIBRARIES})
 endif()
 
 if(BLACKMAGIC_FOUND)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -360,8 +360,7 @@ if (TARGET RESVG::resvg)
   #include_directories(${RESVG_INCLUDE_DIRS})
   target_link_libraries(openshot PUBLIC RESVG::resvg)
 
-  # define a global var (used in the C++)
-  add_definitions( -DUSE_RESVG=1 )
+  target_compile_definitions(openshot PUBLIC "-DUSE_RESVG=1")
   set(CMAKE_SWIG_FLAGS "-DUSE_RESVG=1")
 endif()
 

--- a/src/QtImageReader.cpp
+++ b/src/QtImageReader.cpp
@@ -218,11 +218,14 @@ std::shared_ptr<Frame> QtImageReader::GetFrame(int64_t requested_frame)
 
 	// Scale image smaller (or use a previous scaled image)
 	if (!cached_image || (max_size.width() != max_width || max_size.height() != max_height)) {
+
+		bool rendered = false;
 #if USE_RESVG == 1
 		// If defined and found in CMake, utilize the libresvg for parsing
 		// SVG files and rasterizing them to QImages.
 		// Only use resvg for files ending in '.svg' or '.svgz'
 		if (path.toLower().endsWith(".svg") || path.toLower().endsWith(".svgz")) {
+
 			ResvgRenderer renderer(path);
 			if (renderer.isValid()) {
 				// Scale SVG size to keep aspect ratio, and fill the max_size as best as possible
@@ -230,30 +233,25 @@ std::shared_ptr<Frame> QtImageReader::GetFrame(int64_t requested_frame)
 				svg_size.scale(max_width, max_height, Qt::KeepAspectRatio);
 
 				// Create empty QImage
-				cached_image = std::shared_ptr<QImage>(new QImage(QSize(svg_size.width(), svg_size.height()), QImage::Format_RGBA8888));
+				cached_image = std::shared_ptr<QImage>(new QImage(QSize(svg_size.width(), svg_size.height()), QImage::Format_ARGB32_Premultiplied));
 				cached_image->fill(Qt::transparent);
 
 				// Render SVG into QImage
 				QPainter p(cached_image.get());
 				renderer.render(&p);
 				p.end();
-			} else {
-				// Resize current rasterized SVG (since we failed to parse original SVG file with resvg)
-				cached_image = std::shared_ptr<QImage>(new QImage(image->scaled(max_width, max_height, Qt::KeepAspectRatio, Qt::SmoothTransformation)));
-				cached_image = std::shared_ptr<QImage>(new QImage(cached_image->convertToFormat(QImage::Format_RGBA8888)));
+				rendered = true;
 			}
-		} else {
+		}
+#endif
+
+		if (!rendered) {
 			// We need to resize the original image to a smaller image (for performance reasons)
 			// Only do this once, to prevent tons of unneeded scaling operations
 			cached_image = std::shared_ptr<QImage>(new QImage(image->scaled(max_width, max_height, Qt::KeepAspectRatio, Qt::SmoothTransformation)));
-			cached_image = std::shared_ptr<QImage>(new QImage(cached_image->convertToFormat(QImage::Format_RGBA8888)));
 		}
-#else
-		// We need to resize the original image to a smaller image (for performance reasons)
-		// Only do this once, to prevent tons of unneeded scaling operations
-		cached_image = std::shared_ptr<QImage>(new QImage(image->scaled(max_width, max_height, Qt::KeepAspectRatio, Qt::SmoothTransformation)));
+
 		cached_image = std::shared_ptr<QImage>(new QImage(cached_image->convertToFormat(QImage::Format_RGBA8888)));
-#endif
 
 		// Set max size (to later determine if max_size is changed)
 		max_size.setWidth(max_width);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -76,7 +76,7 @@ ENDIF (ImageMagick_FOUND)
 
 ################# LIBOPENSHOT-AUDIO ###################
 # Find JUCE-based openshot Audio libraries
-FIND_PACKAGE(OpenShotAudio 0.1.8 REQUIRED)
+FIND_PACKAGE(OpenShotAudio 0.1.9 REQUIRED)
 
 # Include Juce headers (needed for compile)
 include_directories(${LIBOPENSHOT_AUDIO_INCLUDE_DIRS})
@@ -92,16 +92,6 @@ IF (ENABLE_BLACKMAGIC)
 		include_directories(${BLACKMAGIC_INCLUDE_DIR})
 	ENDIF (BLACKMAGIC_FOUND)
 ENDIF (ENABLE_BLACKMAGIC)
-
-
-################### RESVG #####################
-# Find resvg library (used for rendering svg files)
-FIND_PACKAGE(RESVG)
-
-# Include resvg headers (optional SVG library)
-if (RESVG_FOUND)
-	include_directories(${RESVG_INCLUDE_DIRS})
-endif(RESVG_FOUND)
 
 
 ###############  SET TEST SOURCE FILES  #################


### PR DESCRIPTION
resvg should be rendering to `QImage::Format_ARGB32_Premultiplied`, according to @RazrFalcon.

Also, tightened up the code a bit. Works fine on my system, but the AppImage will be the ultimate test.