### PR TITLE
Set clip in constructor to resolve scale crop issue

### DIFF
--- a/src/Clip.cpp
+++ b/src/Clip.cpp
@@ -150,6 +150,10 @@ Clip::Clip(ReaderBase* new_reader) : resampler(NULL), reader(new_reader), alloca
 
 	// Update duration
 	End(reader->info.duration);
+
+	if (new_reader) {
+		new_reader->SetClip(this);
+	}
 }
 
 // Constructor with filepath

--- a/src/Clip.cpp
+++ b/src/Clip.cpp
@@ -148,11 +148,10 @@ Clip::Clip(ReaderBase* new_reader) : resampler(NULL), reader(new_reader), alloca
 	Open();
 	Close();
 
-	// Update duration
-	End(reader->info.duration);
-
-	if (new_reader) {
-		new_reader->SetClip(this);
+	// Update duration and set parent
+	if (reader) {
+		End(reader->info.duration);
+		reader->SetClip(this);
 	}
 }
 
@@ -206,9 +205,10 @@ Clip::Clip(std::string path) : resampler(NULL), reader(NULL), allocated_reader(N
 		}
 	}
 
-	// Update duration
+	// Update duration and set parent
 	if (reader) {
 		End(reader->info.duration);
+		reader->SetClip(this);
 		allocated_reader = reader;
 		init_reader_rotation();
 	}


### PR DESCRIPTION
This fix resolves issue: #419 

Clips are scale cropped in two places FFmpegReader.cpp and in Timeline.cpp:556.

FFmpegReader calculates the wrong size for scale with crop. It is because Timeline doesn't set clip for FFmpegReader (and for all readers) so FFmpegReader doesn't now anything about SCALE_CROP, because it is a property of Clip.

And in FFmpegReader in line 1396 (in the last version) Clip *parent = (Clip *) GetClip();

We get parent = NULL and so it doesn't check scale property and calculate sizes using default formulas which are incorrect for SCALE_CROP case (and may be for SCALE_FIT and SCALE_STRETCH too).

I'll post some before and after screen-grabs just now but this change fixes the issue with 1:1 video scaling/cropping.