### PR TITLE
Resolve ambiguous abs() call

### DIFF
--- a/src/KeyFrame.cpp
+++ b/src/KeyFrame.cpp
@@ -71,7 +71,7 @@ namespace {
 			}
 			double const x = p0.X * B[0] + p1.X * B[1] + p2.X * B[2] + p3.X * B[3];
 			double const y = p0.Y * B[0] + p1.Y * B[1] + p2.Y * B[2] + p3.Y * B[3];
-			if (abs(target - x) < allowed_error) {
+			if (fabs(target - x) < allowed_error) {
 				return y;
 			}
 			if (x > target) {


### PR DESCRIPTION
Signed-off-by: Christoph Willing <chris.willing@linux.com>

This resolves compilatin problem:
~~~
error: call of overloaded 'abs(double)' is ambiguous`
~~~
by  using fabs(double) from cmath rather than trying abs(int) from stdlib.h or  std::abs(long long int) from cstdlib