### PR TITLE
Adding stale bot for github issue management (libopenshot)

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,7 +1,7 @@
 # Number of days of inactivity before an issue becomes stale
-daysUntilStale: 60
+daysUntilStale: 90
 # Number of days of inactivity before a stale issue is closed
-daysUntilClose: 7
+daysUntilClose: 10
 # Issues with these labels will never be considered stale
 exemptLabels:
   - pinned
@@ -16,3 +16,7 @@ markComment: >
   for your contributions.
 # Comment to post when closing a stale issue. Set to `false` to disable
 closeComment: false
+# Only close issues
+only: issues
+# Don't close issues which are assigned to somebody
+exemptAssignees: true

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,18 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 60
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 7
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - pinned
+  - security
+  - enhancement
+# Label to use when marking an issue as stale
+staleLabel: stale
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as **stale** because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: false


### PR DESCRIPTION
Experimental support for `stale` plugin, to help with issue management on GitHub. https://github.com/marketplace/stale

Related PR for libopenshot-audio: https://github.com/OpenShot/libopenshot-audio/pull/93