### PR TITLE
Use Qt::endl with QTextStream

### DIFF
--- a/include/CacheDisk.h
+++ b/include/CacheDisk.h
@@ -38,8 +38,6 @@
 #include "Frame.h"
 #include "Exceptions.h"
 #include <QDir>
-#include <QString>
-#include <QTextStream>
 
 namespace openshot {
 

--- a/include/QtUtilities.h
+++ b/include/QtUtilities.h
@@ -1,0 +1,44 @@
+/**
+ * @file
+ * @brief Header file for QtUtilities (compatibiity overlay)
+ * @author FeRD (Frank Dana) <ferdnyc@gmail.com>
+ */
+
+/* LICENSE
+ *
+ * Copyright (c) 2008-2020 OpenShot Studios, LLC
+ * <http://www.openshotstudios.com/>. This file is part of
+ * OpenShot Library (libopenshot), an open-source project dedicated to
+ * delivering high quality video editing and animation solutions to the
+ * world. For more information visit <http://www.openshot.org/>.
+ *
+ * OpenShot Library (libopenshot) is free software: you can redistribute it
+ * and/or modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * OpenShot Library (libopenshot) is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with OpenShot Library. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef OPENSHOT_QT_UTILITIES_H
+#define OPENSHOT_QT_UTILITIES_H
+
+#include <Qt>
+#include <QTextStream>
+
+// Fix Qt::endl for older Qt versions
+// From: https://bugreports.qt.io/browse/QTBUG-82680
+#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
+namespace Qt {
+  using TextStreamFunction = QTextStream& (*)(QTextStream&);
+  constexpr TextStreamFunction endl = ::endl;
+}
+#endif
+
+#endif // OPENSHOT_QT_UTILITIES_H

--- a/src/CacheDisk.cpp
+++ b/src/CacheDisk.cpp
@@ -191,10 +191,10 @@ void CacheDisk::Add(std::shared_ptr<Frame> frame)
 
 			if (audio_file.open(QIODevice::WriteOnly)) {
 				QTextStream audio_stream(&audio_file);
-				audio_stream << frame->SampleRate() << endl;
-				audio_stream << frame->GetAudioChannelsCount() << endl;
-				audio_stream << frame->GetAudioSamplesCount() << endl;
-				audio_stream << frame->ChannelsLayout() << endl;
+				audio_stream << frame->SampleRate() << Qt::endl;
+				audio_stream << frame->GetAudioChannelsCount() << Qt::endl;
+				audio_stream << frame->GetAudioSamplesCount() << Qt::endl;
+				audio_stream << frame->ChannelsLayout() << Qt::endl;
 
 				// Loop through all samples
 				for (int channel = 0; channel < frame->GetAudioChannelsCount(); channel++)
@@ -202,7 +202,7 @@ void CacheDisk::Add(std::shared_ptr<Frame> frame)
 					// Get audio for this channel
 					float *samples = frame->GetAudioSamples(channel);
 					for (int sample = 0; sample < frame->GetAudioSamplesCount(); sample++)
-						audio_stream << samples[sample] << endl;
+						audio_stream << samples[sample] << Qt::endl;
 				}
 
 			}

--- a/src/CacheDisk.cpp
+++ b/src/CacheDisk.cpp
@@ -29,6 +29,7 @@
  */
 
 #include "../include/CacheDisk.h"
+#include "../include/QtUtilities.h"
 #include <Qt>
 #include <QString>
 #include <QTextStream>

--- a/src/CacheDisk.cpp
+++ b/src/CacheDisk.cpp
@@ -29,6 +29,9 @@
  */
 
 #include "../include/CacheDisk.h"
+#include <Qt>
+#include <QString>
+#include <QTextStream>
 
 using namespace std;
 using namespace openshot;


### PR DESCRIPTION
Recent Qt releases complain about `endl` being used to terminate `QTextStream` lines, and recommend using `Qt::endl` instead. So, let's.