### PR TITLE
Move off deprecated OpenMP API, fix FFmpeg code paths

### DIFF
--- a/include/FFmpegReader.h
+++ b/include/FFmpegReader.h
@@ -233,14 +233,13 @@ namespace openshot {
 		/// codecs have trouble seeking, and can introduce artifacts or blank images into the video.
 		bool enable_seek;
 
-		/// Constructor for FFmpegReader.  This automatically opens the media file and loads
-		/// frame 1, or it throws one of the following exceptions.
-		FFmpegReader(std::string path);
-
-		/// Constructor for FFmpegReader.  This only opens the media file to inspect its properties
-		/// if inspect_reader=true. When not inspecting the media file, it's much faster, and useful
-		/// when you are inflating the object using JSON after instantiating it.
-		FFmpegReader(std::string path, bool inspect_reader);
+		/// @brief Constructor for FFmpegReader.
+		///
+		/// Sets (and possibly opens) the media file path,
+		/// or throws an exception.
+		/// @param path  The filesystem location to load
+		/// @param inspect_reader  if true (the default), automatically open the media file and loads frame 1.
+		FFmpegReader(const std::string& path, bool inspect_reader=true);
 
 		/// Destructor
 		virtual ~FFmpegReader();

--- a/include/FFmpegWriter.h
+++ b/include/FFmpegWriter.h
@@ -251,9 +251,11 @@ namespace openshot {
 
 	public:
 
-		/// @brief Constructor for FFmpegWriter. Throws one of the following exceptions.
+		/// @brief Constructor for FFmpegWriter.
+		/// Throws an exception on failure to open path.
+		///
 		/// @param path The file path of the video file you want to open and read
-		FFmpegWriter(std::string path);
+		FFmpegWriter(const std::string& path);
 
 		/// Close the writer
 		void Close();

--- a/include/OpenMPUtilities.h
+++ b/include/OpenMPUtilities.h
@@ -41,5 +41,12 @@
 #define OPEN_MP_NUM_PROCESSORS (std::min(omp_get_num_procs(), std::max(2, openshot::Settings::Instance()->OMP_THREADS) ))
 #define FF_NUM_PROCESSORS (std::min(omp_get_num_procs(), std::max(2, openshot::Settings::Instance()->FF_THREADS) ))
 
+// Set max-active-levels to the max supported, if possible
+// (supported_active_levels is OpenMP 5.0 (November 2018) or later, only.)
+#if (_OPENMP >= 201811)
+  #define OPEN_MP_MAX_ACTIVE openmp_get_supported_active_levels()
+#else
+  #define OPEN_MP_MAX_ACTIVE OPEN_MP_NUM_PROCESSORS
+#endif
 
 #endif

--- a/include/Timeline.h
+++ b/include/Timeline.h
@@ -202,19 +202,23 @@ namespace openshot {
 
 	public:
 
-		/// @brief Default Constructor for the timeline (which sets the canvas width and height and FPS)
-		/// @param width The width of the timeline (and thus, the generated openshot::Frame objects)
-		/// @param height The height of the timeline (and thus, the generated openshot::Frame objects)
-		/// @param fps The frames rate of the timeline
-		/// @param sample_rate The sample rate of the timeline's audio
-		/// @param channels The number of audio channels of the timeline
+		/// @brief Default Constructor for the timeline (which configures the default frame properties)
+		/// @param width The image width of generated openshot::Frame objects
+		/// @param height The image height of generated openshot::Frame objects
+		/// @param fps The frame rate of the generated video
+		/// @param sample_rate The audio sample rate
+		/// @param channels The number of audio channels
 		/// @param channel_layout The channel layout (i.e. mono, stereo, 3 point surround, etc...)
 		Timeline(int width, int height, Fraction fps, int sample_rate, int channels, ChannelLayout channel_layout);
 
-		/// @brief Constructor for the timeline (which loads a JSON structure from a file path, and initializes a timeline)
+		/// @brief Project-file constructor for the timeline
+		///
+		/// Loads a JSON structure from a file path, and
+		/// initializes the timeline described within.
+		///
 		/// @param projectPath The path of the UTF-8 *.osp project file (JSON contents). Contents will be loaded automatically.
-		/// @param convert_absolute_paths Should all paths be converted to absolute paths (based on the folder of the path provided)
-		Timeline(std::string projectPath, bool convert_absolute_paths);
+		/// @param convert_absolute_paths Should all paths be converted to absolute paths (relative to the location of projectPath)
+		Timeline(const std::string& projectPath, bool convert_absolute_paths);
 
         virtual ~Timeline();
 

--- a/src/FFmpegReader.cpp
+++ b/src/FFmpegReader.cpp
@@ -83,7 +83,7 @@ int hw_de_on = 0;
 	AVHWDeviceType hw_de_av_device_type_global = AV_HWDEVICE_TYPE_NONE;
 #endif
 
-FFmpegReader::FFmpegReader(std::string path)
+FFmpegReader::FFmpegReader(const std::string& path, bool inspect_reader)
 		: last_frame(0), is_seeking(0), seeking_pts(0), seeking_frame(0), seek_count(0),
 		  audio_pts_offset(99999), video_pts_offset(99999), path(path), is_video_seek(true), check_interlace(false),
 		  check_fps(false), enable_seek(true), is_open(false), seek_audio_frame_found(0), seek_video_frame_found(0),
@@ -91,27 +91,6 @@ FFmpegReader::FFmpegReader(std::string path)
 		  current_video_frame(0), has_missing_frames(false), num_packets_since_video_frame(0), num_checks_since_final(0),
 		  packet(NULL) {
 
-	// Initialize FFMpeg, and register all formats and codecs
-	AV_REGISTER_ALL
-	AVCODEC_REGISTER_ALL
-
-	// Init cache
-	working_cache.SetMaxBytesFromInfo(OPEN_MP_NUM_PROCESSORS * info.fps.ToDouble() * 2, info.width, info.height, info.sample_rate, info.channels);
-	missing_frames.SetMaxBytesFromInfo(OPEN_MP_NUM_PROCESSORS * 2, info.width, info.height, info.sample_rate, info.channels);
-	final_cache.SetMaxBytesFromInfo(OPEN_MP_NUM_PROCESSORS * 2, info.width, info.height, info.sample_rate, info.channels);
-
-	// Open and Close the reader, to populate its attributes (such as height, width, etc...)
-	Open();
-	Close();
-}
-
-FFmpegReader::FFmpegReader(std::string path, bool inspect_reader)
-		: last_frame(0), is_seeking(0), seeking_pts(0), seeking_frame(0), seek_count(0),
-		  audio_pts_offset(99999), video_pts_offset(99999), path(path), is_video_seek(true), check_interlace(false),
-		  check_fps(false), enable_seek(true), is_open(false), seek_audio_frame_found(0), seek_video_frame_found(0),
-		  prev_samples(0), prev_pts(0), pts_total(0), pts_counter(0), is_duration_known(false), largest_frame_processed(0),
-		  current_video_frame(0), has_missing_frames(false), num_packets_since_video_frame(0), num_checks_since_final(0),
-		  packet(NULL) {
 
 	// Initialize FFMpeg, and register all formats and codecs
 	AV_REGISTER_ALL

--- a/src/FFmpegReader.cpp
+++ b/src/FFmpegReader.cpp
@@ -91,6 +91,11 @@ FFmpegReader::FFmpegReader(const std::string& path, bool inspect_reader)
 		  current_video_frame(0), has_missing_frames(false), num_packets_since_video_frame(0), num_checks_since_final(0),
 		  packet(NULL) {
 
+	// Configure OpenMP parallelism
+	// Default number of threads per section
+	omp_set_num_threads(OPEN_MP_NUM_PROCESSORS);
+	// Allow nested parallel sections as deeply as supported
+	omp_set_max_active_levels(OPEN_MP_MAX_ACTIVE);
 
 	// Initialize FFMpeg, and register all formats and codecs
 	AV_REGISTER_ALL
@@ -876,11 +881,6 @@ std::shared_ptr<Frame> FFmpegReader::ReadStream(int64_t requested_frame) {
 	int packets_processed = 0;
 	int minimum_packets = OPEN_MP_NUM_PROCESSORS;
 	int max_packets = 4096;
-
-	// Set the number of threads in OpenMP
-	omp_set_num_threads(OPEN_MP_NUM_PROCESSORS);
-	// Allow nested OpenMP sections
-	omp_set_nested(true);
 
 	// Debug output
 	ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::ReadStream", "requested_frame", requested_frame, "OPEN_MP_NUM_PROCESSORS", OPEN_MP_NUM_PROCESSORS);

--- a/src/FFmpegWriter.cpp
+++ b/src/FFmpegWriter.cpp
@@ -552,7 +552,7 @@ void FFmpegWriter::SetOption(StreamType stream, std::string name, std::string va
 						}
 						else if (strstr(info.vcodec.c_str(), "rav1e") != NULL) {
 							// Set number of tiles to a fixed value
-							// TODO Let user choose number of tiles 
+							// TODO Let user choose number of tiles
 							av_opt_set_int(c->priv_data, "qp", std::min(std::stoi(value),255), 0);
 							av_opt_set_int(c->priv_data, "speed", 7, 0);
 							av_opt_set_int(c->priv_data, "tile-rows", 2, 0);		// number of rows
@@ -560,7 +560,7 @@ void FFmpegWriter::SetOption(StreamType stream, std::string name, std::string va
 						}
 						else if (strstr(info.vcodec.c_str(), "aom") != NULL) {
 							// Set number of tiles to a fixed value
-							// TODO Let user choose number of tiles 
+							// TODO Let user choose number of tiles
 							// libaom doesn't have qp only crf
 							av_opt_set_int(c->priv_data, "crf", std::min(std::stoi(value),63), 0);
 							av_opt_set_int(c->priv_data, "tile-rows", 1, 0);		// log2 of number of rows
@@ -691,15 +691,8 @@ void FFmpegWriter::WriteFrame(std::shared_ptr<Frame> frame) {
 
 	// Write the frames once it reaches the correct cache size
 	if ((int)spooled_video_frames.size() == cache_size || (int)spooled_audio_frames.size() == cache_size) {
-		// Is writer currently writing?
-		if (!is_writing)
-			// Write frames to video file
-			write_queued_frames();
-
-		else {
-			// Write frames to video file
-			write_queued_frames();
-		}
+		// Write frames to video file
+		write_queued_frames();
 	}
 
 	// Keep track of the last frame added

--- a/src/FFmpegWriter.cpp
+++ b/src/FFmpegWriter.cpp
@@ -83,7 +83,7 @@ static int set_hwframe_ctx(AVCodecContext *ctx, AVBufferRef *hw_device_ctx, int6
 }
 #endif // HAVE_HW_ACCEL
 
-FFmpegWriter::FFmpegWriter(std::string path) :
+FFmpegWriter::FFmpegWriter(const std::string& path) :
 		path(path), fmt(NULL), oc(NULL), audio_st(NULL), video_st(NULL), samples(NULL),
 		audio_outbuf(NULL), audio_outbuf_size(0), audio_input_frame_size(0), audio_input_position(0),
 		initial_audio_input_frame_size(0), img_convert_ctx(NULL), cache_size(8), num_of_rescalers(32),

--- a/src/FFmpegWriter.cpp
+++ b/src/FFmpegWriter.cpp
@@ -95,6 +95,12 @@ FFmpegWriter::FFmpegWriter(const std::string& path) :
 	info.has_audio = false;
 	info.has_video = false;
 
+	// Configure OpenMP parallelism
+	// Default number of threads per block
+	omp_set_num_threads(OPEN_MP_NUM_PROCESSORS);
+	// Allow nested parallel sections as deeply as supported
+	omp_set_max_active_levels(OPEN_MP_MAX_ACTIVE);
+
 	// Initialize FFMpeg, and register all formats and codecs
 	AV_REGISTER_ALL
 
@@ -713,11 +719,6 @@ void FFmpegWriter::write_queued_frames() {
 	// Empty spool
 	spooled_video_frames.clear();
 	spooled_audio_frames.clear();
-
-	// Set the number of threads in OpenMP
-	omp_set_num_threads(OPEN_MP_NUM_PROCESSORS);
-	// Allow nested OpenMP sections
-	omp_set_nested(true);
 
 	// Create blank exception
 	bool has_error_encoding_video = false;

--- a/src/Timeline.cpp
+++ b/src/Timeline.cpp
@@ -82,7 +82,7 @@ Timeline::Timeline(int width, int height, Fraction fps, int sample_rate, int cha
 }
 
 // Constructor for the timeline (which loads a JSON structure from a file path, and initializes a timeline)
-Timeline::Timeline(std::string projectPath, bool convert_absolute_paths) :
+Timeline::Timeline(const std::string& projectPath, bool convert_absolute_paths) :
 		is_open(false), auto_map_clips(true), managed_cache(true), path(projectPath) {
 
 	// Create CrashHandler and Attach (incase of errors)

--- a/src/Timeline.cpp
+++ b/src/Timeline.cpp
@@ -67,7 +67,13 @@ Timeline::Timeline(int width, int height, Fraction fps, int sample_rate, int cha
 	info.acodec = "openshot::timeline";
 	info.vcodec = "openshot::timeline";
 
-    // Init max image size
+	// Configure OpenMP parallelism
+	// Default number of threads per block
+	omp_set_num_threads(OPEN_MP_NUM_PROCESSORS);
+	// Allow nested parallel sections as deeply as supported
+	omp_set_max_active_levels(OPEN_MP_MAX_ACTIVE);
+
+	// Init max image size
 	SetMaxSize(info.width, info.height);
 
 	// Init cache
@@ -193,6 +199,12 @@ Timeline::Timeline(std::string projectPath, bool convert_absolute_paths) :
 	info.video_timebase = info.fps.Reciprocal();
 	info.has_video = true;
 	info.has_audio = true;
+
+	// Configure OpenMP parallelism
+	// Default number of threads per section
+	omp_set_num_threads(OPEN_MP_NUM_PROCESSORS);
+	// Allow nested parallel sections as deeply as supported
+	omp_set_max_active_levels(OPEN_MP_MAX_ACTIVE);
 
 	// Init max image size
 	SetMaxSize(info.width, info.height);
@@ -891,10 +903,6 @@ std::shared_ptr<Frame> Timeline::GetFrame(int64_t requested_frame)
 		std::vector<Clip*> nearby_clips;
 		#pragma omp critical (T_GetFrame)
 		nearby_clips = find_intersecting_clips(requested_frame, minimum_frames, true);
-
-		omp_set_num_threads(OPEN_MP_NUM_PROCESSORS);
-		// Allow nested OpenMP sections
-		omp_set_nested(true);
 
 		// Debug output
 		ZmqLogger::Instance()->AppendDebugMethod("Timeline::GetFrame", "requested_frame", requested_frame, "minimum_frames", minimum_frames, "OPEN_MP_NUM_PROCESSORS", OPEN_MP_NUM_PROCESSORS);


### PR DESCRIPTION
This was primarily inspired by Codecov flagging some code as unreachable, turned out it has a bit of history. But this corrects that, moves us off of a deprecated OpenMP API call, and makes some tweaks to FFmpegWriter/Reader along with Timeline, while I was touching them.

I'll explain some of the changes in inline comments.