### PR TITLE
Change of name of library

### DIFF
--- a/src/FFmpegWriter.cpp
+++ b/src/FFmpegWriter.cpp
@@ -539,7 +539,7 @@ void FFmpegWriter::SetOption(StreamType stream, std::string name, std::string va
 				switch (c->codec_id) {
 					case AV_CODEC_ID_AV1 :
 						c->bit_rate = 0;
-						if (strstr(info.vcodec.c_str(), "svt_av1") != NULL) {
+						if (strstr(info.vcodec.c_str(), "svtav1") != NULL) {
 							av_opt_set_int(c->priv_data, "qp", std::min(std::stoi(value),63), 0);
 						}
 						else if (strstr(info.vcodec.c_str(), "rav1e") != NULL) {
@@ -1239,7 +1239,7 @@ AVStream *FFmpegWriter::add_video_stream() {
 					info.video_bit_rate = calculated_quality;
 				} // medium
 			}
-			if (strstr(info.vcodec.c_str(), "svt_av1") != NULL) {
+			if (strstr(info.vcodec.c_str(), "svtav1") != NULL) {
 				av_opt_set_int(c->priv_data, "preset", 6, 0);
 				av_opt_set_int(c->priv_data, "forced-idr",1,0);
 			}


### PR DESCRIPTION
With the official inclusion of SVT-AV1 the library changed from svt_av1 to svtav1. This takes this into account