### PR TITLE
Fix support for older CMake

### DIFF
--- a/src/bindings/ruby/CMakeLists.txt
+++ b/src/bindings/ruby/CMakeLists.txt
@@ -73,7 +73,7 @@ set_property(SOURCE openshot.i PROPERTY CPLUSPLUS ON)
 set_property(SOURCE openshot.i PROPERTY SWIG_MODULE_NAME openshot)
 
 ### Unbreak std::isfinite()
-add_compile_definitions(HAVE_ISFINITE=1)
+add_definitions(-DHAVE_ISFINITE=1)
 
 ### Suppress a ton of warnings in the generated SWIG C++ code
 set(SWIG_CXX_FLAGS "-Wno-unused-variable -Wno-unused-function \


### PR DESCRIPTION
I used `add_compile_definitions()` in #515, which is CMake 3.12+ only. (Oops.) Switch to `add_definitions()` which has been supported since the dawn of time.