### PR TITLE
Travis: Add FFmpeg 3.2 build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ matrix:
 
     - name: "Coverage (Ubuntu 18.04 Bionic)"
       env:
-        - BUILD_VERSION=coverage_ffmpeg3
+        - BUILD_VERSION=coverage_ffmpeg34
         - CMAKE_EXTRA_ARGS="-DENABLE_COVERAGE=1"
         - TEST_TARGET=coverage
       os: linux
@@ -80,9 +80,9 @@ matrix:
           - libavresample4
           - libswresample3
 
-    - name: "FFmpeg 3 GCC (Ubuntu 18.04 Bionic)"
+    - name: "FFmpeg 3.4 GCC (Ubuntu 18.04 Bionic)"
       env:
-        - BUILD_VERSION=ffmpeg3
+        - BUILD_VERSION=ffmpeg34
         - CMAKE_EXTRA_ARGS=""
         - TEST_TARGET=test
       os: linux
@@ -97,9 +97,9 @@ matrix:
           - qt5-default
           - libjsoncpp-dev
 
-    - name: "FFmpeg 3 Clang (Ubuntu 18.04 Bionic)"
+    - name: "FFmpeg 3.4 Clang (Ubuntu 18.04 Bionic)"
       env:
-        - BUILD_VERSION=clang_ffmpeg3
+        - BUILD_VERSION=clang_ffmpeg34
         - CMAKE_EXTRA_ARGS=""
         - TEST_TARGET=test
       os: linux
@@ -114,6 +114,31 @@ matrix:
           - *ff_common
           - qt5-default
           - libomp-dev
+
+    - name: "FFmpeg 3.2 GCC (Ubuntu 16.04 Xenial)"
+      env:
+        - BUILD_VERSION=ffmpeg32
+        - CMAKE_EXTRA_ARGS=""
+        - TEST_TARGET="os_test"
+      os: linux
+      dist: xenial
+      addons:
+        apt:
+          sources:
+          - sourceline: 'ppa:openshot.developers/libopenshot-daily'
+          - sourceline: 'ppa:beineri/opt-qt-5.10.0-xenial'
+          - sourceline: 'ppa:jon-hedgerows/ffmpeg-backports'
+          packages:
+          - *ff_common
+          - libavcodec57
+          - libavdevice57
+          - libavfilter6
+          - libavformat57
+          - libavresample3
+          - libavutil55
+          - libpostproc54
+          - libswresample2
+          - libswscale4
 
     - name: "FFmpeg 2 GCC (Ubuntu 16.04 Xenial)"
       env:

--- a/include/FFmpegUtilities.h
+++ b/include/FFmpegUtilities.h
@@ -47,6 +47,10 @@
 		#include <libavformat/avformat.h>
 	#if (LIBAVFORMAT_VERSION_MAJOR >= 57)
 		#include <libavutil/hwcontext.h> //PM
+		// FFmpeg 3.2's AVHWDeviceType enum doesn't include _NONE
+		#ifndef AV_HWDEVICE_TYPE_NONE
+			#define AV_HWDEVICE_TYPE_NONE AV_HWDEVICE_TYPE_VAAPI
+		#endif
 	#endif
 		#include <libswscale/swscale.h>
 		// Change this to the first version swrescale works


### PR DESCRIPTION
This adds an additional build type to the Travis matrix, building against FFmpeg 3.2 specifically (using a PPA which packages FFmpeg 3.2.6 for Ubuntu Xenial) — the existing FFmpeg 3 builds are relabeled "FFmpeg 3.4" to differentiate them.