### PR TITLE
MagickUtils: Add #pragma to silence IM6 warning

### DIFF
--- a/include/MagickUtilities.h
+++ b/include/MagickUtilities.h
@@ -32,7 +32,11 @@
 
 #ifdef USE_IMAGEMAGICK
 
+// Exclude a warning message with IM6 headers
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wignored-qualifiers"
     #include "Magick++.h"
+#pragma GCC diagnostic pop
 
     // Determine ImageMagick version, as IM7 isn't fully
     // backwards compatible


### PR DESCRIPTION
Stupid ImageMagick 6 has a code boner in its header files that produces warning messages at every `#include`, if `-Wextra` is enabled during build:
```
In file included from /usr/include/ImageMagick-6/magick/memory_.h:22,
                 from /usr/include/ImageMagick-6/magick/MagickCore.h:125,
                 from /usr/include/ImageMagick-6/Magick++/Include.h:45,
                 from /usr/include/ImageMagick-6/Magick++.h:10,
                 from /home/ferd/rpmbuild/REPOS/libopenshot/worktree-valgrind/include/Qt/../MagickUtilities.h:39,
                 from /home/ferd/rpmbuild/REPOS/libopenshot/worktree-valgrind/include/Qt/../Frame.h:56,
                 from /home/ferd/rpmbuild/REPOS/libopenshot/worktree-valgrind/include/Qt/../RendererBase.h:34,
                 from /home/ferd/rpmbuild/REPOS/libopenshot/worktree-valgrind/include/Qt/VideoRenderer.h:34,
                 from /home/ferd/rpmbuild/REPOS/libopenshot/worktree-valgrind/include/Qt/VideoRenderWidget.h:37,
                 from /home/ferd/rpmbuild/REPOS/libopenshot/worktree-valgrind/include/Qt/PlayerDemo.h:41,
                 from /home/ferd/rpmbuild/REPOS/libopenshot/worktree-valgrind/build/src/openshot_autogen/RMFXSSRFNF/moc_PlayerDemo.cpp:10,
                 from /home/ferd/rpmbuild/REPOS/libopenshot/worktree-valgrind/build/src/openshot_autogen/mocs_compilation.cpp:2:
/usr/include/ImageMagick-6/magick/memory_.h: In function ‘MagickCore::MagickBooleanType MagickCore::HeapOverflowSanityCheckGetSize(size_t, size_t, size_t*)’:
/usr/include/ImageMagick-6/magick/memory_.h:98:20: warning: type qualifiers ignored on cast result type [-Wignored-qualifiers]
   98 |   assert(extent != (size_t *const) NULL);
      |                    ^
```

...and so on, every time `Frame.h` is `#include`d. (Which is _a **lot**_.) A `#pragma` disables the not-of-any-use-to-us warning.