### PR TITLE
Tests: Increase coverage for ImageReader, 100% for ImageWriter

### DIFF
--- a/include/ImageReader.h
+++ b/include/ImageReader.h
@@ -76,15 +76,15 @@ namespace openshot
 		bool is_open;
 
 	public:
-
-		/// Constructor for ImageReader.  This automatically opens the media file and loads
-		/// frame 1, or it throws one of the following exceptions.
-		ImageReader(std::string path);
-
-		/// Constructor for ImageReader.  This only opens the media file to inspect its properties
-		/// if inspect_reader=true. When not inspecting the media file, it's much faster, and useful
-		/// when you are inflating the object using JSON after instantiating it.
-		ImageReader(std::string path, bool inspect_reader);
+		/// @brief Constructor for ImageReader.
+		///
+		/// Opens the media file to inspect its properties and loads frame 1,
+		/// iff inspect_reader == true (the default). Pass a false value in
+		/// the optional parameter to defer this initial Open()/Close() cycle.
+		///
+		/// When not inspecting the media file, it's much faster, and useful
+		/// when you are inflating the object using JSON after instantiation.
+		ImageReader(const std::string& path, bool inspect_reader=true);
 
 		/// Close File
 		void Close() override;

--- a/include/QtImageReader.h
+++ b/include/QtImageReader.h
@@ -72,15 +72,15 @@ namespace openshot
 		QSize max_size;	///> Current max_size as calculated with Clip properties
 
 	public:
-
-		/// Constructor for QtImageReader.  This automatically opens the media file and loads
-		/// frame 1, or it throws one of the following exceptions.
-		QtImageReader(std::string path);
-
-		/// Constructor for QtImageReader.  This only opens the media file to inspect its properties
-		/// if inspect_reader=true. When not inspecting the media file, it's much faster, and useful
-		/// when you are inflating the object using JSON after instantiating it.
-		QtImageReader(std::string path, bool inspect_reader);
+		/// @brief Constructor for QtImageReader.
+		///
+		/// Opens the media file to inspect its properties and loads frame 1,
+		/// iff inspect_reader == true (the default). Pass a false value in
+		/// the optional parameter to defer this initial Open()/Close() cycle.
+		///
+		/// When not inspecting the media file, it's much faster, and useful
+		/// when you are inflating the object using JSON after instantiation.
+		QtImageReader(std::string path, bool inspect_reader=true);
 
 		virtual ~QtImageReader();
 

--- a/src/ImageReader.cpp
+++ b/src/ImageReader.cpp
@@ -35,14 +35,7 @@
 
 using namespace openshot;
 
-ImageReader::ImageReader(std::string path) : path(path), is_open(false)
-{
-	// Open and Close the reader, to populate its attributes (such as height, width, etc...)
-	Open();
-	Close();
-}
-
-ImageReader::ImageReader(std::string path, bool inspect_reader) : path(path), is_open(false)
+ImageReader::ImageReader(const std::string& path, bool inspect_reader) : path(path), is_open(false)
 {
 	// Open and Close the reader, to populate its attributes (such as height, width, etc...)
 	if (inspect_reader) {

--- a/src/QtImageReader.cpp
+++ b/src/QtImageReader.cpp
@@ -44,13 +44,6 @@
 
 using namespace openshot;
 
-QtImageReader::QtImageReader(std::string path) : path{QString::fromStdString(path)}, is_open(false)
-{
-	// Open and Close the reader, to populate its attributes (such as height, width, etc...)
-	Open();
-	Close();
-}
-
 QtImageReader::QtImageReader(std::string path, bool inspect_reader) : path{QString::fromStdString(path)}, is_open(false)
 {
 	// Open and Close the reader, to populate its attributes (such as height, width, etc...)

--- a/tests/ImageWriter_Tests.cpp
+++ b/tests/ImageWriter_Tests.cpp
@@ -61,6 +61,8 @@ TEST(Gif)
 	/* WRITER ---------------- */
 	ImageWriter w("output1.gif");
 
+	CHECK_EQUAL(false, w.IsOpen());
+
 	// Check for exception on write-before-open
 	CHECK_THROW(w.WriteFrame(&r, 500, 504), WriterClosed);
 
@@ -79,7 +81,16 @@ TEST(Gif)
 
 	// Open up the 5th frame from the newly created GIF
 	ImageReader r1("output1.gif[4]");
+
+	// Basic Reader state queries
+	CHECK_EQUAL("ImageReader", r1.Name());
+
+	CacheMemory* c = r1.GetCache();
+	CHECK_EQUAL(true, c == nullptr);
+
+	CHECK_EQUAL(false, r1.IsOpen());
 	r1.Open();
+	CHECK_EQUAL(true, r1.IsOpen());
 
 	// Verify various settings
 	CHECK_EQUAL(r.info.width, r1.info.width);

--- a/tests/ImageWriter_Tests.cpp
+++ b/tests/ImageWriter_Tests.cpp
@@ -37,16 +37,32 @@ using namespace std;
 using namespace openshot;
 
 #ifdef USE_IMAGEMAGICK
-TEST(ImageWriter_Test_Gif)
+SUITE(ImageWriter)
 {
-	// Reader
+
+TEST(Gif)
+{
+	// Reader ---------------
+
+	// Bad path
+	FFmpegReader bad_r("/tmp/bleeblorp.xls", false);
+	CHECK_THROW(bad_r.Open(), InvalidFile);
+
+	// Good path
 	stringstream path;
 	path << TEST_MEDIA_PATH << "sintel_trailer-720p.mp4";
 	FFmpegReader r(path.str());
+
+	// Read-before-open error
+	CHECK_THROW(r.GetFrame(1), ReaderClosed);
+
 	r.Open();
 
 	/* WRITER ---------------- */
 	ImageWriter w("output1.gif");
+
+	// Check for exception on write-before-open
+	CHECK_THROW(w.WriteFrame(&r, 500, 504), WriterClosed);
 
 	// Set the image output settings (format, fps, width, height, quality, loops, combine)
 	w.SetVideoOptions("GIF", r.info.fps, r.info.width, r.info.height, 70, 1, true);
@@ -82,4 +98,6 @@ TEST(ImageWriter_Test_Gif)
 	CHECK_CLOSE(11, (int)pixels[pixel_index + 2], 5);
 	CHECK_CLOSE(255, (int)pixels[pixel_index + 3], 5);
 }
+
+} // SUITE
 #endif


### PR DESCRIPTION
`ImageWriter.cpp` was literally _one line_ of code away from full coverage, so I wrote a `CHECK_THROW()` test for that one line (an exception).

I also added `CHECK_THROW()`s for two exceptions in `ImageReader.cpp`, and performed the same constructor consolidation trick on it that I used for FFmpegReader (make `inspect_reader` an optional arg with a default value of true, instead of having two overloads, one with and one without). That should complete the coverage of every method in ImageReader _except_ for the `Json::Value`-form setter and getter.