### PR TITLE
Fix the PTS offset logic error when first reading a file with FFmpegReader

### DIFF
--- a/src/FFmpegReader.cpp
+++ b/src/FFmpegReader.cpp
@@ -1875,6 +1875,8 @@ void FFmpegReader::UpdatePTSOffset(bool is_video) {
 			// Also, determine if PTS is invalid (too far away from zero)
 			// We compare the PTS to the timebase value equal to 1 second (which means the PTS
 			// must be within the -1 second to +1 second of zero, otherwise we ignore it)
+			// TODO: Please see https://github.com/OpenShot/libopenshot/pull/565#issuecomment-690985272
+			// for ideas to improve this logic.
 			int64_t max_offset = info.video_timebase.Reciprocal().ToFloat();
 			if (video_pts_offset < -max_offset || video_pts_offset > max_offset) {
 				// Ignore PTS, it seems invalid
@@ -1892,6 +1894,8 @@ void FFmpegReader::UpdatePTSOffset(bool is_video) {
 			// Also, determine if PTS is invalid (too far away from zero)
 			// We compare the PTS to the timebase value equal to 1 second (which means the PTS
 			// must be within the -1 second to +1 second of zero, otherwise we ignore it)
+			// TODO: Please see https://github.com/OpenShot/libopenshot/pull/565#issuecomment-690985272
+			// for ideas to improve this logic.
 			audio_pts_offset = 0 - packet->pts;
 			int64_t max_offset = info.audio_timebase.Reciprocal().ToFloat();
 			if (audio_pts_offset < -max_offset || audio_pts_offset > max_offset) {

--- a/src/FFmpegReader.cpp
+++ b/src/FFmpegReader.cpp
@@ -1868,8 +1868,18 @@ void FFmpegReader::UpdatePTSOffset(bool is_video) {
 		// VIDEO PACKET
 		if (video_pts_offset == 99999) // Has the offset been set yet?
 		{
-			// Find the difference between PTS and frame number (no more than 10 timebase units allowed)
-			video_pts_offset = 0 - std::max(GetVideoPTS(), (int64_t) info.video_timebase.ToInt() * 10);
+			// Find the difference between PTS and frame number
+			video_pts_offset = 0 - GetVideoPTS();
+
+			// Find the difference between PTS and frame number
+			// Also, determine if PTS is invalid (too far away from zero)
+			// We compare the PTS to the timebase value equal to 1 second (which means the PTS
+			// must be within the -1 second to +1 second of zero, otherwise we ignore it)
+			int64_t max_offset = info.video_timebase.Reciprocal().ToFloat();
+			if (video_pts_offset < -max_offset || video_pts_offset > max_offset) {
+				// Ignore PTS, it seems invalid
+				video_pts_offset = 0;
+			}
 
 			// debug output
 			ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::UpdatePTSOffset (Video)", "video_pts_offset", video_pts_offset, "is_video", is_video);
@@ -1878,8 +1888,16 @@ void FFmpegReader::UpdatePTSOffset(bool is_video) {
 		// AUDIO PACKET
 		if (audio_pts_offset == 99999) // Has the offset been set yet?
 		{
-			// Find the difference between PTS and frame number (no more than 10 timebase units allowed)
-			audio_pts_offset = 0 - std::max(packet->pts, (int64_t) info.audio_timebase.ToInt() * 10);
+			// Find the difference between PTS and frame number
+			// Also, determine if PTS is invalid (too far away from zero)
+			// We compare the PTS to the timebase value equal to 1 second (which means the PTS
+			// must be within the -1 second to +1 second of zero, otherwise we ignore it)
+			audio_pts_offset = 0 - packet->pts;
+			int64_t max_offset = info.audio_timebase.Reciprocal().ToFloat();
+			if (audio_pts_offset < -max_offset || audio_pts_offset > max_offset) {
+				// Ignore PTS, it seems invalid
+				audio_pts_offset = 0;
+			}
 
 			// debug output
 			ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::UpdatePTSOffset (Audio)", "audio_pts_offset", audio_pts_offset, "is_video", is_video);


### PR DESCRIPTION
Use the calculated `0 - PTS`, unless it is too large (more than 1 second off from zero). This is related to a previous PR (with much discussion): https://github.com/OpenShot/libopenshot/pull/311. This PR fixes the regression related to limiting the offset, and I think makes more sense than previous suggestions. 

The PTS offset was always designed as a quick way to "zero" out the video PTS and audio PTS values, so we could calculate frame numbers, based on the starting PTS values, etc... But in my testing, some videos are encoded with negative timestamps, especially common with audio tracks, where the audio starts before the 1st video frame. OpenShot is not really designed to deal with this, and it causes us to search for matching packets which never come. This could/does introduce some amount of audio drift, just depending on how negative the audio timestamps are. Also, in my testing, I've come across videos that have garbage timestamps (usually negative values), for example -9999999999999999, and then the rest of the packets have normal PTS values. So, this is the background on why I want to limit the offset to some reasonable amount (-1 to +1 seconds in timebase units).

I've done some testing on this with my crazy test videos, and this seems to work great.