### PR TITLE
CMake: Remove threading config variables

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -317,11 +317,6 @@ foreach(ff_comp IN LISTS all_comps)
 
 endforeach()
 
-################### Threads ####################
-# Threading library -- uses IMPORTED target Threads::Threads (since CMake 3.1)
-set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
-set(THREADS_PREFER_PTHREAD_FLAG TRUE)
-
 ################### OPENMP #####################
 # Check for OpenMP (used for multi-core processing)
 


### PR DESCRIPTION
As a followup to #540 which removed the `find_package(Threads REQUIRED)` call and subsequent use of the `Threads::Thread` target, this PR eliminates the two legacy CMake variables that we were configuring immediately previous. It seems less problematic to simply let OpenMP handle all this for itself, something it appears perfectly capable of doing now.