### PR TITLE
Improved Profile file parsing and error handling

### DIFF
--- a/src/KeyFrame.cpp
+++ b/src/KeyFrame.cpp
@@ -88,11 +88,16 @@ namespace {
 	double InterpolateBetween(Point const & left, Point const & right, double target, double allowed_error) {
 		assert(left.co.X < target);
 		assert(target <= right.co.X);
+        
+        double returnValue = 0.00;
+        
 		switch (right.interpolation) {
-		case CONSTANT: return left.co.Y;
-		case LINEAR: return InterpolateLinearCurve(left, right, target);
-		case BEZIER: return InterpolateBezierCurve(left, right, target, allowed_error);
+		case CONSTANT: returnValue = left.co.Y;
+		case LINEAR: returnValue = InterpolateLinearCurve(left, right, target);
+		case BEZIER: returnValue = InterpolateBezierCurve(left, right, target, allowed_error);
 		}
+        
+        return returnValue;
 	}
 
 

--- a/src/KeyFrame.cpp
+++ b/src/KeyFrame.cpp
@@ -87,17 +87,15 @@ namespace {
 
 	double InterpolateBetween(Point const & left, Point const & right, double target, double allowed_error) {
 		assert(left.co.X < target);
-		assert(target <= right.co.X);
-        
-        double returnValue = 0.00;
-        
+		assert(target <= right.co.X);        
 		switch (right.interpolation) {
-		case CONSTANT: returnValue = left.co.Y;
-		case LINEAR: returnValue = InterpolateLinearCurve(left, right, target);
-		case BEZIER: returnValue = InterpolateBezierCurve(left, right, target, allowed_error);
+		case CONSTANT: return left.co.Y;
+		case LINEAR: return InterpolateLinearCurve(left, right, target);
+		case BEZIER: return InterpolateBezierCurve(left, right, target, allowed_error);
 		}
         
-        return returnValue;
+        // Control should never reach this point
+        return 0.0;
 	}
 
 


### PR DESCRIPTION
Modified the Profile constructor to better identify invalid or malformed Profile files and throw more informative exceptions when issues are encountered.  I will also be modifying openshot-qt to better handle these exceptions rather than failing silently.

This resolves an issue I had when a malformed Profile file caused a segmentation fault.

While I was in the code, I modified the InterpolateBetween function in KeyFrame.cpp to eliminate a compiler warning.