### PR TITLE
Frame: Fix interlaced AddImage

### DIFF
--- a/src/Frame.cpp
+++ b/src/Frame.cpp
@@ -818,16 +818,23 @@ void Frame::AddImage(std::shared_ptr<QImage> new_image, bool only_odd_lines)
 		// Ignore image of different sizes or formats
 		bool ret=false;
 		#pragma omp critical (AddImage)
-		if (image == new_image || image->size() != image->size() || image->format() != image->format())
-			ret=true;
-		if (ret)
+		{
+			if (image == new_image || image->size() != new_image->size()) {
+				ret = true;
+			}
+			else if (new_image->format() != image->format()) {
+				new_image = std::shared_ptr<QImage>(new QImage(new_image->convertToFormat(image->format())));
+			}
+		}
+		if (ret) {
 			return;
-
+		}
+		
 		// Get the frame's image
 		const GenericScopedLock<juce::CriticalSection> lock(addingImageSection);
 		#pragma omp critical (AddImage)
 		{
-			const unsigned char *pixels = image->constBits();
+			unsigned char *pixels = image->bits();
 			const unsigned char *new_pixels = new_image->constBits();
 
 			// Loop through the scanlines of the image (even or odd)
@@ -836,13 +843,13 @@ void Frame::AddImage(std::shared_ptr<QImage> new_image, bool only_odd_lines)
 				start = 1;
 
 			for (int row = start; row < image->height(); row += 2) {
-				memcpy((unsigned char *) pixels, new_pixels + (row * image->bytesPerLine()), image->bytesPerLine());
-				new_pixels += image->bytesPerLine();
+				int offset = row * image->bytesPerLine();
+				memcpy(pixels + offset, new_pixels + offset, image->bytesPerLine());
 			}
 
 			// Update height and width
-			width = image->width();
 			height = image->height();
+			width = image->width();
 			has_image_data = true;
 		}
 	}


### PR DESCRIPTION
Reading through the `openshot::Frame` code trying to debug the image-format switch, I came across the mess that was the current version of this method:
```c++
openshot::Frame::AddImage(QImage new_image, bool only_odd_lines) {
}
```

It's a good thing it's only called from one spot in the FrameMapper code, because holy _crap_ is it broken! Over the years, changes piled up that just kept moving it further away from what it was supposed to be doing, and because there are no unit tests for interlaced video, they were never noticed. I'm not surprised our interlaced support is broken! I don't know that this will fix it, but it should at least _un-break_ this particular method.

I had to go way, way back in the git history to find the ImageMagick version that it evolved from. Here's the original code, for comparison:
```c++
// Add (or replace) pixel data to the frame (for only the odd or even lines)
void Frame::AddImage(tr1::shared_ptr<Magick::Image> new_image, bool only_odd_lines)
{
	// Replace image (if needed)
	if (image->columns() == 1)
		image = new_image;

	// Loop through each odd or even line, and copy it to the image
	int starting_row = 0;
	if (!only_odd_lines)
		// even rows
		starting_row = 1;

	// Replace some rows of pixels
	for (int row = starting_row; row < new_image->rows(); row += 2)
	{
		// Get row of pixels from original image
		Magick::PixelPacket* row_pixels = image->getPixels(0, row, image->columns(), 1);
		const Magick::PixelPacket* new_row_pixels = new_image->getConstPixels(0, row, image->columns(), 1);

		// Copy pixels
		for (int col = 0; col < image->columns(); col++)
			row_pixels[col] = new_row_pixels[col];

		// Replace them with updated pixels
		image->syncPixels();
	}

}
```

I'll leave some inline comments below about the _new_ version (prior to this PR), for comparison purposes.