### PR TITLE
FindRESVG: Remove debugging messages

### DIFF
--- a/cmake/Modules/FindRESVG.cmake
+++ b/cmake/Modules/FindRESVG.cmake
@@ -97,18 +97,12 @@ if(RESVG_FOUND AND NOT TARGET RESVG::resvg)
   if (WIN32)
     # Windows mis-links SHARED library targets
     add_library(RESVG::resvg UNKNOWN IMPORTED)
-    message(STATUS "  UNKNOWN IMPORTED target for Win32")
   else()
     # Linux needs SHARED to link because libresvg has no SONAME
     add_library(RESVG::resvg SHARED IMPORTED)
     set_property(TARGET RESVG::resvg APPEND PROPERTY
       IMPORTED_NO_SONAME TRUE)
-    message(STATUS "  SHARED IMPORTED target with IMPORTED_NO_SONAME")
   endif()
-
-  message(STATUS "  INCLUDE_DIRECTORIES: ${RESVG_INCLUDE_DIRS}")
-  message(STATUS "  COMPILE_DEFINITIONS: ${RESVG_DEFINITIONS}")
-  message(STATUS "  IMPORTED_LOCATION: ${RESVG_LIBRARIES}")
 
   set_property(TARGET RESVG::resvg APPEND PROPERTY
     INTERFACE_INCLUDE_DIRECTORIES "${RESVG_INCLUDE_DIRS}")


### PR DESCRIPTION
I left a bunch of debug `message()`s in the FindRESVG.cmake module.