### PR TITLE
Don't link Python module with libpython

### DIFF
--- a/src/bindings/python/CMakeLists.txt
+++ b/src/bindings/python/CMakeLists.txt
@@ -87,6 +87,12 @@ set_target_properties(${SWIG_MODULE_pyopenshot_REAL_NAME} PROPERTIES
 ### Link the new python wrapper library with libopenshot
 target_link_libraries(${SWIG_MODULE_pyopenshot_REAL_NAME} PUBLIC openshot)
 
+### Except on Linux, also link with the Python libraries
+### (Not advisable on Linux, per PEP 513. May also apply to macOS, unclear.)
+if (WIN32 OR APPLE)
+  target_link_libraries(${SWIG_MODULE_pyopenshot_REAL_NAME} PUBLIC ${PYTHON_LIBRARIES})
+endif()
+
 ######### INSTALL PATH ########
 if (NOT DEFINED PYTHON_MODULE_PATH AND DEFINED $ENV{PYTHON_MODULE_PATH})
   set(PYTHON_MODULE_PATH $ENV{PYTHON_MODULE_PATH})

--- a/src/bindings/python/CMakeLists.txt
+++ b/src/bindings/python/CMakeLists.txt
@@ -85,8 +85,7 @@ set_target_properties(${SWIG_MODULE_pyopenshot_REAL_NAME} PROPERTIES
   PREFIX "_" OUTPUT_NAME "openshot")
 
 ### Link the new python wrapper library with libopenshot
-target_link_libraries(${SWIG_MODULE_pyopenshot_REAL_NAME} PUBLIC
-  ${PYTHON_LIBRARIES} openshot)
+target_link_libraries(${SWIG_MODULE_pyopenshot_REAL_NAME} PUBLIC openshot)
 
 ######### INSTALL PATH ########
 if (NOT DEFINED PYTHON_MODULE_PATH AND DEFINED $ENV{PYTHON_MODULE_PATH})


### PR DESCRIPTION
Seems we're not meant to be linking with the Python library (**Edit:** on Linux), when
building a module. (See [PEP 513].) Not doing so allows the module to be used with builds of Python other than the library version.

[PEP 513]: https://www.python.org/dev/peps/pep-0513/#id41