### PR TITLE
Add version gating for Zmq and Qt deprecations

### DIFF
--- a/src/QtImageReader.cpp
+++ b/src/QtImageReader.cpp
@@ -111,7 +111,12 @@ void QtImageReader::Open()
 		info.has_audio = false;
 		info.has_video = true;
 		info.has_single_image = true;
-		info.file_size = image->byteCount();
+		#if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
+			// byteCount() is deprecated from Qt 5.10
+			info.file_size = image->sizeInBytes();
+		#else
+			info.file_size = image->byteCount();
+		#endif
 		info.vcodec = "QImage";
 		info.width = image->width();
 		info.height = image->height();

--- a/src/ZmqLogger.cpp
+++ b/src/ZmqLogger.cpp
@@ -120,15 +120,17 @@ void ZmqLogger::Log(string message)
 	// Create a scoped lock, allowing only a single thread to run the following code at one time
 	const GenericScopedLock<CriticalSection> lock(loggerCriticalSection);
 
+#if ZMQ_VERSION >= ZMQ_MAKE_VERSION(4, 3, 1)
 	// Send message over socket (ZeroMQ)
 	zmq::message_t reply(message);
 
-	#if ZMQ_VERSION >= ZMQ_MAKE_VERSION(4, 3, 1)
-		// Set flags for immediate delivery (new API)
-		publisher->send(reply, zmq::send_flags::dontwait);
-	#else
-		publisher->send(reply);
-	#endif
+	// Set flags for immediate delivery (new API)
+	publisher->send(reply, zmq::send_flags::dontwait);
+#else
+	zmq::message_t reply (message.length());
+	memcpy (reply.data(), message.c_str(), message.length());
+	publisher->send(reply);
+#endif
 
 	// Also log to file, if open
 	LogToFile(message);


### PR DESCRIPTION
This PR resolves both of the deprecations showing up in the codebase when building with current dependency versions.

* Qt's <strike>`QImage::sizeInBytes()`</strike>, used once in QtImageReader, <strike>is deprecated</strike> starting with Qt 5.10. (Correction: `QImage::byteCount()` is deprecated, `QImage::sizeInBytes()` is its replacement.)
* ZeroMQ deprecated the `send()` form we've been using starting with version 4.3.1.

The replacement ZMQ API includes a second `flags` argument. We take advantage of the new field to specify `zmq::send_flags::dontwait`, flagging the message for immediate delivery. (It's possible we could use `dontwait` in older ZMQ versions, so perhaps the version check could be broadened. It's also possible that `dontwait` has a negative performance impact, in which case it might be better to remove it. Unit tests would be helpful, but they do not yet exist.)