### PR TITLE
Add version.sh script

### DIFF
--- a/version.sh
+++ b/version.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+grep 'set.*(.*PROJECT_VERSION_FULL' CMakeLists.txt\
+ |sed -e 's#set(PROJECT_VERSION_FULL.*"\(.*\)\")#\1#;q'
+


### PR DESCRIPTION
Just like OpenShot/libopenshot-audio#95, this adds a `version.sh` script at the root of the repo which extracts the `PROJECT_VERSION_FULL` string from `CMakeLists.txt`, and for the same reasons:

> This is useful for building libopenshot-audio as a Mac Homebrew `brew diy` project, which allows ad-hoc building of packages that install directly into the Homebrew environment.
> 
> e.g.
> ```sh
> $ cd libopenshot-audio
> $ cmake $(brew diy --name libopenshot-audio --version $(sh ./version.sh)) .
> [CMake runs with CMAKE_INSTALL_PREFIX set to $(brew --cellar)/libopenshot-audio/<version>/]
> $ cmake --build .
> $ cmake --build . --target install
> $ brew link libopenshot-audio
> ```
> ...and libopenshot-audio is linked into `/usr/local/opt/{lib,include}`.
> 

So, same thing with libopenshot:
```sh
$ cd libopenshot
$ cmake $(brew diy --name libopenshot --version $(sh ./version.sh)) .
[CMake runs with CMAKE_INSTALL_PREFIX set to $(brew --cellar)/libopenshot/<version>/]
$ cmake --build .
$ cmake --build . --target install
$ brew link libopenshot
```

One advantage being, you _don't_ have to give the libopenshot `cmake` run the location of a `libopenshot-audio` installed this way, since anything in the homebrew space is considered "system-installed". (With the right user environment variables set, at least. `brew shellenv` can be used to automatically apply that setup.)