### PR TITLE
Travis: allow_failures for FFmpeg 3.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,8 +32,12 @@ addons:
     - curl
 
 jobs:
-  include:
 
+  # The FFmpeg 3.2 backport PPA has gone missing
+  allow_failures:
+    - name: "FFmpeg 3.2 GCC (Ubuntu 16.04 Xenial)"
+
+  include:
     - name: "Coverage + FFmpeg 3.4 GCC (Ubuntu 18.04 Bionic)"
       env:
         - BUILD_VERSION=coverage_ffmpeg34

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,6 @@ jobs:
         apt:
           sources:
           - sourceline: 'ppa:openshot.developers/libopenshot-daily'
-          - sourceline: 'ppa:beineri/opt-qt-5.12.3-bionic'
           packages:
           - *p_common
           - qt5-default
@@ -96,7 +95,6 @@ jobs:
         apt:
           sources:
           - sourceline: 'ppa:openshot.developers/libopenshot-daily'
-          - sourceline: 'ppa:beineri/opt-qt-5.12.3-bionic'
           packages:
           - *p_common
           - qt5-default
@@ -114,7 +112,6 @@ jobs:
         apt:
           sources:
           - sourceline: 'ppa:openshot.developers/libopenshot-daily'
-          - sourceline: 'ppa:beineri/opt-qt-5.10.0-xenial'
           - sourceline: 'ppa:jon-hedgerows/ffmpeg-backports'
           packages:
           - *p_common


### PR DESCRIPTION
Temporarily set the FFmpeg 3.2 build as "allowed to fail", while we work out what to do about its suddenly-private PPA.