### PR TITLE
Remove FFmpeg 3.2 from Travis matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,11 +32,6 @@ addons:
     - curl
 
 jobs:
-
-  # The FFmpeg 3.2 backport PPA has gone missing
-  allow_failures:
-    - name: "FFmpeg 3.2 GCC (Ubuntu 16.04 Xenial)"
-
   include:
     - name: "Coverage + FFmpeg 3.4 GCC (Ubuntu 18.04 Bionic)"
       env:
@@ -98,31 +93,6 @@ jobs:
           - qt5-default
           - libavresample-dev
           - libomp-dev
-
-    - name: "FFmpeg 3.2 GCC (Ubuntu 16.04 Xenial)"
-      env:
-        - BUILD_VERSION=ffmpeg32
-        - CMAKE_EXTRA_ARGS=""
-        - TEST_TARGET="os_test"
-      os: linux
-      dist: xenial
-      addons:
-        apt:
-          sources:
-          - sourceline: 'ppa:openshot.developers/libopenshot-daily'
-          - sourceline: 'ppa:jon-hedgerows/ffmpeg-backports'
-          packages:
-          - *p_common
-          - libavresample-dev
-          - libavcodec57
-          - libavdevice57
-          - libavfilter6
-          - libavformat57
-          - libavresample3
-          - libavutil55
-          - libpostproc54
-          - libswresample2
-          - libswscale4
 
     - name: "FFmpeg 2 GCC (Ubuntu 16.04 Xenial)"
       env:


### PR DESCRIPTION
The PPA we were using for our FFmpeg 3.2 test builds is gone, and since there's no currently-supported Ubuntu release with 3.2 available there's no reliable way to get it back. Time to just drop it from the build matrix again, building with community PPAs has proven too unreliable to go back down that road. We still have builds in one version each of FFmpeg 2, 3, and 4.