### PR TITLE
Fix FPS setting on FFmpeg 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,8 +32,12 @@ addons:
     - curl
 
 jobs:
-  include:
 
+  # The FFmpeg 3.2 backport PPA has gone missing
+  allow_failures:
+    - name: "FFmpeg 3.2 GCC (Ubuntu 16.04 Xenial)"
+
+  include:
     - name: "Coverage + FFmpeg 3.4 GCC (Ubuntu 18.04 Bionic)"
       env:
         - BUILD_VERSION=coverage_ffmpeg34

--- a/src/FFmpegWriter.cpp
+++ b/src/FFmpegWriter.cpp
@@ -1223,11 +1223,11 @@ AVStream *FFmpegWriter::add_video_stream() {
 	st->time_base.num = info.video_timebase.num;
 	st->time_base.den = info.video_timebase.den;
 #if (LIBAVFORMAT_VERSION_MAJOR >= 58)
-	_Pragma ("GCC diagnostic push");
-	_Pragma ("GCC diagnostic ignored \"-Wdeprecated-declarations\""); \
+	#pragma GCC diagnostic push
+	#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 	st->codec->time_base.num = info.video_timebase.num;
 	st->codec->time_base.den = info.video_timebase.den;
-	_Pragma ("GCC diagnostic pop");
+	#pragma GCC diagnostic pop
 #endif
 
 	c->gop_size = 12; /* TODO: add this to "info"... emit one intra frame every twelve frames at most */

--- a/src/FFmpegWriter.cpp
+++ b/src/FFmpegWriter.cpp
@@ -1222,6 +1222,13 @@ AVStream *FFmpegWriter::add_video_stream() {
 	st->avg_frame_rate = av_inv_q(c->time_base);
 	st->time_base.num = info.video_timebase.num;
 	st->time_base.den = info.video_timebase.den;
+#if (LIBAVFORMAT_VERSION_MAJOR >= 58)
+	_Pragma ("GCC diagnostic push");
+	_Pragma ("GCC diagnostic ignored \"-Wdeprecated-declarations\""); \
+	st->codec->time_base.num = info.video_timebase.num;
+	st->codec->time_base.den = info.video_timebase.den;
+	_Pragma ("GCC diagnostic pop");
+#endif
 
 	c->gop_size = 12; /* TODO: add this to "info"... emit one intra frame every twelve frames at most */
 	c->max_b_frames = 10;


### PR DESCRIPTION
Fix FPS setting on FFmpeg 4, which currently is not setting a valid FPS. This causes all sorts of strange behavior on videos produced with libopenshot using FFmpeg 4. This patch does require a depreciated approach, and I'm not sure how we are supposed to be correctly setting the FPS parameter, so I'm open to suggestions.

Also, thanks to PeterM for troubleshooting this issue and finding a solution! Nice work!