### PR TITLE
Make Travis' syntax checker happy(er)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: cpp
 compiler: gcc
+os: linux
+dist: xenial
 
 # This section uses a rather esoteric (and tricky!) feature of YAML,
 # &aliases and *anchors, to build package lists out of sublists without
@@ -32,7 +34,7 @@ addons:
     - libavresample-dev
     - libswresample-dev
 
-matrix:
+jobs:
   include:
 
     - name: "Coverage + FFmpeg 3.4 GCC (Ubuntu 18.04 Bionic)"


### PR DESCRIPTION
A few things about our `.travis-ci.yml` file annoy their syntax checker. (This doesn't fix all of them, but the duplicate `addons.apt` sections I'm not sure we can fix currently.)