### PR TITLE
Travis: Fix package list syntax, contents

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,18 +11,12 @@ addons:
   apt:
     packages: &p_common  # Packages common to all Ubuntu builds
     - cmake
-    - swig
     - libopenshot-audio-dev
     - libmagick++-dev
     - libunittest++-dev
     - libzmq3-dev
     - qtbase5-dev
     - qtmultimedia5-dev
-    - doxygen
-    - graphviz
-    - curl
-    packages: &ff_common  # Common set of FFmpeg packages
-    - *p_common
     - libfdk-aac-dev
     - libavcodec-dev
     - libavformat-dev
@@ -31,8 +25,11 @@ addons:
     - libavfilter-dev
     - libswscale-dev
     - libpostproc-dev
-    - libavresample-dev
     - libswresample-dev
+    - swig
+    - doxygen
+    - graphviz
+    - curl
 
 jobs:
   include:
@@ -50,8 +47,9 @@ jobs:
           - sourceline: 'ppa:openshot.developers/libopenshot-daily'
           - sourceline: 'ppa:beineri/opt-qt-5.12.3-bionic'
           packages:
-          - *ff_common
+          - *p_common
           - qt5-default
+          - libavresample-dev
           - libjsoncpp-dev
           - lcov
           - binutils-common # For c++filt
@@ -70,7 +68,7 @@ jobs:
           - sourceline: 'ppa:beineri/opt-qt-5.12.3-bionic'
           - sourceline: 'ppa:jonathonf/ffmpeg-4'
           packages:
-          - *ff_common
+          - *p_common
           - qt5-default
           - libjsoncpp-dev
           - libavcodec58
@@ -80,7 +78,6 @@ jobs:
           - libavfilter7
           - libswscale5
           - libpostproc55
-          - libavresample4
           - libswresample3
 
     - name: "FFmpeg 3.4 Clang (Ubuntu 18.04 Bionic)"
@@ -97,8 +94,9 @@ jobs:
           - sourceline: 'ppa:openshot.developers/libopenshot-daily'
           - sourceline: 'ppa:beineri/opt-qt-5.12.3-bionic'
           packages:
-          - *ff_common
+          - *p_common
           - qt5-default
+          - libavresample-dev
           - libomp-dev
 
     - name: "FFmpeg 3.2 GCC (Ubuntu 16.04 Xenial)"
@@ -115,7 +113,8 @@ jobs:
           - sourceline: 'ppa:beineri/opt-qt-5.10.0-xenial'
           - sourceline: 'ppa:jon-hedgerows/ffmpeg-backports'
           packages:
-          - *ff_common
+          - *p_common
+          - libavresample-dev
           - libavcodec57
           - libavdevice57
           - libavfilter6
@@ -139,7 +138,8 @@ jobs:
           - sourceline: 'ppa:openshot.developers/libopenshot-daily'
           - sourceline: 'ppa:beineri/opt-qt-5.10.0-xenial'
           packages:
-          - *ff_common
+          - *p_common
+          - libavresample-dev
 
 script:
   - mkdir -p build; cd build;


### PR DESCRIPTION
- Get rid of two-stage definition of apt.packages list, which was never necessary anyway.
- Remove deprecated `libavresample` from package set for FFmpeg 4