### PR TITLE
Travis: Add libjsoncpp-dev to apt package list

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,6 +66,7 @@ matrix:
           packages:
           - *ff_common
           - qt5-default
+          - libjsoncpp-dev
 
     - name: "FFmpeg 4 GCC (Ubuntu 18.04 Bionic)"
       env:
@@ -83,6 +84,7 @@ matrix:
           packages:
           - *ff_common
           - qt5-default
+          - libjsoncpp-dev
           - libavcodec58
           - libavformat58
           - libavdevice58


### PR DESCRIPTION
Even though we bundle a copy of jsoncpp, it makes more sense to test our builds against the distros' system packages. Our copy is static, whereas the system packages could be updated. If that happens, testing in CI will hopefully help us catch any incompatibilities that get introduced (from either end).