### PR TITLE
Add version/feature #defines to OpenShotVersion.h

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,7 +16,7 @@ linux-builder:
     - unzip artifacts.zip
     - export LIBOPENSHOT_AUDIO_DIR=$CI_PROJECT_DIR/build/install-x64
     - mkdir -p build; cd build;
-    - cmake -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -D"CMAKE_INSTALL_PREFIX:PATH=$CI_PROJECT_DIR/build/install-x64" -D"PYTHON_MODULE_PATH=python" -D"RUBY_MODULE_PATH=ruby" -DCMAKE_BUILD_TYPE:STRING=Release -DUSE_SYSTEM_JSONCPP=0 ../
+    - cmake -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -D"CMAKE_INSTALL_PREFIX:PATH=$CI_PROJECT_DIR/build/install-x64" -D"PYTHON_MODULE_PATH=python" -D"RUBY_MODULE_PATH=ruby" -DCMAKE_BUILD_TYPE:STRING=Release -DAPPIMAGE_BUILD=1 -DUSE_SYSTEM_JSONCPP=0 ../
     - make
     - make install
     - make doc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,6 +76,7 @@ option(DISABLE_BUNDLED_JSONCPP "Don't fall back to bundled JsonCpp" OFF)
 option(ENABLE_IWYU "Enable 'Include What You Use' scanner (CMake 3.3+)" OFF)
 option(ENABLE_TESTS "Build unit tests (requires UnitTest++)" ON)
 option(ENABLE_DOCS "Build API documentation (requires Doxygen)" ON)
+option(APPIMAGE_BUILD "Build to install in an AppImage (Linux only)" OFF)
 
 # Legacy commandline override
 if (DISABLE_TESTS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,12 +91,6 @@ if(DEFINED ENABLE_TESTS)
   set(ENABLE_TESTS ${ENABLE_TESTS} CACHE BOOL "Build unit tests (requires UnitTest++)" FORCE)
 endif()
 
-########## Configure Version.h header ##############
-configure_file(include/OpenShotVersion.h.in include/OpenShotVersion.h @ONLY)
-# We'll want that installed later
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/include/OpenShotVersion.h
-        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/libopenshot)
-
 #### Work around a GCC < 9 bug with handling of _Pragma() in macros
 #### See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=55578
 if ((${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU") AND
@@ -141,6 +135,12 @@ endif()
 
 ############## PROCESS src/ DIRECTORIES ##############
 add_subdirectory(src)
+
+########## Configure Version.h header ##############
+configure_file(include/OpenShotVersion.h.in include/OpenShotVersion.h @ONLY)
+# We'll want that installed later
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/include/OpenShotVersion.h
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/libopenshot)
 
 ################### DOCUMENTATION ###################
 # Find Doxygen (used for documentation)

--- a/include/OpenShotVersion.h.in
+++ b/include/OpenShotVersion.h.in
@@ -42,8 +42,13 @@
 
 #define OPENSHOT_VERSION_SO @PROJECT_SO_VERSION@         /// Shared object version number. This increments any time the API and ABI changes (so old apps will no longer link)
 
-// Useful dependency versioning
-#define QT_VERSION_STR "@QT_VERSION_STR@"
+// Useful dependency versioning / feature availability
+#cmakedefine QT_VERSION_STR "@QT_VERSION_STR@"
+#cmakedefine AVCODEC_VERSION_STR "@AVCODEC_VERSION_STR@"
+#cmakedefine AVFORMAT_VERSION_STR "@AVFORMAT_VERSION_STR@"
+#cmakedefine AVUTIL_VERSION_STR "@AVUTIL_VERSION_STR@"
+#cmakedefine01 HAVE_IMAGEMAGICK
+#cmakedefine01 HAVE_RESVG
 
 #include <sstream>
 

--- a/include/OpenShotVersion.h.in
+++ b/include/OpenShotVersion.h.in
@@ -49,6 +49,7 @@
 #cmakedefine AVUTIL_VERSION_STR "@AVUTIL_VERSION_STR@"
 #cmakedefine01 HAVE_IMAGEMAGICK
 #cmakedefine01 HAVE_RESVG
+#cmakedefine01 APPIMAGE_BUILD
 
 #include <sstream>
 

--- a/include/OpenShotVersion.h.in
+++ b/include/OpenShotVersion.h.in
@@ -42,6 +42,9 @@
 
 #define OPENSHOT_VERSION_SO @PROJECT_SO_VERSION@         /// Shared object version number. This increments any time the API and ABI changes (so old apps will no longer link)
 
+// Useful dependency versioning
+#define QT_VERSION_STR "@QT_VERSION_STR@"
+
 #include <sstream>
 
 namespace openshot

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -289,6 +289,10 @@ foreach(_qt_comp IN LISTS _qt_components)
   endif()
 endforeach()
 
+# Keep track of Qt version, to embed in our version header
+set(QT_VERSION_STR ${Qt5Core_VERSION_STRING} CACHE STRING "Qt version linked with" FORCE)
+mark_as_advanced(QT_VERSION_STR)
+
 ################### FFMPEG #####################
 # Find FFmpeg libraries (used for video encoding / decoding)
 find_package(FFmpeg REQUIRED COMPONENTS avcodec avdevice avformat avutil swscale)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -59,11 +59,6 @@ IF (MAGICKCORE_HDRI_ENABLE)
 ELSE (MAGICKCORE_HDRI_ENABLE)
 	add_definitions( -DMAGICKCORE_HDRI_ENABLE=0 )
 ENDIF (MAGICKCORE_HDRI_ENABLE)
-IF (OPENSHOT_IMAGEMAGICK_COMPATIBILITY)
-	add_definitions( -DOPENSHOT_IMAGEMAGICK_COMPATIBILITY=${OPENSHOT_IMAGEMAGICK_COMPATIBILITY} )
-ELSE (OPENSHOT_IMAGEMAGICK_COMPATIBILITY)
-	add_definitions( -DOPENSHOT_IMAGEMAGICK_COMPATIBILITY=0 )
-ENDIF (OPENSHOT_IMAGEMAGICK_COMPATIBILITY)
 
 # Find the ImageMagick++ library
 find_package(ImageMagick COMPONENTS Magick++ MagickWand MagickCore)
@@ -75,6 +70,8 @@ if (ImageMagick_FOUND)
 	add_definitions( -DUSE_IMAGEMAGICK=1 )
 	set(CMAKE_SWIG_FLAGS "-DUSE_IMAGEMAGICK=1")
 
+    set(HAVE_IMAGEMAGICK TRUE CACHE BOOL "Building with ImageMagick support" FORCE)
+    mark_as_advanced(HAVE_IMAGEMAGICK)
 endif()
 
 ################# LIBOPENSHOT-AUDIO ###################
@@ -297,10 +294,20 @@ mark_as_advanced(QT_VERSION_STR)
 # Find FFmpeg libraries (used for video encoding / decoding)
 find_package(FFmpeg REQUIRED COMPONENTS avcodec avdevice avformat avutil swscale)
 
-foreach(ff_comp avcodec avdevice avformat avfilter avutil postproc swscale swresample avresample)
+set(all_comps avcodec avdevice avformat avfilter avutil postproc swscale swresample avresample)
+set(version_comps avcodec avformat avutil)
+
+foreach(ff_comp IN LISTS all_comps)
   if(TARGET FFmpeg::${ff_comp})
-		target_link_libraries(openshot PUBLIC FFmpeg::${ff_comp})
+    target_link_libraries(openshot PUBLIC FFmpeg::${ff_comp})
+    # Keep track of some FFmpeg lib versions, to embed in our version header
+    if(${ff_comp} IN_LIST version_comps)
+      string(TOUPPER ${ff_comp} v_name)
+      set(${v_name}_VERSION_STR ${${ff_comp}_VERSION} CACHE STRING "${ff_comp} version used" FORCE)
+      mark_as_advanced(${v_name}_VERSION_STR)
+    endif()
   endif()
+
 endforeach()
 
 ################### Threads ####################
@@ -363,6 +370,10 @@ if (TARGET RESVG::resvg)
 
   target_compile_definitions(openshot PUBLIC "-DUSE_RESVG=1")
   set(CMAKE_SWIG_FLAGS "-DUSE_RESVG=1")
+
+  set(HAVE_RESVG TRUE CACHE BOOL "Building with Resvg support" FORCE)
+  mark_as_advanced(HAVE_RESVG)
+
 endif()
 
 ###############  LINK LIBRARY  #################

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -33,8 +33,8 @@ include(GNUInstallDirs)
 # Set some compiler options for Windows
 # required for libopenshot-audio headers
 if (WIN32)
-	add_definitions( -DIGNORE_JUCE_HYPOT=1 )
-	set(CMAKE_CXX_FLAGS " ${CMAKE_CXX_FLAGS} -include cmath")
+  add_definitions( -DIGNORE_JUCE_HYPOT=1 )
+  set(CMAKE_CXX_FLAGS " ${CMAKE_CXX_FLAGS} -include cmath")
 endif()
 
 if (APPLE)
@@ -50,28 +50,28 @@ endif()
 ################ IMAGE MAGICK ##################
 # Set the Quantum Depth that ImageMagick was built with (default to 16 bits)
 IF (MAGICKCORE_QUANTUM_DEPTH)
-	add_definitions( -DMAGICKCORE_QUANTUM_DEPTH=${MAGICKCORE_QUANTUM_DEPTH} )
+  add_definitions( -DMAGICKCORE_QUANTUM_DEPTH=${MAGICKCORE_QUANTUM_DEPTH} )
 ELSE (MAGICKCORE_QUANTUM_DEPTH)
-	add_definitions( -DMAGICKCORE_QUANTUM_DEPTH=16 )
+  add_definitions( -DMAGICKCORE_QUANTUM_DEPTH=16 )
 ENDIF (MAGICKCORE_QUANTUM_DEPTH)
 IF (MAGICKCORE_HDRI_ENABLE)
-	add_definitions( -DMAGICKCORE_HDRI_ENABLE=${MAGICKCORE_HDRI_ENABLE} )
+  add_definitions( -DMAGICKCORE_HDRI_ENABLE=${MAGICKCORE_HDRI_ENABLE} )
 ELSE (MAGICKCORE_HDRI_ENABLE)
-	add_definitions( -DMAGICKCORE_HDRI_ENABLE=0 )
+  add_definitions( -DMAGICKCORE_HDRI_ENABLE=0 )
 ENDIF (MAGICKCORE_HDRI_ENABLE)
 
 # Find the ImageMagick++ library
 find_package(ImageMagick COMPONENTS Magick++ MagickWand MagickCore)
 if (ImageMagick_FOUND)
-	# Include ImageMagick++ headers (needed for compile)
-	include_directories(${ImageMagick_INCLUDE_DIRS})
+  # Include ImageMagick++ headers (needed for compile)
+  include_directories(${ImageMagick_INCLUDE_DIRS})
 
-	# define a global var (used in the C++)
-	add_definitions( -DUSE_IMAGEMAGICK=1 )
-	set(CMAKE_SWIG_FLAGS "-DUSE_IMAGEMAGICK=1")
+  # define a global var (used in the C++)
+  add_definitions( -DUSE_IMAGEMAGICK=1 )
+  list(APPEND CMAKE_SWIG_FLAGS "-DUSE_IMAGEMAGICK=1")
 
-    set(HAVE_IMAGEMAGICK TRUE CACHE BOOL "Building with ImageMagick support" FORCE)
-    mark_as_advanced(HAVE_IMAGEMAGICK)
+  set(HAVE_IMAGEMAGICK TRUE CACHE BOOL "Building with ImageMagick support" FORCE)
+  mark_as_advanced(HAVE_IMAGEMAGICK)
 endif()
 
 ################# LIBOPENSHOT-AUDIO ###################
@@ -85,15 +85,15 @@ include_directories(${LIBOPENSHOT_AUDIO_INCLUDE_DIRS})
 # Find BlackMagic DeckLinkAPI libraries
 if (ENABLE_BLACKMAGIC)
 
-	find_package(BlackMagic)
+  find_package(BlackMagic)
 
-	if (BLACKMAGIC_FOUND)
-		# Include Blackmagic headers (needed for compile)
-		include_directories(${BLACKMAGIC_INCLUDE_DIR})
+  if (BLACKMAGIC_FOUND)
+    # Include Blackmagic headers (needed for compile)
+    include_directories(${BLACKMAGIC_INCLUDE_DIR})
 
-		# define a global var (used in the C++)
-		add_definitions( -DUSE_BLACKMAGIC=1 )
-		set(CMAKE_SWIG_FLAGS "-DUSE_BLACKMAGIC=1")
+    # define a global var (used in the C++)
+    add_definitions( -DUSE_BLACKMAGIC=1 )
+    list(APPEND CMAKE_SWIG_FLAGS "-DUSE_BLACKMAGIC=1")
   endif()
 
 endif()
@@ -148,7 +148,7 @@ set(OPENSHOT_SOURCES
   Fraction.cpp
   Frame.cpp
   FrameMapper.cpp
-	Json.cpp
+  Json.cpp
   KeyFrame.cpp
   OpenShotVersion.cpp
   ZmqLogger.cpp
@@ -216,7 +216,7 @@ set_target_properties(openshot PROPERTIES
 
 # Add optional ImageMagic-dependent sources
 if(ImageMagick_FOUND)
-	target_sources(openshot PRIVATE
+  target_sources(openshot PRIVATE
     ImageReader.cpp
     ImageWriter.cpp
     TextReader.cpp)
@@ -245,7 +245,7 @@ target_include_directories(openshot
 ################### JSONCPP #####################
 # Include jsoncpp headers (needed for JSON parsing)
 if (USE_SYSTEM_JSONCPP)
-	message(STATUS "Looking for system jsoncpp")
+  message(STATUS "Looking for system jsoncpp")
   # Either an installed config or our find module will
   # create the IMPORTED target jsoncpp_lib if successful
   find_package(jsoncpp)
@@ -344,7 +344,7 @@ find_package(cppzmq QUIET) # Creates cppzmq target
 
 # Link ZeroMQ library
 if (TARGET libzmq)
-	target_link_libraries(openshot PUBLIC libzmq)
+  target_link_libraries(openshot PUBLIC libzmq)
 endif()
 # Include cppzmq headers, if not bundled into libzmq
 if (TARGET cppzmq)
@@ -361,7 +361,7 @@ if(DEFINED ENV{RESVGDIR} AND NOT DEFINED RESVG_ROOT)
 endif()
 
 # Find resvg library (used for rendering svg files)
-FIND_PACKAGE(RESVG)
+find_package(RESVG)
 
 # Include resvg headers (optional SVG library)
 if (TARGET RESVG::resvg)
@@ -369,7 +369,7 @@ if (TARGET RESVG::resvg)
   target_link_libraries(openshot PUBLIC RESVG::resvg)
 
   target_compile_definitions(openshot PUBLIC "-DUSE_RESVG=1")
-  set(CMAKE_SWIG_FLAGS "-DUSE_RESVG=1")
+  list(APPEND CMAKE_SWIG_FLAGS "-DUSE_RESVG=1")
 
   set(HAVE_RESVG TRUE CACHE BOOL "Building with Resvg support" FORCE)
   mark_as_advanced(HAVE_RESVG)
@@ -379,7 +379,7 @@ endif()
 ###############  LINK LIBRARY  #################
 # Link remaining dependency libraries
 target_link_libraries(openshot PUBLIC
-	${LIBOPENSHOT_AUDIO_LIBRARIES}
+  ${LIBOPENSHOT_AUDIO_LIBRARIES}
   ${PROFILER})
 
 if(ImageMagick_FOUND)
@@ -391,8 +391,8 @@ if(BLACKMAGIC_FOUND)
 endif()
 
 if(WIN32)
-	# Required for exception handling on Windows
-	target_link_libraries(openshot PUBLIC "imagehlp" "dbghelp" )
+  # Required for exception handling on Windows
+  target_link_libraries(openshot PUBLIC "imagehlp" "dbghelp" )
 endif()
 
 
@@ -401,9 +401,9 @@ endif()
 add_executable(openshot-example examples/Example.cpp)
 
 # Define path to test input files
-SET(TEST_MEDIA_PATH "${PROJECT_SOURCE_DIR}/src/examples/")
+set(TEST_MEDIA_PATH "${PROJECT_SOURCE_DIR}/src/examples/")
 if (WIN32)
-        STRING(REPLACE "/" "\\\\" TEST_MEDIA_PATH TEST_MEDIA_PATH)
+  string(REPLACE "/" "\\\\" TEST_MEDIA_PATH TEST_MEDIA_PATH)
 endif()
 target_compile_definitions(openshot-example PRIVATE
 	-DTEST_MEDIA_PATH="${TEST_MEDIA_PATH}" )
@@ -423,12 +423,12 @@ target_link_libraries(openshot-player openshot)
 
 ############### TEST BLACKMAGIC CAPTURE APP ################
 if (BLACKMAGIC_FOUND)
-	# Create test executable
-	add_executable(openshot-blackmagic
-			examples/ExampleBlackmagic.cpp)
+  # Create test executable
+  add_executable(openshot-blackmagic
+    examples/ExampleBlackmagic.cpp)
 
-	# Link test executable to the new library
-	target_link_libraries(openshot-blackmagic openshot)
+  # Link test executable to the new library
+  target_link_libraries(openshot-blackmagic openshot)
 endif()
 
 ############### INCLUDE SWIG BINDINGS ################
@@ -448,13 +448,13 @@ install(DIRECTORY ${CMAKE_SOURCE_DIR}/include/
 
 ############### CPACK PACKAGING ##############
 if(MINGW)
-	set(CPACK_GENERATOR "NSIS")
+  set(CPACK_GENERATOR "NSIS")
 endif()
 if(UNIX AND NOT APPLE)
-	set(CPACK_GENERATOR "DEB")
+  set(CPACK_GENERATOR "DEB")
 endif()
 #if(UNIX AND APPLE)
-#	set(CPACK_GENERATOR "DragNDrop")
+#  set(CPACK_GENERATOR "DragNDrop")
 #endif()
 set(CPACK_DEBIAN_PACKAGE_MAINTAINER "Jonathan Thomas") #required
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -80,7 +80,6 @@ if(ImageMagick_FOUND)
 
 	# define a global var (used in the C++)
 	add_definitions( -DUSE_IMAGEMAGICK=1 )
-	set(CMAKE_SWIG_FLAGS "-DUSE_IMAGEMAGICK=1")
 endif()
 
 ################# LIBOPENSHOT-AUDIO ###################


### PR DESCRIPTION
The CMake process will pick up Qt's `Qt5Core_VERSION_STRING` variable and stick it in the CMake cache (with forced updating each run). A new `#define` in the header exports that as `QT_VERSION_STR` to both the library and the Python bindings. That way it can be queried at runtime, same as PyQt5's versioning:
```python3
>>> import openshot
>>> print(openshot.QT_VERSION_STR)
5.13.2
>>> from PyQt5 import Qt
>>> print(Qt.QT_VERSION_STR)
5.13.2
>>> print(Qt.PYQT_VERSION_STR)
5.13.2
```

**Edit:** I added a few more:
```python3
>>> openshot.AVUTIL_VERSION_STR
'56.31.100'
>>> openshot.AVCODEC_VERSION_STR
'58.54.100'
>>> openshot.AVFORMAT_VERSION_STR
'58.29.100'
>>> openshot.HAVE_IMAGEMAGICK
1
>>> openshot.HAVE_RESVG
1
```

**Edit2:** One more:
```python3
>>> openshot.APPIMAGE_BUILD
0
```
It's implemented as a CMake option, default `OFF` (hence the `0`). The Gitlab Linux runner will enable it (`cmake -DAPPIMAGE_BUILD=1`) when it generates the build environment.

I'll probably merge this soon, as it shouldn't affect any existing code and I'm going to have a need for that last one in an OpenShot PR shortly.

Inspired by https://github.com/OpenShot/openshot-qt/issues/3442#issuecomment-625206538