### PR TITLE
Adding ability for a Clip to auto-detect and instantiate a Timeline Reader

### DIFF
--- a/include/Settings.h
+++ b/include/Settings.h
@@ -124,6 +124,10 @@ namespace openshot {
 		/// The audio device name to use during playback
 		std::string PLAYBACK_AUDIO_DEVICE_NAME = "";
 
+		/// The current install path of OpenShot (needs to be set when using Timeline(path), since certain
+		/// paths depend on the location of OpenShot transitions and files)
+		std::string PATH_OPENSHOT_INSTALL = "";
+
 		/// Create or get an instance of this logger singleton (invoke the class with this method)
 		static Settings * Instance();
 	};

--- a/include/Timeline.h
+++ b/include/Timeline.h
@@ -36,6 +36,7 @@
 #include <set>
 #include <QtGui/QImage>
 #include <QtGui/QPainter>
+#include <QtCore/QRegularExpression>
 #include "CacheBase.h"
 #include "CacheDisk.h"
 #include "CacheMemory.h"
@@ -156,6 +157,7 @@ namespace openshot {
 		CacheBase *final_cache; ///<Final cache of timeline frames
 		std::set<FrameMapper*> allocated_frame_mappers; ///< all the frame mappers we allocated and must free
 		bool managed_cache; ///< Does this timeline instance manage the cache object
+		std::string path; ///< Optional path of loaded UTF-8 OpenShot JSON project file
 
 		/// Process a new layer of video or audio
 		void add_layer(std::shared_ptr<Frame> new_frame, Clip* source_clip, int64_t clip_frame_number, int64_t timeline_frame_number, bool is_top_clip, float max_volume);
@@ -208,6 +210,11 @@ namespace openshot {
 		/// @param channels The number of audio channels of the timeline
 		/// @param channel_layout The channel layout (i.e. mono, stereo, 3 point surround, etc...)
 		Timeline(int width, int height, Fraction fps, int sample_rate, int channels, ChannelLayout channel_layout);
+
+		/// @brief Constructor for the timeline (which loads a JSON structure from a file path, and initializes a timeline)
+		/// @param projectPath The path of the UTF-8 *.osp project file (JSON contents). Contents will be loaded automatically.
+		/// @param convert_absolute_paths Should all paths be converted to absolute paths (based on the folder of the path provided)
+		Timeline(std::string projectPath, bool convert_absolute_paths);
 
         virtual ~Timeline();
 


### PR DESCRIPTION
Adding ability for a Clip to auto-detect and instantiate a Timeline Reader from the *.osp file type. Added new Timeline constructor, to auto load UTF-8 JSON file, and regex convert all paths to absolute. Fixed a dead lock issue when a Timeline loads another Timeline.

This is the first big step towards allowing multiple *.osp files to exist inside an OpenShot Project. This opens up an infinite number of cool possibilities, such as splitting projects into scenes, and then combining scenes at the end. Or importing templates (i.e. *.osp projects) with the complexity hidden from the user (since it looks like a normal clip). I have big plans for this soon!!!

However, performance seems suspect currently, and we'll need to dig deeper, and determine how to most efficiently set thread limits and cache limits for nested Timeline readers.