### PR TITLE
ReaderBase_Tests: 100% internal coverage

### DIFF
--- a/tests/ReaderBase_Tests.cpp
+++ b/tests/ReaderBase_Tests.cpp
@@ -49,9 +49,9 @@ TEST(ReaderBase_Derived_Class)
 		std::shared_ptr<Frame> GetFrame(int64_t number) { std::shared_ptr<Frame> f(new Frame()); return f; }
 		void Close() { };
 		void Open() { };
-		string Json() const { return NULL; };
+		string Json() const { return ""; };
 		void SetJson(string value) { };
-		Json::Value JsonValue() const { return (int) NULL; };
+		Json::Value JsonValue() const { return Json::Value("{}"); };
 		void SetJsonValue(Json::Value root) { };
 		bool IsOpen() { return true; };
 		string Name() { return "TestReader"; };
@@ -59,6 +59,23 @@ TEST(ReaderBase_Derived_Class)
 
 	// Create an instance of the derived class
 	TestReader t1;
+
+	// Validate the new class
+	CHECK_EQUAL("TestReader", t1.Name());
+
+	t1.Close();
+	t1.Open();
+	CHECK_EQUAL(true, t1.IsOpen());
+
+	CHECK_EQUAL(true, t1.GetCache() == NULL);
+
+	t1.SetJson("{ }");
+	t1.SetJsonValue(Json::Value("{}"));
+	CHECK_EQUAL("", t1.Json());
+	auto json = t1.JsonValue();
+	CHECK_EQUAL(json, Json::Value("{}"));
+
+	auto f = t1.GetFrame(1);
 
 	// Check some of the default values of the FileInfo struct on the base class
 	CHECK_EQUAL(false, t1.info.has_audio);


### PR DESCRIPTION
This PR completes coverage for the `ReaderBase_Tests.cpp` file _itself_, by adding code to exercise the derived class that's defined in the test source. (It does nothing to affect the coverage of any libopenshot source code, merely the coverage of the source code for the unit test itself.)