### PR TITLE
Bitratecorrect

### DIFF
--- a/src/FFmpegWriter.cpp
+++ b/src/FFmpegWriter.cpp
@@ -1202,8 +1202,10 @@ AVStream *FFmpegWriter::add_video_stream() {
 		) {
 		c->bit_rate = info.video_bit_rate;
 		if (info.video_bit_rate >= 1500000) {
-			c->qmin = 2;
-			c->qmax = 30;
+	        if (c->codec_id == AV_CODEC_ID_MPEG2VIDEO)  {
+                c->qmin = 3;
+                c->qmax = 30;
+            }
 		}
 		// Here should be the setting for low fixed bitrate
 		// Defaults are used because mpeg2 otherwise had problems

--- a/src/FFmpegWriter.cpp
+++ b/src/FFmpegWriter.cpp
@@ -1202,10 +1202,10 @@ AVStream *FFmpegWriter::add_video_stream() {
 		) {
 		c->bit_rate = info.video_bit_rate;
 		if (info.video_bit_rate >= 1500000) {
-	        if (c->codec_id == AV_CODEC_ID_MPEG2VIDEO)  {
-                c->qmin = 3;
-                c->qmax = 30;
-            }
+			if (c->codec_id == AV_CODEC_ID_MPEG2VIDEO)  {
+				c->qmin = 3;
+				c->qmax = 30;
+			}
 		}
 		// Here should be the setting for low fixed bitrate
 		// Defaults are used because mpeg2 otherwise had problems

--- a/src/FFmpegWriter.cpp
+++ b/src/FFmpegWriter.cpp
@@ -1203,7 +1203,7 @@ AVStream *FFmpegWriter::add_video_stream() {
 		c->bit_rate = info.video_bit_rate;
 		if (info.video_bit_rate >= 1500000) {
 			if (c->codec_id == AV_CODEC_ID_MPEG2VIDEO)  {
-				c->qmin = 3;
+				c->qmin = 2;
 				c->qmax = 30;
 			}
 		}


### PR DESCRIPTION
The values for qmax and qmin were set for all codec but only mpeg2 needed them and as a result the bitrates of the exported clips could be wrong. Now only when the export is with mpeg2 the default values are changed.