### PR TITLE
Set IMPORTED_NO_SONAME on RESVG target

### DIFF
--- a/cmake/Modules/FindRESVG.cmake
+++ b/cmake/Modules/FindRESVG.cmake
@@ -94,17 +94,27 @@ find_package_handle_standard_args(RESVG
 # Export target
 if(RESVG_FOUND AND NOT TARGET RESVG::resvg)
   message(STATUS "Creating IMPORTED target RESVG::resvg")
-  add_library(RESVG::resvg SHARED IMPORTED)
+  if (WIN32)
+    # Windows mis-links SHARED library targets
+    add_library(RESVG::resvg UNKNOWN IMPORTED)
+    message(STATUS "  UNKNOWN IMPORTED target for Win32")
+  else()
+    # Linux needs SHARED to link because libresvg has no SONAME
+    add_library(RESVG::resvg SHARED IMPORTED)
+    set_property(TARGET RESVG::resvg APPEND PROPERTY
+      IMPORTED_NO_SONAME TRUE)
+    message(STATUS "  SHARED IMPORTED target with IMPORTED_NO_SONAME")
+  endif()
 
-  set_target_properties(RESVG::resvg PROPERTIES
+  message(STATUS "  INCLUDE_DIRECTORIES: ${RESVG_INCLUDE_DIRS}")
+  message(STATUS "  COMPILE_DEFINITIONS: ${RESVG_DEFINITIONS}")
+  message(STATUS "  IMPORTED_LOCATION: ${RESVG_LIBRARIES}")
+
+  set_property(TARGET RESVG::resvg APPEND PROPERTY
     INTERFACE_INCLUDE_DIRECTORIES "${RESVG_INCLUDE_DIRS}")
 
   set_property(TARGET RESVG::resvg APPEND PROPERTY
     INTERFACE_COMPILE_DEFINITIONS "${RESVG_DEFINITIONS}")
-
-  # libresvg.so doesn't have a SONAME
-  set_property(TARGET RESVG::resvg APPEND PROPERTY
-    IMPORTED_NO_SONAME TRUE)
 
   set_property(TARGET RESVG::resvg APPEND PROPERTY
     IMPORTED_LOCATION "${RESVG_LIBRARIES}")

--- a/cmake/Modules/FindRESVG.cmake
+++ b/cmake/Modules/FindRESVG.cmake
@@ -94,13 +94,17 @@ find_package_handle_standard_args(RESVG
 # Export target
 if(RESVG_FOUND AND NOT TARGET RESVG::resvg)
   message(STATUS "Creating IMPORTED target RESVG::resvg")
-  add_library(RESVG::resvg UNKNOWN IMPORTED)
+  add_library(RESVG::resvg SHARED IMPORTED)
 
   set_target_properties(RESVG::resvg PROPERTIES
     INTERFACE_INCLUDE_DIRECTORIES "${RESVG_INCLUDE_DIRS}")
 
   set_property(TARGET RESVG::resvg APPEND PROPERTY
     INTERFACE_COMPILE_DEFINITIONS "${RESVG_DEFINITIONS}")
+
+  # libresvg.so doesn't have a SONAME
+  set_property(TARGET RESVG::resvg APPEND PROPERTY
+    IMPORTED_NO_SONAME TRUE)
 
   set_property(TARGET RESVG::resvg APPEND PROPERTY
     IMPORTED_LOCATION "${RESVG_LIBRARIES}")


### PR DESCRIPTION
Prevents the library from being linked with its full path, instead of letting `ld` locate it at runtime.