### PR TITLE
Handle FFmpeg 3.2's missing AV_HWDEVICE_TYPE_NONE

### DIFF
--- a/include/FFmpegUtilities.h
+++ b/include/FFmpegUtilities.h
@@ -47,6 +47,10 @@
 		#include <libavformat/avformat.h>
 	#if (LIBAVFORMAT_VERSION_MAJOR >= 57)
 		#include <libavutil/hwcontext.h> //PM
+		// FFmpeg 3.2's AVHWDeviceType enum doesn't include _NONE
+		#ifndef AV_HWDEVICE_TYPE_NONE
+			#define AV_HWDEVICE_TYPE_NONE AV_HWDEVICE_TYPE_VAAPI
+		#endif
 	#endif
 		#include <libswscale/swscale.h>
 		// Change this to the first version swrescale works


### PR DESCRIPTION
As pointed out by @cwilling in #433, FFmpeg 3.2's `AVHWDeviceType` enum doesn't include an `AV_HWDEVICE_TYPE_NONE` value — it wasn't added until FFmpeg 3.4. As a workaround, we can just `#define` it to `AV_HWDEVICE_TYPE_VAAPI` in `FFmpegUtilities.h` if it doesn't exist.

Fixes #433 
