### PR TITLE
ZeroMQ's std::string support is too new

### DIFF
--- a/cmake/Modules/FindZeroMQ.cmake
+++ b/cmake/Modules/FindZeroMQ.cmake
@@ -5,14 +5,16 @@ pkg_check_modules(PC_LIBZMQ QUIET libzmq)
 set(ZeroMQ_VERSION ${PC_LIBZMQ_VERSION})
 
 find_path(ZeroMQ_INCLUDE_DIR zmq.h
-	  PATHS ${ZeroMQ_DIR}/include
-                ${PC_LIBZMQ_INCLUDE_DIRS})
+  PATHS
+    ${ZeroMQ_DIR}/include
+    ${PC_LIBZMQ_INCLUDE_DIRS})
 
 find_library(ZeroMQ_LIBRARY
-	     NAMES zmq
-	     PATHS ${ZeroMQ_DIR}/lib
-                   ${PC_LIBZMQ_LIBDIR}
-		   ${PC_LIBZMQ_LIBRARY_DIRS})
+  NAMES zmq
+  PATHS
+    ${ZeroMQ_DIR}/lib
+    ${PC_LIBZMQ_LIBDIR}
+    ${PC_LIBZMQ_LIBRARY_DIRS})
 
 if(ZeroMQ_LIBRARY)
     set(ZeroMQ_FOUND ON)
@@ -31,4 +33,9 @@ endif()
 include ( FindPackageHandleStandardArgs )
 # handle the QUIETLY and REQUIRED arguments and set ZMQ_FOUND to TRUE
 # if all listed variables are TRUE
-find_package_handle_standard_args ( ZeroMQ DEFAULT_MSG ZeroMQ_LIBRARIES ZeroMQ_INCLUDE_DIRS )
+find_package_handle_standard_args(ZeroMQ
+  REQUIRED_VARS
+    ZeroMQ_LIBRARIES
+    ZeroMQ_INCLUDE_DIRS
+  VERSION_VAR
+    ZeroMQ_VERSION)

--- a/src/ZmqLogger.cpp
+++ b/src/ZmqLogger.cpp
@@ -71,7 +71,7 @@ ZmqLogger *ZmqLogger::Instance()
 }
 
 // Set the connection for this logger
-void ZmqLogger::Connection(string new_connection)
+void ZmqLogger::Connection(std::string new_connection)
 {
 	// Create a scoped lock, allowing only a single thread to run the following code at one time
 	const GenericScopedLock<CriticalSection> lock(loggerCriticalSection);
@@ -102,7 +102,7 @@ void ZmqLogger::Connection(string new_connection)
 		publisher->bind(connection.c_str());
 
 	} catch (zmq::error_t &e) {
-		cout << "ZmqLogger::Connection - Error binding to " << connection << ". Switching to an available port." << endl;
+		std::cout << "ZmqLogger::Connection - Error binding to " << connection << ". Switching to an available port." << std::endl;
 		connection = "tcp://*:*";
 		publisher->bind(connection.c_str());
 	}
@@ -111,7 +111,7 @@ void ZmqLogger::Connection(string new_connection)
 	usleep(250000);
 }
 
-void ZmqLogger::Log(string message)
+void ZmqLogger::Log(std::string message)
 {
 	if (!enabled)
 		// Don't do anything
@@ -120,15 +120,14 @@ void ZmqLogger::Log(string message)
 	// Create a scoped lock, allowing only a single thread to run the following code at one time
 	const GenericScopedLock<CriticalSection> lock(loggerCriticalSection);
 
-#if ZMQ_VERSION >= ZMQ_MAKE_VERSION(4, 3, 1)
 	// Send message over socket (ZeroMQ)
-	zmq::message_t reply(message);
+	zmq::message_t reply (message.length());
+	std::memcpy (reply.data(), message.c_str(), message.length());
 
+#if ZMQ_VERSION >= ZMQ_MAKE_VERSION(4, 3, 1)
 	// Set flags for immediate delivery (new API)
 	publisher->send(reply, zmq::send_flags::dontwait);
 #else
-	zmq::message_t reply (message.length());
-	memcpy (reply.data(), message.c_str(), message.length());
 	publisher->send(reply);
 #endif
 
@@ -137,14 +136,14 @@ void ZmqLogger::Log(string message)
 }
 
 // Log message to a file (if path set)
-void ZmqLogger::LogToFile(string message)
+void ZmqLogger::LogToFile(std::string message)
 {
 	// Write to log file (if opened, and force it to write to disk in case of a crash)
 	if (log_file.is_open())
 		log_file << message << std::flush;
 }
 
-void ZmqLogger::Path(string new_path)
+void ZmqLogger::Path(std::string new_path)
 {
 	// Update path
 	file_path = new_path;
@@ -154,14 +153,14 @@ void ZmqLogger::Path(string new_path)
 		log_file.close();
 
 	// Open file (write + append)
-	log_file.open (file_path.c_str(), ios::out | ios::app);
+	log_file.open (file_path.c_str(), std::ios::out | std::ios::app);
 
 	// Get current time and log first message
-	time_t now = time(0);
-	tm* localtm = localtime(&now);
-	log_file << "------------------------------------------" << endl;
-	log_file << "libopenshot logging: " << asctime(localtm);
-	log_file << "------------------------------------------" << endl;
+	std::time_t now = std::time(0);
+	std::tm* localtm = std::localtime(&now);
+	log_file << "------------------------------------------" << std::endl;
+	log_file << "libopenshot logging: " << std::asctime(localtm);
+	log_file << "------------------------------------------" << std::endl;
 }
 
 void ZmqLogger::Close()
@@ -182,13 +181,13 @@ void ZmqLogger::Close()
 }
 
 // Append debug information
-void ZmqLogger::AppendDebugMethod(string method_name,
-				  string arg1_name, float arg1_value,
-				  string arg2_name, float arg2_value,
-				  string arg3_name, float arg3_value,
-				  string arg4_name, float arg4_value,
-				  string arg5_name, float arg5_value,
-				  string arg6_name, float arg6_value)
+void ZmqLogger::AppendDebugMethod(std::string method_name,
+				  std::string arg1_name, float arg1_value,
+				  std::string arg2_name, float arg2_value,
+				  std::string arg3_name, float arg3_value,
+				  std::string arg4_name, float arg4_value,
+				  std::string arg5_name, float arg5_value,
+				  std::string arg6_name, float arg6_value)
 {
 	if (!enabled)
 		// Don't do anything
@@ -198,8 +197,8 @@ void ZmqLogger::AppendDebugMethod(string method_name,
 		// Create a scoped lock, allowing only a single thread to run the following code at one time
 		const GenericScopedLock<CriticalSection> lock(loggerCriticalSection);
 
-		stringstream message;
-		message << fixed << setprecision(4);
+		std::stringstream message;
+		message << std::fixed << std::setprecision(4);
 		message << method_name << " (";
 
 		// Add attributes to method JSON


### PR DESCRIPTION
Whoops. Seems I broke ZeroMQ on both the Windows and macOS builders, trying to use `std::string` with `zmq::message_t`. (In my defense, it works fine on Fedora 31! Must be a recent feature.)

I've reverted to the old `memcpy()` version of message construction, for all ZeroMQ versions.