### PR TITLE
Raise preview cache to CPUs*8 frames, max 64

### DIFF
--- a/src/Qt/VideoCacheThread.cpp
+++ b/src/Qt/VideoCacheThread.cpp
@@ -29,13 +29,14 @@
  */
 
 #include "../../include/Qt/VideoCacheThread.h"
+#include <algorithm>
 
 namespace openshot
 {
 	// Constructor
 	VideoCacheThread::VideoCacheThread()
 	: Thread("video-cache"), speed(1), is_playing(false), position(1)
-	, reader(NULL), max_frames(OPEN_MP_NUM_PROCESSORS * 2), current_display_frame(1)
+	, reader(NULL), max_frames(std::min(OPEN_MP_NUM_PROCESSORS * 8, 64)), current_display_frame(1)
     {
     }
 


### PR DESCRIPTION
At least on my 4-core, far from high-performance system, the effect this has on playback stuttering and smoothness is _immense_.

With a 32-frame cache, even with debug logging enabled the preview is _largely_ smooth, at least when playing a Timeline with a single, unedited clip on it. With only 8 frames of buffer to work with, playback is jerky and stuttering even in that simple, best-case scenario.