### PR TITLE
Saturation: streamline and parallelize

### DIFF
--- a/src/effects/Saturation.cpp
+++ b/src/effects/Saturation.cpp
@@ -69,44 +69,36 @@ std::shared_ptr<Frame> Saturation::GetFrame(std::shared_ptr<Frame> frame, int64_
 	if (!frame_image)
 		return frame;
 
+	int pixel_count = frame_image->width() * frame_image->height();
+
 	// Get keyframe values for this frame
 	float saturation_value = saturation.GetValue(frame_number);
 
 	// Constants used for color saturation formula
-	double pR = .299;
-	double pG = .587;
-	double pB = .114;
+	const double pR = .299;
+	const double pG = .587;
+	const double pB = .114;
 
 	// Loop through pixels
 	unsigned char *pixels = (unsigned char *) frame_image->bits();
-	for (int pixel = 0, byte_index=0; pixel < frame_image->width() * frame_image->height(); pixel++, byte_index+=4)
+
+	#pragma omp parallel for shared (pixels)
+	for (int pixel = 0; pixel < pixel_count; ++pixel)
 	{
 		// Get the RGB values from the pixel
-		int R = pixels[byte_index];
-		int G = pixels[byte_index + 1];
-		int B = pixels[byte_index + 2];
-		int A = pixels[byte_index + 3];
+		int R = pixels[pixel * 4];
+		int G = pixels[pixel * 4 + 1];
+		int B = pixels[pixel * 4 + 2];
 
 		// Calculate the saturation multiplier
 		double p = sqrt( (R * R * pR) +
-						 (G * G * pG) +
-						 (B * B * pB) );
+		                 (G * G * pG) +
+		                 (B * B * pB) );
 
-		// Adjust the saturation
-		R = p + (R - p) * saturation_value;
-		G = p + (G - p) * saturation_value;
-		B = p + (B - p) * saturation_value;
-
-		// Constrain the value from 0 to 255
-		R = constrain(R);
-		G = constrain(G);
-		B = constrain(B);
-
-		// Set all pixels to new value
-		pixels[byte_index] = R;
-		pixels[byte_index + 1] = G;
-		pixels[byte_index + 2] = B;
-		pixels[byte_index + 3] = A; // leave the alpha value alone
+		// Apply adjusted and constrained saturation
+		pixels[pixel * 4]     = constrain(p + (R - p) * saturation_value);
+		pixels[pixel * 4 + 1] = constrain(p + (G - p) * saturation_value);
+		pixels[pixel * 4 + 2] = constrain(p + (B - p) * saturation_value);
 	}
 
 	// return the modified frame


### PR DESCRIPTION
Once again, Saturation was fairly efficient already, but adding `#pragma omp parallel for` and eliminating some intermediate variable storage allows it to run roughly twice as fast on my system, and I would expect even better results from a more powerful CPU.
