### PR TITLE
Drop QtMultimedia and QtMultimediaWidgets deps

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -284,7 +284,7 @@ endif ()
 
 ################# QT5 ###################
 # Find QT5 libraries
-set(_qt_components Widgets Core Gui Multimedia MultimediaWidgets)
+set(_qt_components Core Gui Widgets)
 find_package(Qt5 COMPONENTS ${_qt_components} REQUIRED)
 
 foreach(_qt_comp IN LISTS _qt_components)


### PR DESCRIPTION
Turns out, we don't actually use any of the classes in QtMultimedia (or its Widgets), so this PR drops them as dependencies.

This also prevents both Qt5Network and Qt5OpenGL getting pulled in as dependencies, and reduces our Qt dependency fingerprint significantly to just the three modules (now) listed in the `CMakeLists.txt`: QtCore, QtGui, and QtWidgets.

Shared libs being what they are, it only reduces the final size of `libopenshot.so` by about 33Kb, but the size isn't the point. (Besides, not loading four big Qt modules could give runtime a teeny tiny bit more pep, theoretically.)

```console
# Before
$ ldd libopenshot.so.0.2.5 |& grep -i qt
	libQt5MultimediaWidgets.so.5 => /lib64/libQt5MultimediaWidgets.so.5 (0x00007f8911972000)
	libQt5Widgets.so.5 => /lib64/libQt5Widgets.so.5 (0x00007f89112cc000)
	libQt5Multimedia.so.5 => /lib64/libQt5Multimedia.so.5 (0x00007f89111e2000)
	libQt5Gui.so.5 => /lib64/libQt5Gui.so.5 (0x00007f8910c79000)
	libQt5Network.so.5 => /lib64/libQt5Network.so.5 (0x00007f8910af0000)
	libQt5Core.so.5 => /lib64/libQt5Core.so.5 (0x00007f89105d3000)
	libQt5OpenGL.so.5 => /lib64/libQt5OpenGL.so.5 (0x00007f890dfa7000)

# After
$ ldd libopenshot.so.0.2.5 |& grep -i qt
	libQt5Widgets.so.5 => /lib64/libQt5Widgets.so.5 (0x00007f8429fff000)
	libQt5Gui.so.5 => /lib64/libQt5Gui.so.5 (0x00007f842785c000)
	libQt5Core.so.5 => /lib64/libQt5Core.so.5 (0x00007f8427341000)
```