### PR TITLE
Travis: Switch to Ubuntu 20.04 Focal for FFmpeg 4 build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,19 +57,17 @@ jobs:
           - lcov
           - binutils-common # For c++filt
 
-    - name: "FFmpeg 4 GCC (Ubuntu 18.04 Bionic)"
+    - name: "FFmpeg 4 GCC (Ubuntu 20.04 Focal)"
       env:
         - BUILD_VERSION=ffmpeg4
         - CMAKE_EXTRA_ARGS=""
         - TEST_TARGET=test
       os: linux
-      dist: bionic
+      dist: focal
       addons:
         apt:
           sources:
           - sourceline: 'ppa:openshot.developers/libopenshot-daily'
-          - sourceline: 'ppa:beineri/opt-qt-5.12.3-bionic'
-          - sourceline: 'ppa:jonathonf/ffmpeg-4'
           packages:
           - *p_common
           - qt5-default

--- a/src/bindings/ruby/CMakeLists.txt
+++ b/src/bindings/ruby/CMakeLists.txt
@@ -48,13 +48,15 @@ option(SILENCE_RUBY_VERSION_WARNING
 
 if (${RUBY_VERSION} VERSION_GREATER 2.6.9 AND ${SWIG_VERSION} VERSION_LESS 4.0.3)
   if (NOT ${SILENCE_RUBY_VERSION_WARNING})
-    message(WARNING "
+    message(WARNING "\
 Ruby 2.7.0+ detected, building the libopenshot Ruby API bindings \
-requires a pre-release version of SWIG 4.0.3 with this commit: \
-https://github.com/swig/swig/commit/5542cc228ad10bdc5c91107afb77c808c43bf2a4")
-    message(STATUS "
-To disable this warning, add -DSILENCE_RUBY_VERSION_WARNING:BOOL=1 to the cmake \
-command line, or enable the option in the CMake GUI.")
+requires either SWIG 4.0.3 or an older version patched with this commit: \
+https://github.com/swig/swig/commit/5542cc228ad10bdc5c91107afb77c808c43bf2a4 \
+(Recent Fedora and Ubuntu distro packages of SWIG 4.0.1 have already been \
+patched.)")
+    message(STATUS "To disable the previous warning, add \
+-DSILENCE_RUBY_VERSION_WARNING:BOOL=1 to the cmake command line, \
+or enable the option in the CMake GUI.")
   endif()
 endif()
 


### PR DESCRIPTION
Travis appear to have quietly brought up Ubuntu Focal as an available build `dist` (still undocumented anywhere, AFAICT). Still, using an undocumented Travis environment is the lesser evil, vs. using FFmpeg packages from a community PPA that's already bailed on us once.