### PR TITLE
Enable building with a libopenshot-audio that's based on non-bundled JUCE

### DIFF
--- a/include/Qt/AudioPlaybackThread.h
+++ b/include/Qt/AudioPlaybackThread.h
@@ -75,7 +75,7 @@ namespace openshot
 		static AudioDeviceManagerSingleton * Instance();
 
 		/// Public device manager property
-		AudioDeviceManager audioDeviceManager;
+		juce::AudioDeviceManager audioDeviceManager;
 
 		/// Close audio device
 		void CloseAudioDevice();
@@ -86,9 +86,9 @@ namespace openshot
      */
     class AudioPlaybackThread : juce::Thread
     {
-		AudioSourcePlayer player;
-		AudioTransportSource transport;
-		MixerAudioSource mixer;
+		juce::AudioSourcePlayer player;
+		juce::AudioTransportSource transport;
+		juce::MixerAudioSource mixer;
 		AudioReaderSource *source;
 		double sampleRate;
 		int numChannels;

--- a/src/Frame.cpp
+++ b/src/Frame.cpp
@@ -992,8 +992,8 @@ void Frame::Play()
 	juce::AudioSourcePlayer audioSourcePlayer;
 	deviceManager.addAudioCallback (&audioSourcePlayer);
 
-	ScopedPointer<AudioBufferSource> my_source;
-	my_source = new AudioBufferSource(audio.get());
+	std::unique_ptr<AudioBufferSource> my_source;
+	my_source.reset (new AudioBufferSource (audio.get()));
 
 	// Create TimeSliceThread for audio buffering
 	juce::TimeSliceThread my_thread("Audio buffer thread");
@@ -1002,7 +1002,7 @@ void Frame::Play()
 	my_thread.startThread();
 
 	AudioTransportSource transport1;
-	transport1.setSource (my_source,
+	transport1.setSource (my_source.get(),
 			5000, // tells it to buffer this many samples ahead
 			&my_thread,
 			(double) sample_rate,

--- a/src/Frame.cpp
+++ b/src/Frame.cpp
@@ -829,7 +829,7 @@ void Frame::AddImage(std::shared_ptr<QImage> new_image, bool only_odd_lines)
 		if (ret) {
 			return;
 		}
-		
+
 		// Get the frame's image
 		const GenericScopedLock<juce::CriticalSection> lock(addingImageSection);
 		#pragma omp critical (AddImage)
@@ -979,7 +979,8 @@ void Frame::Play()
 		return;
 
 	juce::AudioDeviceManager deviceManager;
-	String error = deviceManager.initialise (0, /* number of input channels */
+	juce::String error = deviceManager.initialise (
+	        0, /* number of input channels */
 	        2, /* number of output channels */
 	        0, /* no XML settings.. */
 	        true  /* select default device on failure */);
@@ -1001,7 +1002,7 @@ void Frame::Play()
 	// Start thread
 	my_thread.startThread();
 
-	AudioTransportSource transport1;
+	juce::AudioTransportSource transport1;
 	transport1.setSource (my_source.get(),
 			5000, // tells it to buffer this many samples ahead
 			&my_thread,

--- a/src/bindings/ruby/CMakeLists.txt
+++ b/src/bindings/ruby/CMakeLists.txt
@@ -72,6 +72,9 @@ endif()
 set_property(SOURCE openshot.i PROPERTY CPLUSPLUS ON)
 set_property(SOURCE openshot.i PROPERTY SWIG_MODULE_NAME openshot)
 
+### Unbreak std::isfinite()
+add_compile_definitions(HAVE_ISFINITE=1)
+
 ### Suppress a ton of warnings in the generated SWIG C++ code
 set(SWIG_CXX_FLAGS "-Wno-unused-variable -Wno-unused-function \
   -Wno-deprecated-copy -Wno-class-memaccess -Wno-cast-function-type \


### PR DESCRIPTION
This is the companion PR to OpenShot/libopenshot-audio#97, and contains the fixes necessary in libopenshot's build to ensure that it works with a libopenshot-audio that wasn't built from our bundled JUCE sources.

(See that PR, as well as [Debian bug 925755](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=925755), for background.)

In addition:
* Added some overlooked `juce::` prefixing, in places the unit tests don't touch (so it's not technically critical)
* Replaced our one use of `juce::ScopedPointer` (which is [deprecated](https://juce.com/discover/stories/coding-standards#object-lifetime-and-ownership)) with the recommended `std::unique_ptr` replacement.