### PR TITLE
FrameMapper + Resampling loses samples

### DIFF
--- a/src/FrameMapper.cpp
+++ b/src/FrameMapper.cpp
@@ -487,7 +487,7 @@ std::shared_ptr<Frame> FrameMapper::GetFrame(int64_t requested_frame)
 			// includes some additional input samples on first iteration,
 			// and continues the offset to ensure that the sample rate
 			// converter isn't input limited.
-			const int EXTRA_INPUT_SAMPLES = 20;
+			const int EXTRA_INPUT_SAMPLES = 100;
 
 			// Extend end sample count by an additional EXTRA_INPUT_SAMPLES samples
 			copy_samples.sample_end += EXTRA_INPUT_SAMPLES;


### PR DESCRIPTION
Apparently, we need enough padding during resampling, so we exceed the # of samples required for the first frame, and 20 was just too low for many frame rates / sample rates. This seems kind of random / arbitrary, but it's an easy fix for a more complex issue, where resampling always leaves behind some samples for the next call, and we can really mess up our sample division logic.