### PR TITLE
Fix zmq version check

### DIFF
--- a/src/ZmqLogger.cpp
+++ b/src/ZmqLogger.cpp
@@ -120,7 +120,7 @@ void ZmqLogger::Log(string message)
 	// Create a scoped lock, allowing only a single thread to run the following code at one time
 	const GenericScopedLock<CriticalSection> lock(loggerCriticalSection);
 
-#if ZMQ_VERSION >= ZMQ_MAKE_VERSION(4, 3, 1)
+#if ZMQ_VERSION > ZMQ_MAKE_VERSION(4, 3, 1)
 	// Send message over socket (ZeroMQ)
 	zmq::message_t reply(message);
 


### PR DESCRIPTION
zmq.h
```
#define ZMQ_VERSION_MAJOR 4
#define ZMQ_VERSION_MINOR 3
#define ZMQ_VERSION_PATCH 1

#define ZMQ_MAKE_VERSION(major, minor, patch)                                  \
    ((major) *10000 + (minor) *100 + (patch))
#define ZMQ_VERSION                                                            \
    ZMQ_MAKE_VERSION (ZMQ_VERSION_MAJOR, ZMQ_VERSION_MINOR, ZMQ_VERSION_PATCH)
```

error without fix:
```
$ make
[  1%] Automatic MOC for target openshot
[  1%] Built target openshot_autogen
Scanning dependencies of target openshot
[  2%] Building CXX object src/CMakeFiles/openshot.dir/ZmqLogger.cpp.o
/home/chiller/Desktop/git-extern/libopenshot/src/ZmqLogger.cpp: In member function ‘void openshot::ZmqLogger::Log(std::__cxx11::string)’:
/home/chiller/Desktop/git-extern/libopenshot/src/ZmqLogger.cpp:125:30: error: no matching function for call to ‘zmq::message_t::message_t(std::__cxx11::string&)’
  zmq::message_t reply(message);
                              ^
In file included from /home/chiller/Desktop/git-extern/libopenshot/src/../include/ZmqLogger.h:43,
                 from /home/chiller/Desktop/git-extern/libopenshot/src/ZmqLogger.cpp:31:
/usr/include/zmq.hpp:247:16: note: candidate: ‘zmq::message_t::message_t(zmq::message_t&&)’
         inline message_t (message_t &&rhs): msg (rhs.msg)
                ^~~~~~~~~
/usr/include/zmq.hpp:247:16: note:   no known conversion for argument 1 from ‘std::__cxx11::string’ {aka ‘std::__cxx11::basic_string<char>’} to ‘zmq::message_t&&’
/usr/include/zmq.hpp:238:16: note: candidate: ‘zmq::message_t::message_t(void*, size_t, void (*)(void*, void*), void*)’
         inline message_t (void *data_, size_t size_, free_fn *ffn_,
                ^~~~~~~~~
/usr/include/zmq.hpp:238:16: note:   candidate expects 4 arguments, 1 provided
/usr/include/zmq.hpp:230:16: note: candidate: ‘zmq::message_t::message_t(const void*, size_t)’
         inline message_t (const void *data_, size_t size_)
                ^~~~~~~~~
/usr/include/zmq.hpp:230:16: note:   candidate expects 2 arguments, 1 provided
/usr/include/zmq.hpp:212:30: note: candidate: ‘template<class I> zmq::message_t::message_t(I, I)’
         template<typename I> message_t(I first, I last):
                              ^~~~~~~~~
/usr/include/zmq.hpp:212:30: note:   template argument deduction/substitution failed:
/home/chiller/Desktop/git-extern/libopenshot/src/ZmqLogger.cpp:125:30: note:   candidate expects 2 arguments, 1 provided
  zmq::message_t reply(message);
                              ^
In file included from /home/chiller/Desktop/git-extern/libopenshot/src/../include/ZmqLogger.h:43,
                 from /home/chiller/Desktop/git-extern/libopenshot/src/ZmqLogger.cpp:31:
/usr/include/zmq.hpp:205:25: note: candidate: ‘zmq::message_t::message_t(size_t)’
         inline explicit message_t (size_t size_)
                         ^~~~~~~~~
/usr/include/zmq.hpp:205:25: note:   no known conversion for argument 1 from ‘std::__cxx11::string’ {aka ‘std::__cxx11::basic_string<char>’} to ‘size_t’ {aka ‘long unsigned int’}
/usr/include/zmq.hpp:198:16: note: candidate: ‘zmq::message_t::message_t()’
         inline message_t ()
                ^~~~~~~~~
/usr/include/zmq.hpp:198:16: note:   candidate expects 0 arguments, 1 provided
/home/chiller/Desktop/git-extern/libopenshot/src/ZmqLogger.cpp:128:30: error: ‘zmq::send_flags’ has not been declared
  publisher->send(reply, zmq::send_flags::dontwait);
                              ^~~~~~~~~~
make[2]: *** [src/CMakeFiles/openshot.dir/build.make:414: src/CMakeFiles/openshot.dir/ZmqLogger.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:164: src/CMakeFiles/openshot.dir/all] Error 2
make: *** [Makefile:152: all] Error 2
```