### PR TITLE
Use Codecov.io for coverage reporting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ addons:
     - qtmultimedia5-dev
     - doxygen
     - graphviz
+    - curl
     packages: &ff_common  # Common set of FFmpeg packages
     - *p_common
     - libfdk-aac-dev
@@ -34,7 +35,10 @@ addons:
 matrix:
   include:
     - name: "FFmpeg 2 GCC (Ubuntu 16.04 Xenial)"
-      env: BUILD_VERSION=ffmpeg2
+      env:
+        - BUILD_VERSION=ffmpeg2
+        - CMAKE_EXTRA_ARGS=""
+        - TEST_TARGET="os_test"
       os: linux
       dist: xenial
       addons:
@@ -46,7 +50,10 @@ matrix:
           - *ff_common
 
     - name: "FFmpeg 3 GCC (Ubuntu 18.04 Bionic)"
-      env: BUILD_VERSION=ffmpeg3
+      env:
+        - BUILD_VERSION=ffmpeg3
+        - CMAKE_EXTRA_ARGS=""
+        - TEST_TARGET=test
       os: linux
       dist: bionic
       addons:
@@ -59,7 +66,10 @@ matrix:
           - qt5-default
 
     - name: "FFmpeg 4 GCC (Ubuntu 18.04 Bionic)"
-      env: BUILD_VERSION=ffmpeg4
+      env:
+        - BUILD_VERSION=ffmpeg4
+        - CMAKE_EXTRA_ARGS=""
+        - TEST_TARGET=test
       os: linux
       dist: bionic
       addons:
@@ -82,7 +92,10 @@ matrix:
           - libswresample3
 
     - name: "FFmpeg 3 Clang (Ubuntu 18.04 Bionic)"
-      env: BUILD_VERSION=ffmpeg3
+      env:
+        - BUILD_VERSION=clang_ffmpeg3
+        - CMAKE_EXTRA_ARGS=""
+        - TEST_TARGET=test
       os: linux
       dist: bionic
       compiler: clang
@@ -96,9 +109,31 @@ matrix:
           - qt5-default
           - libomp-dev
 
+    - name: "Coverage (Ubuntu 18.04 Bionic)"
+      env:
+        - BUILD_VERSION=coverage_ffmpeg3
+        - CMAKE_EXTRA_ARGS="-DENABLE_COVERAGE=1"
+        - TEST_TARGET=coverage
+      os: linux
+      dist: bionic
+      addons:
+        apt:
+          sources:
+          - sourceline: 'ppa:openshot.developers/libopenshot-daily'
+          - sourceline: 'ppa:beineri/opt-qt-5.12.3-bionic'
+          packages:
+          - *ff_common
+          - qt5-default
+          - lcov
+          - binutils-common # For c++filt
+
 script:
   - mkdir -p build; cd build;
   - cmake -DCMAKE_BUILD_TYPE:STRING="Debug" ../
   - make VERBOSE=1
-  - make os_test
+  - make ${TEST_TARGET}
   - make install DESTDIR="$BUILD_VERSION"
+  - cd ..
+
+after_success:
+  - if [ "x$TEST_TARGET" = "xcoverage" ]; then bash <(curl -s https://codecov.io/bash) -f build/coverage.info || echo "Codecov did not collect coverage reports"; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,28 +33,13 @@ addons:
     - libswresample-dev
 
 matrix:
-
   include:
-    - name: "FFmpeg 2 GCC (Ubuntu 16.04 Xenial)"
-      env:
-        - BUILD_VERSION=ffmpeg2
-        - CMAKE_EXTRA_ARGS=""
-        - TEST_TARGET="os_test"
-      os: linux
-      dist: xenial
-      addons:
-        apt:
-          sources:
-          - sourceline: 'ppa:openshot.developers/libopenshot-daily'
-          - sourceline: 'ppa:beineri/opt-qt-5.10.0-xenial'
-          packages:
-          - *ff_common
 
-    - name: "FFmpeg 3 GCC (Ubuntu 18.04 Bionic)"
+    - name: "Coverage (Ubuntu 18.04 Bionic)"
       env:
-        - BUILD_VERSION=ffmpeg3
-        - CMAKE_EXTRA_ARGS=""
-        - TEST_TARGET=test
+        - BUILD_VERSION=coverage_ffmpeg3
+        - CMAKE_EXTRA_ARGS="-DENABLE_COVERAGE=1"
+        - TEST_TARGET=coverage
       os: linux
       dist: bionic
       addons:
@@ -65,7 +50,8 @@ matrix:
           packages:
           - *ff_common
           - qt5-default
-          - libjsoncpp-dev
+          - lcov
+          - binutils-common # For c++filt
 
     - name: "FFmpeg 4 GCC (Ubuntu 18.04 Bionic)"
       env:
@@ -94,6 +80,23 @@ matrix:
           - libavresample4
           - libswresample3
 
+    - name: "FFmpeg 3 GCC (Ubuntu 18.04 Bionic)"
+      env:
+        - BUILD_VERSION=ffmpeg3
+        - CMAKE_EXTRA_ARGS=""
+        - TEST_TARGET=test
+      os: linux
+      dist: bionic
+      addons:
+        apt:
+          sources:
+          - sourceline: 'ppa:openshot.developers/libopenshot-daily'
+          - sourceline: 'ppa:beineri/opt-qt-5.12.3-bionic'
+          packages:
+          - *ff_common
+          - qt5-default
+          - libjsoncpp-dev
+
     - name: "FFmpeg 3 Clang (Ubuntu 18.04 Bionic)"
       env:
         - BUILD_VERSION=clang_ffmpeg3
@@ -112,23 +115,20 @@ matrix:
           - qt5-default
           - libomp-dev
 
-    - name: "Coverage (Ubuntu 18.04 Bionic)"
+    - name: "FFmpeg 2 GCC (Ubuntu 16.04 Xenial)"
       env:
-        - BUILD_VERSION=coverage_ffmpeg3
-        - CMAKE_EXTRA_ARGS="-DENABLE_COVERAGE=1"
-        - TEST_TARGET=coverage
+        - BUILD_VERSION=ffmpeg2
+        - CMAKE_EXTRA_ARGS=""
+        - TEST_TARGET="os_test"
       os: linux
-      dist: bionic
+      dist: xenial
       addons:
         apt:
           sources:
           - sourceline: 'ppa:openshot.developers/libopenshot-daily'
-          - sourceline: 'ppa:beineri/opt-qt-5.12.3-bionic'
+          - sourceline: 'ppa:beineri/opt-qt-5.10.0-xenial'
           packages:
           - *ff_common
-          - qt5-default
-          - lcov
-          - binutils-common # For c++filt
 
 script:
   - mkdir -p build; cd build;

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,15 @@
+codecov:
+  branch: default
+coverage:
+  status:
+    project:
+      default:
+        base: pr # Only post a status to pull requests
+        informational: true # Don't block PRs based on coverage stats (yet?)
+ignore:
+  - "/src/examples"
+  - "/src/Qt/demo"
+  - "/thirdparty"
+  - "/doc"
+  - "/cmake"
+  - "/*.md"


### PR DESCRIPTION
[Codacy](https://codacy.com) shows some promise, and I'd still like to use it eventually because it does a whole lot of complex tracking for repo changes, and as noisy and alarmist as it can be, for the most part I like its static analysis reporting.

But, so far setting coverage reporting up hasn't worked, the reports just don't seem to be getting there. meanwhile, setting the repo up at [codecov.io](https://codecov.io/) was a total breeze, it Just Worked™ right away. So, let's funnel our reporting there for now. It's something, at least.