### PR TITLE
bindings: Relative paths, overridable

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,13 +16,11 @@ linux-builder:
     - unzip artifacts.zip
     - export LIBOPENSHOT_AUDIO_DIR=$CI_PROJECT_DIR/build/install-x64
     - mkdir -p build; cd build;
-    - mkdir -p install-x64/python;
-    - cmake -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -D"CMAKE_INSTALL_PREFIX:PATH=$CI_PROJECT_DIR/build/install-x64" -D"CMAKE_BUILD_TYPE:STRING=Release" -D"USE_SYSTEM_JSONCPP=0" ../
+    - cmake -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -D"CMAKE_INSTALL_PREFIX:PATH=$CI_PROJECT_DIR/build/install-x64" -D"PYTHON_MODULE_PATH=python" -D"RUBY_MODULE_PATH=ruby" -DCMAKE_BUILD_TYPE:STRING=Release -DUSE_SYSTEM_JSONCPP=0 ../
     - make
     - make install
     - make doc
     - ~/auto-update-docs "$CI_PROJECT_DIR/build" "$CI_COMMIT_REF_NAME"
-    - mv install-x64/lib/python3.4/site-packages/*openshot* install-x64/python
     - echo -e "CI_PROJECT_NAME:$CI_PROJECT_NAME\nCI_COMMIT_REF_NAME:$CI_COMMIT_REF_NAME\nCI_COMMIT_SHA:$CI_COMMIT_SHA\nCI_JOB_ID:$CI_JOB_ID" > "install-x64/share/$CI_PROJECT_NAME"
     - git log $(git describe --tags --abbrev=0 @^)..@ --oneline --pretty=format:"%C(auto,yellow)%h%C(auto,magenta)% %C(auto,blue)%>(12,trunc)%ad %C(auto,green)%<(25,trunc)%aN%C(auto,reset)%s%C(auto,red)% gD% D" --date=short > "install-x64/share/$CI_PROJECT_NAME.log"
   when: always
@@ -45,11 +43,9 @@ mac-builder:
     - unzip artifacts.zip
     - export LIBOPENSHOT_AUDIO_DIR=$CI_PROJECT_DIR/build/install-x64
     - mkdir -p build; cd build;
-    - mkdir -p install-x64/python;
-    - cmake -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -D"CMAKE_INSTALL_PREFIX:PATH=$CI_PROJECT_DIR/build/install-x64" -DCMAKE_CXX_COMPILER=/usr/local/opt/gcc48/bin/g++-4.8 -DCMAKE_C_COMPILER=/usr/local/opt/gcc48/bin/gcc-4.8 -DCMAKE_PREFIX_PATH=/usr/local/qt5/5.5/clang_64 -DPYTHON_INCLUDE_DIR=/Library/Frameworks/Python.framework/Versions/3.6/include/python3.6m -DPYTHON_LIBRARY=/Library/Frameworks/Python.framework/Versions/3.6/lib/libpython3.6.dylib -DPython_FRAMEWORKS=/Library/Frameworks/Python.framework/ -D"CMAKE_BUILD_TYPE:STRING=Release" -D"CMAKE_OSX_SYSROOT=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.9.sdk" -D"CMAKE_OSX_DEPLOYMENT_TARGET=10.9" -D"CMAKE_INSTALL_RPATH_USE_LINK_PATH=1" -D"ENABLE_RUBY=0" ../
+    - cmake -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -D"CMAKE_INSTALL_PREFIX:PATH=$CI_PROJECT_DIR/build/install-x64" -DCMAKE_CXX_COMPILER=/usr/local/opt/gcc48/bin/g++-4.8 -DCMAKE_C_COMPILER=/usr/local/opt/gcc48/bin/gcc-4.8 -DCMAKE_PREFIX_PATH=/usr/local/qt5/5.5/clang_64 -DPYTHON_INCLUDE_DIR=/Library/Frameworks/Python.framework/Versions/3.6/include/python3.6m -DPYTHON_LIBRARY=/Library/Frameworks/Python.framework/Versions/3.6/lib/libpython3.6.dylib -DPYTHON_MODULE_PATH=python -DPython_FRAMEWORKS=/Library/Frameworks/Python.framework/ -D"CMAKE_BUILD_TYPE:STRING=Release" -D"CMAKE_OSX_SYSROOT=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.9.sdk" -D"CMAKE_OSX_DEPLOYMENT_TARGET=10.9" -D"CMAKE_INSTALL_RPATH_USE_LINK_PATH=1" -D"ENABLE_RUBY=0" ../
     - make
     - make install
-    - mv install-x64/lib/python3.6/site-packages/*openshot* install-x64/python
     - echo -e "CI_PROJECT_NAME:$CI_PROJECT_NAME\nCI_COMMIT_REF_NAME:$CI_COMMIT_REF_NAME\nCI_COMMIT_SHA:$CI_COMMIT_SHA\nCI_JOB_ID:$CI_JOB_ID" > "install-x64/share/$CI_PROJECT_NAME"
     - git log $(git describe --tags --abbrev=0 @^)..@ --oneline --pretty=format:"%C(auto,yellow)%h%C(auto,magenta)% %C(auto,blue)%>(12,trunc)%ad %C(auto,green)%<(25,trunc)%aN%C(auto,reset)%s%C(auto,red)% gD% D" --date=short > "install-x64/share/$CI_PROJECT_NAME.log"
   when: always
@@ -73,9 +69,8 @@ windows-builder-x64:
     - $env:RESVGDIR = "C:\msys64\usr"
     - $env:Path = "C:\msys64\mingw64\bin;C:\msys64\mingw64\lib;C:\msys64\usr\lib\cmake\UnitTest++;C:\msys64\home\jonathan\depot_tools;C:\msys64\usr;C:\msys64\usr\lib;" + $env:Path;
     - New-Item -ItemType Directory -Force -Path build
-    - New-Item -ItemType Directory -Force -Path build\install-x64\python
     - cd build
-    - cmake -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -D"CMAKE_INSTALL_PREFIX:PATH=$CI_PROJECT_DIR\build\install-x64" -G "MSYS Makefiles" -DCMAKE_MAKE_PROGRAM=mingw32-make -D"CMAKE_BUILD_TYPE:STRING=Release" ../
+    - cmake -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -D"CMAKE_INSTALL_PREFIX:PATH=$CI_PROJECT_DIR\build\install-x64" -D"PYTHON_MODULE_PATH=python" -D"RUBY_MODULE_PATH=ruby" -G "MSYS Makefiles" -DCMAKE_MAKE_PROGRAM=mingw32-make -D"CMAKE_BUILD_TYPE:STRING=Release" ../
     - mingw32-make install
     - Move-Item -Force -path "install-x64\lib\python3.7\site-packages\*openshot*" -destination "install-x64\python\"
     - New-Item -path "install-x64/share/" -Name "$CI_PROJECT_NAME" -Value "CI_PROJECT_NAME:$CI_PROJECT_NAME`nCI_COMMIT_REF_NAME:$CI_COMMIT_REF_NAME`nCI_COMMIT_SHA:$CI_COMMIT_SHA`nCI_JOB_ID:$CI_JOB_ID" -ItemType file -force
@@ -102,11 +97,9 @@ windows-builder-x86:
     - $env:RESVGDIR = "C:\msys32\usr"
     - $env:Path = "C:\msys32\mingw32\bin;C:\msys32\mingw32\lib;C:\msys32\usr\lib\cmake\UnitTest++;C:\msys32\home\jonathan\depot_tools;C:\msys32\usr;C:\msys32\usr\lib;" + $env:Path;
     - New-Item -ItemType Directory -Force -Path build
-    - New-Item -ItemType Directory -Force -Path build\install-x86\python
     - cd build
-    - cmake -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -D"CMAKE_INSTALL_PREFIX:PATH=$CI_PROJECT_DIR\build\install-x86" -G "MSYS Makefiles" -DCMAKE_MAKE_PROGRAM=mingw32-make -D"CMAKE_BUILD_TYPE:STRING=Release" -D"CMAKE_CXX_FLAGS=-m32" -D"CMAKE_EXE_LINKER_FLAGS=-Wl,--large-address-aware" -D"CMAKE_C_FLAGS=-m32" ../
+    - cmake -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -D"CMAKE_INSTALL_PREFIX:PATH=$CI_PROJECT_DIR\build\install-x86" -D"PYTHON_MODULE_PATH=python" -D"RUBY_MODULE_PATH=ruby" -G "MSYS Makefiles" -DCMAKE_MAKE_PROGRAM=mingw32-make -D"CMAKE_BUILD_TYPE:STRING=Release" -D"CMAKE_CXX_FLAGS=-m32" -D"CMAKE_EXE_LINKER_FLAGS=-Wl,--large-address-aware" -D"CMAKE_C_FLAGS=-m32" ../
     - mingw32-make install
-    - Move-Item -Force -path "install-x86\lib\python3.7\site-packages\*openshot*" -destination "install-x86\python\"
     - New-Item -path "install-x86/share/" -Name "$CI_PROJECT_NAME" -Value "CI_PROJECT_NAME:$CI_PROJECT_NAME`nCI_COMMIT_REF_NAME:$CI_COMMIT_REF_NAME`nCI_COMMIT_SHA:$CI_COMMIT_SHA`nCI_JOB_ID:$CI_JOB_ID" -ItemType file -force
     - $PREV_GIT_LABEL=(git describe --tags --abbrev=0 '@^')
     - git log "$PREV_GIT_LABEL..@" --oneline --pretty=format:"%C(auto,yellow)%h%C(auto,magenta)% %C(auto,blue)%>(12,trunc)%ad %C(auto,green)%<(25,trunc)%aN%C(auto,reset)%s%C(auto,red)% gD% D" --date=short > "install-x86/share/$CI_PROJECT_NAME.log"

--- a/.travis.yml
+++ b/.travis.yml
@@ -157,10 +157,10 @@ matrix:
 
 script:
   - mkdir -p build; cd build;
-  - cmake -DCMAKE_BUILD_TYPE:STRING="Debug" ${CMAKE_EXTRA_ARGS} ../
+  - cmake -DCMAKE_INSTALL_PREFIX:PATH="$TRAVIS_OS_NAME-x64" -DCMAKE_BUILD_TYPE:STRING="Debug" ${CMAKE_EXTRA_ARGS} ../
   - make VERBOSE=1
   - make ${TEST_TARGET}
-  - make install DESTDIR="$BUILD_VERSION"
+  - make install
   - cd ..
 
 after_success:

--- a/src/bindings/python/CMakeLists.txt
+++ b/src/bindings/python/CMakeLists.txt
@@ -26,34 +26,34 @@
 
 
 ############### SWIG PYTHON BINDINGS ################
-FIND_PACKAGE(SWIG 3.0 REQUIRED)
-INCLUDE(${SWIG_USE_FILE})
+find_package(SWIG 3.0 REQUIRED)
+include(${SWIG_USE_FILE})
 
 ### Enable some legacy SWIG behaviors, in newer CMAKEs
 if (POLICY CMP0078)
-	cmake_policy(SET CMP0078 OLD)
+  cmake_policy(SET CMP0078 OLD)
 endif()
 if (POLICY CMP0086)
-	cmake_policy(SET CMP0086 OLD)
+  cmake_policy(SET CMP0086 OLD)
 endif()
 
 FIND_PACKAGE(PythonInterp 3)
 FIND_PACKAGE(PythonLibs 3)
 if (PYTHONLIBS_FOUND AND PYTHONINTERP_FOUND)
 
-	### Include Python header files
-	INCLUDE_DIRECTORIES(${PYTHON_INCLUDE_PATH})
-	INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR})
+  ### Include Python header files
+  include_directories(${PYTHON_INCLUDE_PATH})
+  include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
-	### Enable C++ support in SWIG
-	set_property(SOURCE openshot.i PROPERTY CPLUSPLUS ON)
-	set_property(SOURCE openshot.i PROPERTY SWIG_MODULE_NAME openshot)
+  ### Enable C++ support in SWIG
+  set_property(SOURCE openshot.i PROPERTY CPLUSPLUS ON)
+  set_property(SOURCE openshot.i PROPERTY SWIG_MODULE_NAME openshot)
 
-	### Suppress a ton of warnings in the generated SWIG C++ code
-	set(SWIG_CXX_FLAGS "-Wno-unused-variable -Wno-unused-function -Wno-deprecated-copy -Wno-class-memaccess -Wno-cast-function-type \
+  ### Suppress a ton of warnings in the generated SWIG C++ code
+  set(SWIG_CXX_FLAGS "-Wno-unused-variable -Wno-unused-function -Wno-deprecated-copy -Wno-class-memaccess -Wno-cast-function-type \
 -Wno-unused-parameter -Wno-catch-value -Wno-sign-compare -Wno-ignored-qualifiers")
-	separate_arguments(sw_flags UNIX_COMMAND ${SWIG_CXX_FLAGS})
-	set_property(SOURCE openshot.i PROPERTY GENERATED_COMPILE_OPTIONS ${sw_flags})
+  separate_arguments(sw_flags UNIX_COMMAND ${SWIG_CXX_FLAGS})
+  set_property(SOURCE openshot.i PROPERTY GENERATED_COMPILE_OPTIONS ${sw_flags})
 
   ### Take include dirs from target, automatically if possible
   if (CMAKE_VERSION VERSION_GREATER 3.13)
@@ -62,19 +62,19 @@ if (PYTHONLIBS_FOUND AND PYTHONINTERP_FOUND)
     set_property(SOURCE openshot.i PROPERTY INCLUDE_DIRECTORIES $<TARGET_PROPERTY:openshot,INCLUDE_DIRECTORIES>)
   endif ()
 
-	### Add the SWIG interface file (which defines all the SWIG methods)
-	if (CMAKE_VERSION VERSION_LESS 3.8.0)
-		swig_add_module(pyopenshot python openshot.i)
-	else()
-		swig_add_library(pyopenshot LANGUAGE python SOURCES openshot.i)
-	endif()
+  ### Add the SWIG interface file (which defines all the SWIG methods)
+  if (CMAKE_VERSION VERSION_LESS 3.8.0)
+    swig_add_module(pyopenshot python openshot.i)
+  else()
+    swig_add_library(pyopenshot LANGUAGE python SOURCES openshot.i)
+  endif()
 
-	### Set output name of target
-	set_target_properties(${SWIG_MODULE_pyopenshot_REAL_NAME} PROPERTIES
+  ### Set output name of target
+  set_target_properties(${SWIG_MODULE_pyopenshot_REAL_NAME} PROPERTIES
     PREFIX "_" OUTPUT_NAME "openshot")
 
-	### Link the new python wrapper library with libopenshot
-	target_link_libraries(${SWIG_MODULE_pyopenshot_REAL_NAME} PUBLIC
+  ### Link the new python wrapper library with libopenshot
+  target_link_libraries(${SWIG_MODULE_pyopenshot_REAL_NAME} PUBLIC
     ${PYTHON_LIBRARIES} openshot)
 
   ######### INSTALL PATH ########
@@ -88,12 +88,12 @@ if (PYTHONLIBS_FOUND AND PYTHONINTERP_FOUND)
     endif()
 
     if (UNIX AND NOT APPLE)
-	    ### Check if the following Debian-friendly python module path exists
-	    set(PYTHON_MODULE_PATH "lib/python${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}/dist-packages")
-	    if (NOT EXISTS "${CMAKE_INSTALL_PREFIX}/${PYTHON_MODULE_PATH}")
+      ### Check if the following Debian-friendly python module path exists
+      set(PYTHON_MODULE_PATH "lib/python${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}/dist-packages")
+      if (NOT EXISTS "${CMAKE_INSTALL_PREFIX}/${PYTHON_MODULE_PATH}")
 
         ### Calculate the python module path (using distutils)
-		    execute_process ( COMMAND ${PYTHON_EXECUTABLE} -c "\
+        execute_process ( COMMAND ${PYTHON_EXECUTABLE} -c "\
 from distutils.sysconfig import get_python_lib; \
 print( get_python_lib( plat_specific=True, prefix='' ) )"
           OUTPUT_VARIABLE PYTHON_MODULE_PATH
@@ -104,9 +104,9 @@ print( get_python_lib( plat_specific=True, prefix='' ) )"
 
   message(STATUS "PYTHON_MODULE_PATH: ${CMAKE_INSTALL_PREFIX}/${PYTHON_MODULE_PATH}")
 
-	############### INSTALL HEADERS & LIBRARY ################
-	### Install Python bindings
-	install(TARGETS ${SWIG_MODULE_pyopenshot_REAL_NAME}
+  ############### INSTALL HEADERS & LIBRARY ################
+  ### Install Python bindings
+  install(TARGETS ${SWIG_MODULE_pyopenshot_REAL_NAME}
     DESTINATION ${PYTHON_MODULE_PATH} )
   install(FILES ${CMAKE_CURRENT_BINARY_DIR}/openshot.py
     DESTINATION ${PYTHON_MODULE_PATH} )

--- a/src/bindings/python/CMakeLists.txt
+++ b/src/bindings/python/CMakeLists.txt
@@ -71,36 +71,44 @@ if (PYTHONLIBS_FOUND AND PYTHONINTERP_FOUND)
 
 	### Set output name of target
 	set_target_properties(${SWIG_MODULE_pyopenshot_REAL_NAME} PROPERTIES
-	                      PREFIX "_" OUTPUT_NAME "openshot")
+    PREFIX "_" OUTPUT_NAME "openshot")
 
 	### Link the new python wrapper library with libopenshot
-	target_link_libraries(${SWIG_MODULE_pyopenshot_REAL_NAME}
-                        PUBLIC ${PYTHON_LIBRARIES} openshot)
+	target_link_libraries(${SWIG_MODULE_pyopenshot_REAL_NAME} PUBLIC
+    ${PYTHON_LIBRARIES} openshot)
 
-	### Check if the following Debian-friendly python module path exists
-	SET(PYTHON_MODULE_PATH "${CMAKE_INSTALL_PREFIX}/lib/python${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}/dist-packages")
-	if (NOT EXISTS ${PYTHON_MODULE_PATH})
+  ######### INSTALL PATH ########
+  if (NOT DEFINED PYTHON_MODULE_PATH AND DEFINED $ENV{PYTHON_MODULE_PATH})
+    set(PYTHON_MODULE_PATH $ENV{PYTHON_MODULE_PATH})
+  endif()
 
-		### Calculate the python module path (using distutils)
-		execute_process ( COMMAND ${PYTHON_EXECUTABLE} -c "\
+  if (NOT DEFINED PYTHON_MODULE_PATH)
+    if (WIN32 OR APPLE)
+      set (PYTHON_MODULE_PATH "python")
+    endif()
+
+    if (UNIX AND NOT APPLE)
+	    ### Check if the following Debian-friendly python module path exists
+	    set(PYTHON_MODULE_PATH "lib/python${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}/dist-packages")
+	    if (NOT EXISTS "${CMAKE_INSTALL_PREFIX}/${PYTHON_MODULE_PATH}")
+
+        ### Calculate the python module path (using distutils)
+		    execute_process ( COMMAND ${PYTHON_EXECUTABLE} -c "\
 from distutils.sysconfig import get_python_lib; \
-print( get_python_lib( plat_specific=True, prefix='${CMAKE_INSTALL_PREFIX}' ) )"
-			OUTPUT_VARIABLE _ABS_PYTHON_MODULE_PATH
-			OUTPUT_STRIP_TRAILING_WHITESPACE )
+print( get_python_lib( plat_specific=True, prefix='' ) )"
+          OUTPUT_VARIABLE PYTHON_MODULE_PATH
+          OUTPUT_STRIP_TRAILING_WHITESPACE )
+      endif()
+    endif()
+  endif()
 
-		GET_FILENAME_COMPONENT(_ABS_PYTHON_MODULE_PATH
-				"${_ABS_PYTHON_MODULE_PATH}" ABSOLUTE)
-		FILE(RELATIVE_PATH _REL_PYTHON_MODULE_PATH
-				${CMAKE_INSTALL_PREFIX} ${_ABS_PYTHON_MODULE_PATH})
-		SET(PYTHON_MODULE_PATH ${_ABS_PYTHON_MODULE_PATH})
-	endif()
-	message("PYTHON_MODULE_PATH: ${PYTHON_MODULE_PATH}")
+  message(STATUS "PYTHON_MODULE_PATH: ${CMAKE_INSTALL_PREFIX}/${PYTHON_MODULE_PATH}")
 
 	############### INSTALL HEADERS & LIBRARY ################
 	### Install Python bindings
-	INSTALL(TARGETS ${SWIG_MODULE_pyopenshot_REAL_NAME}
-	        LIBRARY DESTINATION ${PYTHON_MODULE_PATH} )
-	INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/openshot.py
-	        DESTINATION ${PYTHON_MODULE_PATH} )
+	install(TARGETS ${SWIG_MODULE_pyopenshot_REAL_NAME}
+    DESTINATION ${PYTHON_MODULE_PATH} )
+  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/openshot.py
+    DESTINATION ${PYTHON_MODULE_PATH} )
 
 endif ()

--- a/src/bindings/ruby/CMakeLists.txt
+++ b/src/bindings/ruby/CMakeLists.txt
@@ -36,56 +36,74 @@ if (POLICY CMP0086)
 	cmake_policy(SET CMP0086 OLD)
 endif()
 
-FIND_PACKAGE(Ruby)
-IF (RUBY_FOUND)
+find_package(Ruby)
+if (NOT RUBY_FOUND)
+  return()
+endif()
 
-	### Include the Ruby header files
-	INCLUDE_DIRECTORIES(${RUBY_INCLUDE_DIRS})
-	INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR})
+### Include the Ruby header files
+INCLUDE_DIRECTORIES(${RUBY_INCLUDE_DIRS})
+INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR})
 
-	### Enable C++ in SWIG
-	set_property(SOURCE openshot.i PROPERTY CPLUSPLUS ON)
-	set_property(SOURCE openshot.i PROPERTY SWIG_MODULE_NAME openshot)
+### Enable C++ in SWIG
+set_property(SOURCE openshot.i PROPERTY CPLUSPLUS ON)
+set_property(SOURCE openshot.i PROPERTY SWIG_MODULE_NAME openshot)
 
-	### Suppress a ton of warnings in the generated SWIG C++ code
-	set(SWIG_CXX_FLAGS "-Wno-unused-variable -Wno-unused-function -Wno-deprecated-copy -Wno-class-memaccess -Wno-cast-function-type \
+### Suppress a ton of warnings in the generated SWIG C++ code
+set(SWIG_CXX_FLAGS "-Wno-unused-variable -Wno-unused-function -Wno-deprecated-copy -Wno-class-memaccess -Wno-cast-function-type \
 -Wno-unused-parameter -Wno-catch-value -Wno-sign-compare -Wno-ignored-qualifiers")
-	separate_arguments(sw_flags UNIX_COMMAND ${SWIG_CXX_FLAGS})
-	set_property(SOURCE openshot.i PROPERTY GENERATED_COMPILE_OPTIONS ${sw_flags})
+separate_arguments(sw_flags UNIX_COMMAND ${SWIG_CXX_FLAGS})
+set_property(SOURCE openshot.i PROPERTY GENERATED_COMPILE_OPTIONS ${sw_flags})
 
-	### Take include dirs from target, automatically if possible
-	if (CMAKE_VERSION VERSION_GREATER 3.13)
-		set_property(SOURCE openshot.i PROPERTY USE_TARGET_INCLUDE_DIRECTORIES True)
-	else ()
-		set_property(SOURCE openshot.i PROPERTY INCLUDE_DIRECTORIES $<TARGET_PROPERTY:openshot,INCLUDE_DIRECTORIES>)
-	endif ()
+### Take include dirs from target, automatically if possible
+if (CMAKE_VERSION VERSION_GREATER 3.13)
+	set_property(SOURCE openshot.i PROPERTY USE_TARGET_INCLUDE_DIRECTORIES True)
+else ()
+	set_property(SOURCE openshot.i PROPERTY INCLUDE_DIRECTORIES $<TARGET_PROPERTY:openshot,INCLUDE_DIRECTORIES>)
+endif ()
 
-	### Add the SWIG interface file (which defines all the SWIG methods)
-	if (CMAKE_VERSION VERSION_LESS 3.8.0)
-		swig_add_module(rbopenshot ruby openshot.i)
-	else()
-		swig_add_library(rbopenshot LANGUAGE ruby SOURCES openshot.i)
-	endif()
+### Add the SWIG interface file (which defines all the SWIG methods)
+if (CMAKE_VERSION VERSION_LESS 3.8.0)
+	swig_add_module(rbopenshot ruby openshot.i)
+else()
+	swig_add_library(rbopenshot LANGUAGE ruby SOURCES openshot.i)
+endif()
 
-	### Set name of target (with no prefix, since Ruby does not like that)
-	SET_TARGET_PROPERTIES(${SWIG_MODULE_rbopenshot_REAL_NAME} PROPERTIES
-	                      PREFIX "" OUTPUT_NAME "openshot")
+### Set name of target (with no prefix, since Ruby does not like that)
+set_target_properties(${SWIG_MODULE_rbopenshot_REAL_NAME} PROPERTIES
+    PREFIX "" OUTPUT_NAME "openshot")
 
-	### Link the new Ruby wrapper library with libopenshot
-	target_link_libraries(${SWIG_MODULE_rbopenshot_REAL_NAME}
-	                      ${RUBY_LIBRARY} openshot)
+### Link the new Ruby wrapper library with libopenshot
+target_link_libraries(${SWIG_MODULE_rbopenshot_REAL_NAME} PUBLIC
+    ${RUBY_LIBRARY} openshot)
 
-	### FIND THE RUBY INTERPRETER (AND THE LOAD_PATH FOLDER)
-	EXECUTE_PROCESS(COMMAND ${RUBY_EXECUTABLE}
-	                -r rbconfig -e "print RbConfig::CONFIG['vendorarchdir']"
-	                OUTPUT_VARIABLE RUBY_VENDOR_ARCH_DIR)
-	MESSAGE(STATUS "Ruby executable: ${RUBY_EXECUTABLE}")
-	MESSAGE(STATUS "Ruby vendor arch dir: ${RUBY_VENDOR_ARCH_DIR}")
-	MESSAGE(STATUS "Ruby include path: ${RUBY_INCLUDE_PATH}")
+######### INSTALL PATH ########
+if (NOT DEFINED RUBY_MODULE_PATH AND DEFINED $ENV{RUBY_MODULE_PATH})
+  set(RUBY_MODULE_PATH $ENV{RUBY_MODULE_PATH})
+endif()
 
-	############### INSTALL HEADERS & LIBRARY ################
-	# Install Ruby bindings
-	install(TARGETS ${SWIG_MODULE_rbopenshot_REAL_NAME}
-	        LIBRARY DESTINATION ${RUBY_VENDOR_ARCH_DIR} )
+if (NOT DEFINED RUBY_MODULE_PATH)
+  if (WIN32 OR APPLE)
+    set (RUBY_MODULE_PATH "ruby")
+  endif()
 
-ENDIF (RUBY_FOUND)
+  if (UNIX AND NOT APPLE)
+    ### FIND THE RUBY INTERPRETER (AND THE LOAD_PATH FOLDER)
+    execute_process(COMMAND ${RUBY_EXECUTABLE} -r rbconfig
+      -e "dir = RbConfig::CONFIG['vendorarchdir']"
+      -e "dir.start_with?(RbConfig::CONFIG['prefix']) && dir.sub!(RbConfig::CONFIG['prefix']+'/', '')"
+      -e "p dir"
+      OUTPUT_VARIABLE RUBY_MODULE_PATH
+      OUTPUT_STRIP_TRAILING_WHITESPACE )
+    # Ruby quotes its output strings
+    string(REPLACE "\"" "" RUBY_MODULE_PATH "${RUBY_MODULE_PATH}")
+  endif()
+endif()
+
+message(STATUS "RUBY_MODULE_PATH: ${CMAKE_INSTALL_PREFIX}/${RUBY_MODULE_PATH}")
+  
+############### INSTALL HEADERS & LIBRARY ################
+# Install Ruby bindings
+install(TARGETS ${SWIG_MODULE_rbopenshot_REAL_NAME}
+        DESTINATION ${RUBY_MODULE_PATH} )
+

--- a/src/bindings/ruby/CMakeLists.txt
+++ b/src/bindings/ruby/CMakeLists.txt
@@ -25,8 +25,8 @@
 ################################################################################
 
 ############### RUBY BINDINGS ################
-FIND_PACKAGE(SWIG 3.0 REQUIRED)
-INCLUDE(${SWIG_USE_FILE})
+find_package(SWIG 3.0 REQUIRED)
+include(${SWIG_USE_FILE})
 
 ### Enable some legacy SWIG behaviors, in newer CMAKEs
 if (POLICY CMP0078)
@@ -42,8 +42,8 @@ if (NOT RUBY_FOUND)
 endif()
 
 ### Include the Ruby header files
-INCLUDE_DIRECTORIES(${RUBY_INCLUDE_DIRS})
-INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR})
+include_directories(${RUBY_INCLUDE_DIRS})
+include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
 ### Enable C++ in SWIG
 set_property(SOURCE openshot.i PROPERTY CPLUSPLUS ON)
@@ -105,5 +105,5 @@ message(STATUS "RUBY_MODULE_PATH: ${CMAKE_INSTALL_PREFIX}/${RUBY_MODULE_PATH}")
 ############### INSTALL HEADERS & LIBRARY ################
 # Install Ruby bindings
 install(TARGETS ${SWIG_MODULE_rbopenshot_REAL_NAME}
-        DESTINATION ${RUBY_MODULE_PATH} )
+  DESTINATION ${RUBY_MODULE_PATH} )
 


### PR DESCRIPTION
This is an attempt to fix the install paths for the bindings files, in particular the Ruby bindings which have been installing to an absolute path (which causes problems when building as non-root). In addition, the Gitlab builder scripts were _moving_ Python artifacts from their installed locations to `${CMAKE_INSTALL_PREFIX}/python`, which is just silly.

Now, `PYTHON_MODULE_PATH` or `RUBY_MODULE_PATH` can be defined on the CMake command line, and they'll override the detection process. (They're interpreted relative to the install prefix, so just `-DPYTHON_MODULE_PATH=python` recreates the previous scripted output.

In addition, the module paths on Windows and MacOS default to simply "python" or "ruby" instead of bothering with detection, since we don't install on the system there anyway.