### PR TITLE
ColorShift: Use one-word name in EffectInfo

### DIFF
--- a/src/EffectInfo.cpp
+++ b/src/EffectInfo.cpp
@@ -56,7 +56,7 @@ EffectBase* EffectInfo::CreateEffect(std::string effect_type) {
 	else if (effect_type == "ChromaKey")
 		return new ChromaKey();
 
-	else if (effect_type == "Color Shift")
+	else if (effect_type == "ColorShift")
 		return new ColorShift();
 
 	else if (effect_type == "Crop")


### PR DESCRIPTION
This fix is already on the release branch, merging here for completeness' sake.