### PR TITLE
Optimized, parallelized Blur effect

### DIFF
--- a/include/effects/Blur.h
+++ b/include/effects/Blur.h
@@ -67,7 +67,6 @@ namespace openshot
 		void init_effect_details();
 
 		/// Internal blur methods (inspired and credited to http://blog.ivank.net/fastest-gaussian-blur.html)
-		int* initBoxes(float sigma, int n);
 		void boxBlurH(unsigned char *scl, unsigned char *tcl, int w, int h, int r);
 		void boxBlurT(unsigned char *scl, unsigned char *tcl, int w, int h, int r);
 


### PR DESCRIPTION
This PR optimizes the Blur effect (by far our slowest effect), streamlining the code and (most importantly) adding OMP `#pragma`s to multi-thread the execution where the operations can be cleanly parallelized.

<strike>It still won't win any speed trophies (in fact, it's still slow as _fuck_), but testing on my 4-core Intel i5 system, during an export of an 11-second Big Buck Bunny clip with a default-settings Blur applied:
* CPU usage went up from 25% to 85%-95%
* Export rate estimation increased from 0.57 FPS to > 1.2 FPS, making the new code more than twice as fast
* I don't know what the full export time would have been for the old code because I gave up and canceled after 2 minutes when it was only at 20%. But with the new code, the full export completed in `4m37s` — so, again, more than twice as fast.
* Results appear identical, at least to my eye.</strike>

I took a second run at this, after re-re-rereading the OpenMP docs, and improved the parallelization significantly. Now, exporting a slightly different clip than my previous tests, the results 
on my 4-core Intel Core i5 system are:
* CPU usage went up from 25% to around 85%
* **Export rate estimate increased from 0.58 FPS to over 5.1 FPS**, making the new code **nearly 10x as fast**
* The **old export would've taken about 13 minutes** to complete (again, I aborted before it finished), whereas **the new code can export the same thing in 1m 28s**
* The results are identical; a [video diff](http://dericed.com/2012/display-video-difference-with-ffmpegs-overlay-filter/) of the two exports produces a solid gray field (no differences)
* Unlike my previous attempt, I expect the new code now **will** benefit from additional cores, and run even faster

#### Note
You may notice that in my new code, I don't use `initBoxes`, and the `sigma` property does nothing. In fact, I removed the `initBoxes` function (and all references to it) _completely_.

The reason for this is simple: **In the _current_ (old) Blur effect, the results of `initBoxes` are never used, and the `sigma` property does nothing.**

I don't know if that was intentional or a bug, but in the existing Blur code, `initBoxes()` is a useless function — even though it's called, the results are never used in the code. So as things stood, there was no point in having it in the code. Which is why I removed it.
