### PR TITLE
Various unit tests: Increase coverage

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -7,11 +7,10 @@ coverage:
         base: pr # Only post a status to pull requests
         informational: true # Don't block PRs based on coverage stats (yet?)
 ignore:
-  - "/examples"
-  - "/bindings"
-  - "/thirdparty/jsoncpp"
-  - "/doc"
-  - "/cmake"
-  - "/*.md"
-  - "bindings"
+  - "examples/**/*"
+  - "bindings/**/*"
+  - "thirdparty/jsoncpp"
+  - "doc"
+  - "cmake"
+  - "*.md"
   - "src/openshot_autogen"

--- a/tests/Color_Tests.cpp
+++ b/tests/Color_Tests.cpp
@@ -52,9 +52,6 @@ TEST(Keyframe_constructor)
 	for (auto& kf : kfs) {
 		kf.AddPoint(100, ++i * 20);
 	}
-	// for (auto kf : kfs) {
-	// 	kf.PrintPoints();
-	// }
 	auto c = openshot::Color(kfs[0], kfs[1], kfs[2], kfs[3]);
 
 	CHECK_CLOSE(20, c.red.GetLong(100), 0.01);
@@ -163,7 +160,7 @@ TEST(Json)
 }
 
 TEST(SetJson) {
-	std::string json_input = R"json(
+	const std::string json_input = R"json(
 	{
 		"red": { "Points": [ { "co": { "X": 1.0, "Y": 0.0 }, "interpolation": 0 } ] },
 		"green": { "Points": [ { "co": { "X": 1.0, "Y": 128.0 }, "interpolation": 0 } ] },

--- a/tests/Color_Tests.cpp
+++ b/tests/Color_Tests.cpp
@@ -33,23 +33,40 @@
 #define DONT_SET_USING_JUCE_NAMESPACE 1
 #include "OpenShot.h"
 
-using namespace std;
-using namespace openshot;
+SUITE(Color) {
 
-TEST(Color_Default_Constructor)
+TEST(Default_Constructor)
 {
 	// Create an empty color
-	Color c1;
+	openshot::Color c1;
 
 	CHECK_CLOSE(0.0f, c1.red.GetValue(0), 0.00001);
 	CHECK_CLOSE(0.0f, c1.green.GetValue(0), 0.00001);
 	CHECK_CLOSE(0.0f, c1.blue.GetValue(0), 0.00001);
 }
 
-TEST(Color_Animate_Colors)
+TEST(Keyframe_constructor)
+{
+	std::vector<openshot::Keyframe> kfs{0, 0, 0, 0};
+	int64_t i(0);
+	for (auto& kf : kfs) {
+		kf.AddPoint(100, ++i * 20);
+	}
+	// for (auto kf : kfs) {
+	// 	kf.PrintPoints();
+	// }
+	auto c = openshot::Color(kfs[0], kfs[1], kfs[2], kfs[3]);
+
+	CHECK_CLOSE(20, c.red.GetLong(100), 0.01);
+	CHECK_CLOSE(40, c.green.GetLong(100), 0.01);
+	CHECK_CLOSE(60, c.blue.GetLong(100), 0.01);
+	CHECK_CLOSE(80, c.alpha.GetLong(100), 0.01);
+}
+
+TEST(Animate_Colors)
 {
 	// Create an empty color
-	Color c1;
+	openshot::Color c1;
 
 	// Set starting color (on frame 0)
 	c1.red.AddPoint(1, 0);
@@ -67,7 +84,7 @@ TEST(Color_Animate_Colors)
 	CHECK_CLOSE(160, c1.blue.GetLong(500), 0.01);
 }
 
-TEST(Color_HEX_Value)
+TEST(HEX_Value)
 {
 	// Color
 	openshot::Color c;
@@ -84,7 +101,7 @@ TEST(Color_HEX_Value)
 
 }
 
-TEST(Color_HEX_Constructor)
+TEST(HEX_Constructor)
 {
 	// Color
 	openshot::Color c("#4586db");
@@ -97,7 +114,7 @@ TEST(Color_HEX_Constructor)
 	CHECK_EQUAL("#ffffff", c.GetColorHex(100));
 }
 
-TEST(Color_Distance)
+TEST(Distance)
 {
 	// Color
 	openshot::Color c1("#040a0c");
@@ -105,11 +122,11 @@ TEST(Color_Distance)
 	openshot::Color c3("#000000");
 	openshot::Color c4("#ffffff");
 
-	CHECK_CLOSE(19.0f, Color::GetDistance(c1.red.GetInt(1), c1.blue.GetInt(1), c1.green.GetInt(1), c2.red.GetInt(1), c2.blue.GetInt(1), c2.green.GetInt(1)), 0.001);
-	CHECK_CLOSE(764.0f, Color::GetDistance(c3.red.GetInt(1), c3.blue.GetInt(1), c3.green.GetInt(1), c4.red.GetInt(1), c4.blue.GetInt(1), c4.green.GetInt(1)), 0.001);
+	CHECK_CLOSE(19.0f, openshot::Color::GetDistance(c1.red.GetInt(1), c1.blue.GetInt(1), c1.green.GetInt(1), c2.red.GetInt(1), c2.blue.GetInt(1), c2.green.GetInt(1)), 0.001);
+	CHECK_CLOSE(764.0f, openshot::Color::GetDistance(c3.red.GetInt(1), c3.blue.GetInt(1), c3.green.GetInt(1), c4.red.GetInt(1), c4.blue.GetInt(1), c4.green.GetInt(1)), 0.001);
 }
 
-TEST(Color_RGBA_Constructor)
+TEST(RGBA_Constructor)
 {
 	// Color
 	openshot::Color c(69, 134, 219, 255);
@@ -126,3 +143,41 @@ TEST(Color_RGBA_Constructor)
 	CHECK_EQUAL("#4586db", c1.GetColorHex(1));
 	CHECK_EQUAL(128, c1.alpha.GetInt(1));
 }
+
+TEST(Json)
+{
+	openshot::Color c(128, 128, 128, 0);
+	openshot::Color c1;
+	c1.red.AddPoint(1, 128);
+	c1.green.AddPoint(1, 128);
+	c1.blue.AddPoint(1, 128);
+	c1.alpha.AddPoint(1, 0);
+	// Check that JSON produced is identical
+	auto j = c.Json();
+	auto j1 = c1.Json();
+	CHECK_EQUAL(j, j1);
+	// Check Json::Value representation
+	auto jv = c.JsonValue();
+	auto jv_string = jv.toStyledString();
+	CHECK_EQUAL(jv_string, j1);
+}
+
+TEST(SetJson) {
+	std::string json_input = R"json(
+	{
+		"red": { "Points": [ { "co": { "X": 1.0, "Y": 0.0 }, "interpolation": 0 } ] },
+		"green": { "Points": [ { "co": { "X": 1.0, "Y": 128.0 }, "interpolation": 0 } ] },
+		"blue": { "Points": [ { "co": { "X": 1.0, "Y": 64.0 }, "interpolation": 0 } ] },
+		"alpha": { "Points": [ { "co": { "X": 1.0, "Y": 192.0 }, "interpolation": 0 } ] }
+	}
+		)json";
+	openshot::Color c;
+	CHECK_THROW(c.SetJson("}{"), openshot::InvalidJSON);
+	c.SetJson(json_input);
+	CHECK_CLOSE(0, c.red.GetLong(10), 0.01);
+	CHECK_CLOSE(128, c.green.GetLong(10), 0.01);
+	CHECK_CLOSE(64, c.blue.GetLong(10), 0.01);
+	CHECK_CLOSE(192, c.alpha.GetLong(10), 0.01);
+}
+
+}  // SUITE

--- a/tests/FrameMapper_Tests.cpp
+++ b/tests/FrameMapper_Tests.cpp
@@ -31,33 +31,35 @@
 #include "UnitTest++.h"
 // Prevent name clashes with juce::UnitTest
 #define DONT_SET_USING_JUCE_NAMESPACE 1
-#include "OpenShot.h"
+#include "CacheMemory.h"
+#include "Clip.h"
+#include "DummyReader.h"
+#include "FFmpegReader.h"
+#include "Fraction.h"
+#include "Frame.h"
+#include "FrameMapper.h"
+#include "Timeline.h"
 
 using namespace std;
 using namespace openshot;
 
-TEST(FrameMapper_Get_Valid_Frame)
+SUITE(FrameMapper) {
+TEST(NoOp_GetMappedFrame)
 {
 	// Create a reader
 	DummyReader r(Fraction(24,1), 720, 480, 22000, 2, 5.0);
 
-	// Create mapping between 24 fps and 29.97 fps using classic pulldown
-	FrameMapper mapping(&r, Fraction(30000, 1001), PULLDOWN_CLASSIC, 22000, 2, LAYOUT_STEREO);
+	// Create mapping between 24 fps and 24 fps without pulldown
+	FrameMapper mapping(&r, Fraction(24, 1), PULLDOWN_NONE, 22000, 2, LAYOUT_STEREO);
+	CHECK_EQUAL("FrameMapper", mapping.Name());
 
-	try
-	{
-		// Should find this frame
-		MappedFrame f = mapping.GetMappedFrame(125);
-		CHECK(true); // success
-	}
-	catch (OutOfBoundsFrame &e)
-	{
-		// Unexpected failure to find frame
-		CHECK(false);
-	}
+	// Should find this frame
+	MappedFrame f = mapping.GetMappedFrame(125);
+	CHECK_EQUAL(125, f.Odd.Frame);
+	CHECK_EQUAL(125, f.Even.Frame);
 }
 
-TEST(FrameMapper_Invalid_Frame_Too_Small)
+TEST(Invalid_Frame_Too_Small)
 {
 	// Create a reader
 	DummyReader r(Fraction(24,1), 720, 480, 22000, 2, 5.0);
@@ -70,7 +72,7 @@ TEST(FrameMapper_Invalid_Frame_Too_Small)
 
 }
 
-TEST(FrameMapper_24_fps_to_30_fps_Pulldown_Classic)
+TEST(24_fps_to_30_fps_Pulldown_Classic)
 {
 	// Create a reader
 	DummyReader r(Fraction(24,1), 720, 480, 22000, 2, 5.0);
@@ -87,7 +89,7 @@ TEST(FrameMapper_24_fps_to_30_fps_Pulldown_Classic)
 	CHECK_EQUAL(3, frame3.Even.Frame);
 }
 
-TEST(FrameMapper_24_fps_to_30_fps_Pulldown_Advanced)
+TEST(24_fps_to_30_fps_Pulldown_Advanced)
 {
 	// Create a reader
 	DummyReader r(Fraction(24,1), 720, 480, 22000, 2, 5.0);
@@ -107,7 +109,7 @@ TEST(FrameMapper_24_fps_to_30_fps_Pulldown_Advanced)
 	CHECK_EQUAL(3, frame4.Even.Frame);
 }
 
-TEST(FrameMapper_24_fps_to_30_fps_Pulldown_None)
+TEST(24_fps_to_30_fps_Pulldown_None)
 {
 	// Create a reader
 	DummyReader r(Fraction(24,1), 720, 480, 22000, 2, 5.0);
@@ -124,7 +126,7 @@ TEST(FrameMapper_24_fps_to_30_fps_Pulldown_None)
 	CHECK_EQUAL(4, frame5.Even.Frame);
 }
 
-TEST(FrameMapper_30_fps_to_24_fps_Pulldown_Classic)
+TEST(30_fps_to_24_fps_Pulldown_Classic)
 {
 	// Create a reader
 	DummyReader r(Fraction(30, 1), 720, 480, 22000, 2, 5.0);
@@ -144,7 +146,7 @@ TEST(FrameMapper_30_fps_to_24_fps_Pulldown_Classic)
 	CHECK_EQUAL(6, frame5.Even.Frame);
 }
 
-TEST(FrameMapper_30_fps_to_24_fps_Pulldown_Advanced)
+TEST(30_fps_to_24_fps_Pulldown_Advanced)
 {
 	// Create a reader
 	DummyReader r(Fraction(30, 1), 720, 480, 22000, 2, 5.0);
@@ -164,7 +166,7 @@ TEST(FrameMapper_30_fps_to_24_fps_Pulldown_Advanced)
 	CHECK_EQUAL(5, frame4.Even.Frame);
 }
 
-TEST(FrameMapper_30_fps_to_24_fps_Pulldown_None)
+TEST(30_fps_to_24_fps_Pulldown_None)
 {
 	// Create a reader
 	DummyReader r(Fraction(30, 1), 720, 480, 22000, 2, 5.0);
@@ -181,7 +183,7 @@ TEST(FrameMapper_30_fps_to_24_fps_Pulldown_None)
 	CHECK_EQUAL(6, frame5.Even.Frame);
 }
 
-TEST(FrameMapper_resample_audio_48000_to_41000)
+TEST(resample_audio_48000_to_41000)
 {
 	// Create a reader: 24 fps, 2 channels, 48000 sample rate
 	stringstream path;
@@ -211,7 +213,7 @@ TEST(FrameMapper_resample_audio_48000_to_41000)
 	map.Close();
 }
 
-TEST (FrameMapper_resample_audio_mapper) {
+TEST(resample_audio_mapper) {
 	// This test verifies that audio data can be resampled on FrameMapper
 	// instances, even on frame rates that do not divide evenly, and that no audio data is misplaced
 	// or duplicated. We verify this by creating a SIN wave, add those data points to a DummyReader,
@@ -350,7 +352,7 @@ TEST (FrameMapper_resample_audio_mapper) {
 	r.Close();
 }
 
-TEST (FrameMapper_redistribute_samples_per_frame) {
+TEST(redistribute_samples_per_frame) {
 	// This test verifies that audio data is correctly aligned on
 	// FrameMapper instances. We do this by creating 2 Clips based on the same parent reader
 	// (i.e. same exact audio sample data). We use a Timeline to overlap these clips
@@ -472,3 +474,6 @@ TEST (FrameMapper_redistribute_samples_per_frame) {
 	cache.Clear();
 	r.Close();
 }
+
+}  // SUITE
+

--- a/tests/FrameMapper_Tests.cpp
+++ b/tests/FrameMapper_Tests.cpp
@@ -44,6 +44,7 @@ using namespace std;
 using namespace openshot;
 
 SUITE(FrameMapper) {
+
 TEST(NoOp_GetMappedFrame)
 {
 	// Create a reader
@@ -57,6 +58,15 @@ TEST(NoOp_GetMappedFrame)
 	MappedFrame f = mapping.GetMappedFrame(100);
 	CHECK_EQUAL(100, f.Odd.Frame);
 	CHECK_EQUAL(100, f.Even.Frame);
+
+	// Should return end frame
+	f = mapping.GetMappedFrame(150);
+	CHECK_EQUAL(120, f.Odd.Frame);
+	CHECK_EQUAL(120, f.Even.Frame);
+
+	mapping.Close();
+	mapping.Reader(nullptr);
+	CHECK_THROW(mapping.Reader(), ReaderClosed);
 }
 
 TEST(Invalid_Frame_Too_Small)
@@ -473,6 +483,19 @@ TEST(redistribute_samples_per_frame) {
 	// Clean up
 	cache.Clear();
 	r.Close();
+}
+
+TEST(Json)
+{
+	DummyReader r(Fraction(30,1), 1280, 720, 48000, 2, 5.0);
+	FrameMapper map(&r, Fraction(30, 1), PULLDOWN_NONE, 48000, 2, LAYOUT_STEREO);
+
+	// Read JSON config & write it back again
+	const std::string map_config = map.Json();
+	map.SetJson(map_config);
+
+	CHECK_EQUAL(48000, map.info.sample_rate);
+	CHECK_EQUAL(30, map.info.fps.num);
 }
 
 }  // SUITE

--- a/tests/FrameMapper_Tests.cpp
+++ b/tests/FrameMapper_Tests.cpp
@@ -54,9 +54,9 @@ TEST(NoOp_GetMappedFrame)
 	CHECK_EQUAL("FrameMapper", mapping.Name());
 
 	// Should find this frame
-	MappedFrame f = mapping.GetMappedFrame(125);
-	CHECK_EQUAL(125, f.Odd.Frame);
-	CHECK_EQUAL(125, f.Even.Frame);
+	MappedFrame f = mapping.GetMappedFrame(100);
+	CHECK_EQUAL(100, f.Odd.Frame);
+	CHECK_EQUAL(100, f.Even.Frame);
 }
 
 TEST(Invalid_Frame_Too_Small)
@@ -476,4 +476,3 @@ TEST(redistribute_samples_per_frame) {
 }
 
 }  // SUITE
-

--- a/tests/Point_Tests.cpp
+++ b/tests/Point_Tests.cpp
@@ -33,86 +33,141 @@
 #define DONT_SET_USING_JUCE_NAMESPACE 1
 #include "OpenShot.h"
 
-using namespace std;
-using namespace openshot;
+SUITE(POINT) {
 
-TEST(Point_Default_Constructor)
+TEST(Default_Constructor)
+{
+	openshot::Point p;
+
+	// Default values
+	CHECK_EQUAL(1, p.co.X);
+	CHECK_EQUAL(0, p.co.Y);
+	CHECK_EQUAL(0.5, p.handle_left.X);
+	CHECK_EQUAL(1.0, p.handle_left.Y);
+	CHECK_EQUAL(0.5, p.handle_right.X);
+	CHECK_EQUAL(0.0, p.handle_right.Y);
+	CHECK_EQUAL(openshot::InterpolationType::BEZIER, p.interpolation);
+	CHECK_EQUAL(openshot::HandleType::AUTO, p.handle_type);
+}
+TEST(XY_Constructor)
 {
 	// Create a point with X and Y values
 	openshot::Point p1(2,9);
 
 	CHECK_EQUAL(2, p1.co.X);
 	CHECK_EQUAL(9, p1.co.Y);
-	CHECK_EQUAL(BEZIER, p1.interpolation);
+	CHECK_EQUAL(openshot::InterpolationType::BEZIER, p1.interpolation);
 }
 
-TEST(Point_Constructor_With_Coordinate)
+TEST(Constructor_With_Coordinate)
 {
 	// Create a point with a coordinate
-	Coordinate c1(3,7);
+	openshot::Coordinate c1(3,7);
 	openshot::Point p1(c1);
 
 	CHECK_EQUAL(3, p1.co.X);
 	CHECK_EQUAL(7, p1.co.Y);
-	CHECK_EQUAL(BEZIER, p1.interpolation);
+	CHECK_EQUAL(openshot::InterpolationType::BEZIER, p1.interpolation);
 }
 
-TEST(Point_Constructor_With_Coordinate_And_LINEAR_Interpolation)
+TEST(Constructor_With_Coordinate_And_LINEAR_Interpolation)
 {
 	// Create a point with a coordinate and interpolation
-	Coordinate c1(3,9);
-	InterpolationType interp = LINEAR;
+	openshot::Coordinate c1(3,9);
+	auto interp = openshot::InterpolationType::LINEAR;
 	openshot::Point p1(c1, interp);
 
 	CHECK_EQUAL(3, c1.X);
 	CHECK_EQUAL(9, c1.Y);
-	CHECK_EQUAL(LINEAR, p1.interpolation);
+	CHECK_EQUAL(openshot::InterpolationType::LINEAR, p1.interpolation);
 }
 
-TEST(Point_Constructor_With_Coordinate_And_BEZIER_Interpolation)
+TEST(Constructor_With_Coordinate_And_BEZIER_Interpolation)
 {
 	// Create a point with a coordinate and interpolation
-	Coordinate c1(3,9);
-	InterpolationType interp = BEZIER;
+	openshot::Coordinate c1(3,9);
+	auto interp = openshot::InterpolationType::BEZIER;
 	openshot::Point p1(c1, interp);
 
 	CHECK_EQUAL(3, p1.co.X);
 	CHECK_EQUAL(9, p1.co.Y);
-	CHECK_EQUAL(BEZIER, p1.interpolation);
+	CHECK_EQUAL(openshot::InterpolationType::BEZIER, p1.interpolation);
 }
 
-TEST(Point_Constructor_With_Coordinate_And_CONSTANT_Interpolation)
+TEST(Constructor_With_Coordinate_And_CONSTANT_Interpolation)
 {
 	// Create a point with a coordinate and interpolation
-	Coordinate c1(2,8);
-	InterpolationType interp = CONSTANT;
+	openshot::Coordinate c1(2,8);
+	auto interp = openshot::InterpolationType::CONSTANT;
 	openshot::Point p1(c1, interp);
 
 	CHECK_EQUAL(2, p1.co.X);
 	CHECK_EQUAL(8, p1.co.Y);
-	CHECK_EQUAL(CONSTANT, p1.interpolation);
+	CHECK_EQUAL(openshot::InterpolationType::CONSTANT, p1.interpolation);
 }
 
-TEST(Point_Constructor_With_Coordinate_And_BEZIER_And_AUTO_Handle)
+TEST(Constructor_With_Coordinate_And_BEZIER_And_AUTO_Handle)
 {
 	// Create a point with a coordinate and interpolation
-	Coordinate c1(3,9);
-	openshot::Point p1(c1, BEZIER, AUTO);
+	openshot::Coordinate c1(3,9);
+	openshot::Point p1(c1,
+		openshot::InterpolationType::BEZIER,
+		openshot::HandleType::AUTO);
 
 	CHECK_EQUAL(3, p1.co.X);
 	CHECK_EQUAL(9, p1.co.Y);
-	CHECK_EQUAL(BEZIER, p1.interpolation);
-	CHECK_EQUAL(AUTO, p1.handle_type);
+	CHECK_EQUAL(openshot::InterpolationType::BEZIER, p1.interpolation);
+	CHECK_EQUAL(openshot::HandleType::AUTO, p1.handle_type);
 }
 
-TEST(Point_Constructor_With_Coordinate_And_BEZIER_And_MANUAL_Handle)
+TEST(Constructor_With_Coordinate_And_BEZIER_And_MANUAL_Handle)
 {
 	// Create a point with a coordinate and interpolation
-	Coordinate c1(3,9);
-	openshot::Point p1(c1, BEZIER, MANUAL);
+	openshot::Coordinate c1(3,9);
+	openshot::Point p1(c1,
+		openshot::InterpolationType::BEZIER,
+		openshot::HandleType::MANUAL);
 
 	CHECK_EQUAL(3, p1.co.X);
 	CHECK_EQUAL(9, p1.co.Y);
-	CHECK_EQUAL(BEZIER, p1.interpolation);
-	CHECK_EQUAL(MANUAL, p1.handle_type);
+	CHECK_EQUAL(openshot::InterpolationType::BEZIER, p1.interpolation);
+	CHECK_EQUAL(openshot::HandleType::MANUAL, p1.handle_type);
 }
+
+TEST(Json)
+{
+	openshot::Point p1;
+	openshot::Point p2(1, 0);
+	auto json1 = p1.Json();
+	auto json2 = p2.JsonValue();
+	auto json_string2 = json2.toStyledString();
+	CHECK_EQUAL(json1, json_string2);
+}
+
+TEST(SetJson)
+{
+	openshot::Point p1;
+	std::stringstream json_stream;
+	json_stream << R"json(
+		{
+			"co": { "X": 1.0, "Y": 0.0 },
+			"handle_left": { "X": 2.0, "Y": 3.0 },
+			"handle_right": { "X": 4.0, "Y": -2.0 },
+			"handle_type": )json";
+	json_stream << static_cast<float>(openshot::HandleType::MANUAL) << ",";
+	json_stream << R"json(
+			"interpolation": )json";
+	json_stream << static_cast<float>(openshot::InterpolationType::CONSTANT);
+	json_stream << R"json(
+		}
+		)json";
+	p1.SetJson(json_stream.str());
+	CHECK_EQUAL(2.0, p1.handle_left.X);
+	CHECK_EQUAL(3.0, p1.handle_left.Y);
+	CHECK_EQUAL(4.0, p1.handle_right.X);
+	CHECK_EQUAL(-2.0, p1.handle_right.Y);
+	CHECK_EQUAL(openshot::HandleType::MANUAL, p1.handle_type);
+	CHECK_EQUAL(openshot::InterpolationType::CONSTANT, p1.interpolation);
+}
+
+}  // SUITE


### PR DESCRIPTION
**Update**: I'm an idiot. The failure was due to the short duration, and the fact that there were only 120 frames _available_ in the reader at the specified frame rate. (Though, interestingly, that _doesn't_ throw an `OutOfBoundsFrame` it seems.)

<s>As it says, this PR is a work-in-progress. Not because it's unfinished, but because a test is failing.</s>

I decided to replace the first test (which had a `catch` in it that was screwing up the test coverage) with a simple no-op test: Create a mapping from 24fps to 24fps with no pulldown. Then read its `Name()` (adds an extra line of coverage), and finally read one frame from it. So, it just gets the same frame back. (When you use the right duration.)

<s>Unfortunately, **the test _fails_**, and gets back frame `120` for original frame `125`.
That seems bad.</s>

**Edit**: Added a JSON test that just reads the `Json()` string from the mapper, then `SetJson()`s it back again (and spot-checks that things haven't changed.) That _really_ raised the test coverage; I may do that for the other classes as well.