### PR TITLE
ColorShift effect: Don't init with random values

### DIFF
--- a/src/effects/ColorShift.cpp
+++ b/src/effects/ColorShift.cpp
@@ -33,7 +33,7 @@
 using namespace openshot;
 
 /// Blank constructor, useful when using Json to load the effect properties
-ColorShift::ColorShift() : red_x(-0.05), red_y(0.0), green_x(0.05), green_y(0.0), blue_x(0.0), blue_y(0.0), alpha_x(0.0), alpha_y(0.0) {
+ColorShift::ColorShift() : red_x(0.0), red_y(0.0), green_x(0.0), green_y(0.0), blue_x(0.0), blue_y(0.0), alpha_x(0.0), alpha_y(0.0) {
 	// Init effect properties
 	init_effect_details();
 }


### PR DESCRIPTION
For no discernible reason, the Color Shift effect initializes itself with the following properties:
|Property|Value|
|-----------|-------|
|Alpha X Shift|0.00|
|Alpha Y Shift|0.00|
|<b>Red X Shift</b>|<b>-0.05</b>|
|Red Y Shift|0.00|
|<b>Green X Shift</b>|<b>0.05</b>|
|Green Y Shift|0.00|
|Blue X Shift|0.00|
|Blue Y Shift|0.00|

The random "defaults" are arbitrary and unnecessary, and just complicate management of the effect parameters. This PR loses them, and inits all of the shifts to `0.00`.