### PR TITLE
WIP: New stream-based logging, macros for ZmqLogger

### DIFF
--- a/bindings/python/openshot.i
+++ b/bindings/python/openshot.i
@@ -214,7 +214,7 @@
 	}
 	const std::string __repr__() {
 		std::ostringstream result;
-		result << "Fraction(" << $self->num << ", " << $self->den << ")";
+		result << $self;
 		return result.str();
   }
 	/* Implement dict methods in Python */

--- a/src/CacheBase.h
+++ b/src/CacheBase.h
@@ -32,7 +32,8 @@
 #define OPENSHOT_CACHE_BASE_H
 
 #include <memory>
-#include <cstdlib>
+#include <string>
+
 #include "Frame.h"
 #include "Json.h"
 

--- a/src/Clip.cpp
+++ b/src/Clip.cpp
@@ -40,6 +40,11 @@
 #include "ChunkReader.h"
 #include "DummyReader.h"
 #include "Timeline.h"
+#include "ZmqLogger.h"
+
+#include <QSize>
+#include <QTransform>
+#include <QPainter>
 
 using namespace openshot;
 

--- a/src/Coordinate.h
+++ b/src/Coordinate.h
@@ -75,6 +75,18 @@ namespace openshot {
 		void SetJsonValue(const Json::Value root); ///< Load Json::Value into this object
 	};
 
+	/// Stream output operator for openshot::Coordinate
+	template<class charT, class traits>
+	std::basic_ostream<charT, traits>&
+	operator<<(std::basic_ostream<charT, traits>& o, const openshot::Coordinate& co) {
+    	std::basic_ostringstream<charT, traits> s;
+    	s.flags(o.flags());
+    	s.imbue(o.getloc());
+    	s.precision(o.precision());
+    	s << "(" << co.X << ", " << co.Y << ")";
+    	return o << s.str();
+	};
+
 }
 
 #endif

--- a/src/CrashHandler.cpp
+++ b/src/CrashHandler.cpp
@@ -29,6 +29,10 @@
  */
 
 #include "CrashHandler.h"
+#include "ZmqLogger.h"
+
+#include <iomanip>
+#include <sstream>
 
 using namespace std;
 using namespace openshot;

--- a/src/CrashHandler.h
+++ b/src/CrashHandler.h
@@ -43,7 +43,6 @@
 #endif
 #include <errno.h>
 #include <cxxabi.h>
-#include "ZmqLogger.h"
 
 namespace openshot {
 

--- a/src/FFmpegReader.cpp
+++ b/src/FFmpegReader.cpp
@@ -33,6 +33,7 @@
 
 #include "FFmpegReader.h"
 #include "Exceptions.h"
+#include "ZmqLogger.h"
 
 #include <thread>    // for std::this_thread::sleep_for
 #include <chrono>    // for std::chrono::milliseconds

--- a/src/FFmpegWriter.cpp
+++ b/src/FFmpegWriter.cpp
@@ -33,6 +33,7 @@
 
 #include "FFmpegWriter.h"
 #include "Exceptions.h"
+#include "ZmqLogger.h"
 
 #include <iostream>
 

--- a/src/FFmpegWriter.h
+++ b/src/FFmpegWriter.h
@@ -50,7 +50,6 @@
 #include <unistd.h>
 #include "CacheMemory.h"
 #include "OpenMPUtilities.h"
-#include "ZmqLogger.h"
 #include "Settings.h"
 
 

--- a/src/Fraction.h
+++ b/src/Fraction.h
@@ -84,7 +84,16 @@ namespace openshot {
 		Fraction Reciprocal();
 	};
 
-
+	// Stream output operator for openshot::Fraction
+	template<class charT, class traits>
+	std::basic_ostream<charT, traits>&
+	operator<<(std::basic_ostream<charT, traits>& o, const openshot::Fraction& frac) {
+    	std::basic_ostringstream<charT, traits> s;
+    	s.flags(o.flags());
+    	s.imbue(o.getloc());
+    	s.precision(o.precision());
+    	s << "Fraction(" << frac.num << ", " << frac.den << ")";
+    	return o << s.str();
+	};
 }
-
 #endif

--- a/src/Frame.h
+++ b/src/Frame.h
@@ -47,7 +47,6 @@
 #include <QImage>
 #include <memory>
 #include <unistd.h>
-#include "ZmqLogger.h"
 #include "ChannelLayouts.h"
 #include "AudioBufferSource.h"
 #include "AudioResampler.h"

--- a/src/FrameMapper.cpp
+++ b/src/FrameMapper.cpp
@@ -31,6 +31,7 @@
 #include "FrameMapper.h"
 #include "Exceptions.h"
 #include "Clip.h"
+#include "ZmqLogger.h"
 
 using namespace std;
 using namespace openshot;

--- a/src/ImageReader.h
+++ b/src/ImageReader.h
@@ -35,16 +35,10 @@
 #ifdef USE_IMAGEMAGICK
 
 #include "ReaderBase.h"
-
-#include <cmath>
-#include <ctime>
-#include <iostream>
-#include <omp.h>
-#include <stdio.h>
-#include <memory>
-#include "CacheMemory.h"
-
 #include "MagickUtilities.h"
+
+#include <memory>
+#include <string>
 
 namespace openshot
 {

--- a/src/ImageWriter.cpp
+++ b/src/ImageWriter.cpp
@@ -36,6 +36,7 @@
 
 #include "ImageWriter.h"
 #include "Exceptions.h"
+#include "ZmqLogger.h"
 
 using namespace openshot;
 

--- a/src/Point.h
+++ b/src/Point.h
@@ -126,6 +126,31 @@ namespace openshot
 
 	};
 
+	// Stream output operator for openshot::Point
+	template<class charT, class traits>
+	std::basic_ostream<charT, traits>&
+	operator<<(std::basic_ostream<charT, traits>& o, const openshot::Point& p) {
+    	std::basic_ostringstream<charT, traits> s;
+    	s.flags(o.flags());
+    	s.imbue(o.getloc());
+    	s.precision(o.precision());
+    	s << "co" << p.co;
+		switch(p.interpolation) {
+		case(openshot::LINEAR):
+			s << " interpolation(LINEAR)";
+			break;
+		case(openshot::CONSTANT):
+			s << " interpolation(CONSTANT)";
+			break;
+		case(openshot::BEZIER):
+			s << " interpolation(BEZIER)"
+			  << " handle_left" << p.handle_left
+			  << " handle_right" << p.handle_right;
+			break;
+		}
+    	return o << s.str();
+	};
+
 }
 
 #endif

--- a/src/Qt/PlayerPrivate.cpp
+++ b/src/Qt/PlayerPrivate.cpp
@@ -31,6 +31,7 @@
 
 #include "PlayerPrivate.h"
 #include "Exceptions.h"
+#include "ZmqLogger.h"
 
 #include <thread>    // for std::this_thread::sleep_for
 #include <chrono>    // for std::chrono milliseconds, high_resolution_clock

--- a/src/Qt/VideoCacheThread.cpp
+++ b/src/Qt/VideoCacheThread.cpp
@@ -29,9 +29,14 @@
  */
 
 #include "VideoCacheThread.h"
-#include "Exceptions.h"
-#include <algorithm>
 
+#include "Exceptions.h"
+#include "CacheBase.h"
+#include "ReaderBase.h"
+#include "OpenMPUtilities.h"
+#include "ZmqLogger.h"
+
+#include <algorithm>
 #include <thread>    // for std::this_thread::sleep_for
 #include <chrono>    // for std::chrono::milliseconds
 

--- a/src/Qt/VideoCacheThread.h
+++ b/src/Qt/VideoCacheThread.h
@@ -31,12 +31,18 @@
 #ifndef OPENSHOT_VIDEO_CACHE_THREAD_H
 #define OPENSHOT_VIDEO_CACHE_THREAD_H
 
-#include "../OpenMPUtilities.h"
-#include "../ReaderBase.h"
-#include "../RendererBase.h"
+#include "Frame.h"
+#include "JuceHeader.h"
+
+#include <atomic>
+#include <memory>
 
 namespace openshot
 {
+    // Forward decls
+    class ReaderBase;
+    class RendererBase;
+
     using juce::Thread;
     using juce::WaitableEvent;
 

--- a/src/Qt/VideoPlaybackThread.cpp
+++ b/src/Qt/VideoPlaybackThread.cpp
@@ -30,6 +30,7 @@
  */
 
 #include "VideoPlaybackThread.h"
+#include "ZmqLogger.h"
 
 namespace openshot
 {

--- a/src/QtHtmlReader.h
+++ b/src/QtHtmlReader.h
@@ -35,15 +35,8 @@
 
 #include "ReaderBase.h"
 
-#include <cmath>
-#include <ctime>
-#include <iostream>
-#include <omp.h>
-#include <stdio.h>
 #include <memory>
-#include "CacheMemory.h"
 #include "Enums.h"
-
 
 class QImage;
 

--- a/src/QtImageReader.h
+++ b/src/QtImageReader.h
@@ -31,11 +31,6 @@
 #ifndef OPENSHOT_QIMAGE_READER_H
 #define OPENSHOT_QIMAGE_READER_H
 
-#include <cmath>
-#include <ctime>
-#include <iostream>
-#include <omp.h>
-#include <stdio.h>
 #include <memory>
 
 #include "ReaderBase.h"

--- a/src/QtTextReader.h
+++ b/src/QtTextReader.h
@@ -35,17 +35,11 @@
 
 #include "ReaderBase.h"
 
-#include <cmath>
-#include <ctime>
-#include <iostream>
-#include <omp.h>
-#include <stdio.h>
 #include <memory>
-#include "CacheMemory.h"
 #include "Enums.h"
 
-
-class QImage;
+#include <QImage>
+#include <QFont>
 
 namespace openshot
 {

--- a/src/ReaderBase.cpp
+++ b/src/ReaderBase.cpp
@@ -29,6 +29,8 @@
  */
 
 #include "ReaderBase.h"
+#include "ClipBase.h"
+#include "CacheBase.h"
 
 using namespace openshot;
 

--- a/src/ReaderBase.h
+++ b/src/ReaderBase.h
@@ -36,21 +36,17 @@
 #include <memory>
 #include <cstdlib>
 #include <sstream>
-#include "CacheMemory.h"
 #include "ChannelLayouts.h"
-#include "ClipBase.h"
 #include "Fraction.h"
 #include "Frame.h"
 #include "Json.h"
-#include "ZmqLogger.h"
-#include <QString>
-#include <QGraphicsItem>
-#include <QGraphicsScene>
-#include <QGraphicsPixmapItem>
-#include <QPixmap>
 
 namespace openshot
 {
+	// Forward decls
+	class ClipBase;
+	class CacheBase;
+
 	/**
 	 * @brief This struct contains info about a media file, such as height, width, frames per second, etc...
 	 *

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -29,13 +29,12 @@
  */
 
 #include "Settings.h"
+#include <cstdlib>        // For std::getenv
 
-using namespace std;
 using namespace openshot;
 
-
 // Global reference to Settings
-Settings *Settings::m_pInstance = NULL;
+Settings *Settings::m_pInstance = nullptr;
 
 // Create or Get an instance of the settings singleton
 Settings *Settings::Instance()
@@ -53,6 +52,9 @@ Settings *Settings::Instance()
 		m_pInstance->HW_EN_DEVICE_SET = 0;
 		m_pInstance->PLAYBACK_AUDIO_DEVICE_NAME = "";
 		m_pInstance->DEBUG_TO_STDERR = false;
+		auto env_debug = std::getenv("LIBOPENSHOT_DEBUG");
+		if (env_debug != nullptr)
+			m_pInstance->DEBUG_TO_STDERR = true;
 	}
 
 	return m_pInstance;

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -44,6 +44,7 @@
 #include <unistd.h>
 #include <OpenShotAudio.h>
 
+#define GetSettings() openshot::Settings::Instance()
 
 namespace openshot {
 
@@ -118,7 +119,7 @@ namespace openshot {
 		/// The current install path of OpenShot (needs to be set when using Timeline(path), since certain
 		/// paths depend on the location of OpenShot transitions and files)
 		std::string PATH_OPENSHOT_INSTALL = "";
-    
+
  		/// Whether to dump ZeroMQ debug messages to stderr
 		bool DEBUG_TO_STDERR = false;
 

--- a/src/Timeline.cpp
+++ b/src/Timeline.cpp
@@ -29,6 +29,13 @@
  */
 
 #include "Timeline.h"
+#include "ZmqLogger.h"
+
+#include <QPainter>
+#include <QRegularExpression>
+#include <QDir>
+#include <QFileInfo>
+#include <QString>
 
 #include "CacheBase.h"
 #include "CacheDisk.h"
@@ -654,7 +661,7 @@ std::shared_ptr<Frame> Timeline::GetFrame(int64_t requested_frame)
 	frame = final_cache->GetFrame(requested_frame);
 	if (frame) {
 		// Debug output
-		ZmqLogger::Instance()->AppendDebugMethod("Timeline::GetFrame (Cached frame found)", "requested_frame", requested_frame);
+		zmqLog() << "Timeline::GetFrame (Cached frame found) " << LOGVAR(requested_frame);
 
 		// Return cached frame
 		return frame;

--- a/src/WriterBase.h
+++ b/src/WriterBase.h
@@ -37,7 +37,6 @@
 #include "Fraction.h"
 #include "Frame.h"
 #include "ReaderBase.h"
-#include "ZmqLogger.h"
 
 namespace openshot
 {

--- a/src/ZmqLogger.h
+++ b/src/ZmqLogger.h
@@ -46,8 +46,14 @@
 #include "Settings.h"
 
 
-namespace openshot {
+#ifndef DebugLog
+	#define DebugLog(args...) openshot::ZmqLogger::Instance()->AppendDebugMethod(args)
+#endif
+#ifndef DEBUGVAR
+	#define DEBUGVAR(VAR) #VAR, VAR
+#endif
 
+namespace openshot {
 	/**
 	 * @brief This class is used for logging and sending those logs over a ZemoMQ socket to a listener
 	 *

--- a/src/ZmqLogger.h
+++ b/src/ZmqLogger.h
@@ -39,6 +39,7 @@
 #include <memory>
 #include <zmq.hpp>
 
+#ifndef SWIG
 #ifndef zmqLog
 	#define zmqLog() \
 		openshot::StreamLog(openshot::StreamLog::zmqLogFunction).GetStream()
@@ -46,6 +47,7 @@
 #ifndef LOGVAR
 	#define LOGVAR(VAR) #VAR << " = " << VAR
 #endif
+#endif  // SWIG
 
 #ifndef DebugLog
 	#define DebugLog(args...) openshot::ZmqLogger::Instance()->AppendDebugMethod(args)
@@ -62,7 +64,7 @@ namespace openshot {
 	 * a file and sends the stdout over a socket.
 	 */
 	class ZmqLogger {
-		/// Type aliases
+		// Type aliases
 		using Context = std::unique_ptr<zmq::context_t>;
 		using Publisher = std::unique_ptr<zmq::socket_t>;
 
@@ -141,6 +143,7 @@ namespace openshot {
 		static ZmqLogger * m_pInstance;
 	};
 
+#ifndef SWIG
     /**
      * @brief Stream-based logging class which feeds to ZmqLogger
      *
@@ -149,10 +152,10 @@ namespace openshot {
      * logging variables and their value.
      *
      * @code
-     * // Use the zmqLog() macro to create an instance of StreamLogger
+     * // (1) Use the zmqLog() macro to create an instance of StreamLogger
      * zmqLog() << "Hyperframulated the flux capacitor!";
      *
-     * // To log a variable with its value, use the LOGVAR() macro
+     * // (2) To log a variable with its value, use the LOGVAR() macro
      * int x = 5;
      * int y = 10;
      * zmqLog() << "Out of range! " << LOGVAR(x) << ", " << LOGVAR(y);
@@ -161,31 +164,35 @@ namespace openshot {
      * These messages will be logged:
      * 1: Hyperframulated the flux capacitor!
      * 2: Out of range! x = 5, y = 10
-	 *
+     *
     **/
 
-	// Implementation largely inspired by this StackOverflow answer:
-	//   https://stackoverflow.com/a/48475646/200794
-	// Referencing the Dr. Dobbs article "Logging In C++" by Petru Marginean
-	//   https://www.drdobbs.com/cpp/logging-in-c/201804215
+    // Implementation largely inspired by this StackOverflow answer:
+    //   https://stackoverflow.com/a/48475646/200794
+    // Referencing the Dr. Dobbs article "Logging In C++" by Petru Marginean
+    //   https://www.drdobbs.com/cpp/logging-in-c/201804215
     class StreamLog {
         using LogFunction = std::function<void(const std::string&)>;
 
     public:
-		/// Construct a StreamLog instance that calls logFunction to output messages
+        /// Construct a StreamLog instance that calls logFunction to output messages
         explicit StreamLog(LogFunction logFunction) : m_logFunction(std::move(logFunction)) {};
-		/// Return the logging stream that outputs to the selected function
+        /// Return the logging stream that outputs to the selected function
         std::ostringstream& GetStream() { return m_stringStream; }
-		/// Destroy the logging instance, which calls logFunction to log the stream
+
+        /// Destroy the logging instance, which calls logFunction to log the stream
         ~StreamLog() { m_logFunction(m_stringStream.str()); }
-		/// A logging function that delivers messages to ZmqLogger
-		static void zmqLogFunction(const std::string& message) {
-			ZmqLogger::Instance()->Log(message);
-		}
+
+ 	/// A logging function that delivers messages to ZmqLogger
+        static void zmqLogFunction(const std::string& message) {
+            ZmqLogger::Instance()->Log(message);
+        }
     private:
         std::ostringstream m_stringStream;
         LogFunction m_logFunction;
     };
+#endif  // SWIG
+
 }
 
 #endif

--- a/src/effects/Caption.cpp
+++ b/src/effects/Caption.cpp
@@ -32,6 +32,9 @@
 #include "Exceptions.h"
 #include "../Clip.h"
 #include "../Timeline.h"
+#include <QPainter>
+#include <QPainterPath>
+#include <QRegularExpression>
 
 #include <QString>
 #include <QPoint>

--- a/tests/Fraction.cpp
+++ b/tests/Fraction.cpp
@@ -148,3 +148,12 @@ TEST_CASE( "Reciprocal", "[libopenshot][fraction]" )
 	CHECK(f1.ToFloat() == Approx(1.77777f).margin(0.00001));
 	CHECK(f1.ToDouble() == Approx(1.77777f).margin(0.00001));
 }
+
+TEST_CASE( "Operator ostream", "[libopenshot][fraction]" )
+{
+	std::stringstream output;
+	openshot::Fraction f3(30000, 1001);
+
+	output << f3;
+	CHECK(output.str() == "Fraction(30000, 1001)";
+}

--- a/tests/Point.cpp
+++ b/tests/Point.cpp
@@ -186,3 +186,26 @@ TEST_CASE( "SetJson", "[libopenshot][point]" )
 	CHECK(p1.handle_type == openshot::HandleType::MANUAL);
 	CHECK(p1.interpolation == openshot::InterpolationType::CONSTANT);
 }
+
+
+TEST_CASE( "Operator ostream", "[libopenshot][point]" )
+{
+	openshot::Coordinate c1(10, 5);
+
+	std::stringstream output1;
+	openshot::Point p1(c1, openshot::InterpolationType::LINEAR);
+	output1 << p1;
+	CHECK(output1.str() == "co(10, 5) interpolation(LINEAR)");
+
+	std::stringstream output2;
+	openshot::Point p2(c1, openshot::InterpolationType::CONSTANT);
+	output2 << p2;
+	CHECK(output2.str() == "co(10, 5) interpolation(CONSTANT)");
+
+	std::stringstream output3;
+	openshot::Point p3(c1, openshot::InterpolationType::BEZIER);
+	output3 << p3;
+	CHECK(
+		output3.str() ==
+		"co(10, 5) interpolation(BEZIER) handle_left(0.5, 1) handle_right(0.5, 0)");
+}

--- a/tests/StreamLog.cpp
+++ b/tests/StreamLog.cpp
@@ -1,0 +1,68 @@
+/**
+ * @file
+ * @brief Unit tests for openshot::Fraction
+ * @author Jonathan Thomas <jonathan@openshot.org>
+ *
+ * @ref License
+ */
+
+/* LICENSE
+ *
+ * Copyright (c) 2008-2019 OpenShot Studios, LLC
+ * <http://www.openshotstudios.com/>. This file is part of
+ * OpenShot Library (libopenshot), an open-source project dedicated to
+ * delivering high quality video editing and animation solutions to the
+ * world. For more information visit <http://www.openshot.org/>.
+ *
+ * OpenShot Library (libopenshot) is free software: you can redistribute it
+ * and/or modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * OpenShot Library (libopenshot) is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with OpenShot Library. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <string>
+#include <sstream>
+#include <ostream>
+
+#include <catch2/catch.hpp>
+
+#include "ZmqLogger.h"
+
+// A destination for our logging messages
+std::stringstream output;
+// Define a log function that writes to output
+void myLogOut(const std::string& message) {
+	output << message << std::endl;
+}
+#define myLog() openshot::StreamLog(myLogOut).GetStream()
+
+TEST_CASE( "Log to stream", "[libopenshot][streamlog]" )
+{
+	// Reset output buffer
+	output.str(std::string());
+	output.clear();
+
+	myLog() << "StreamLogger test log";
+
+	CHECK(output.str() == "StreamLogger test log\n");
+}
+
+TEST_CASE( "LOGVAR macro", "[libopenshot][streamlog]" )
+{
+	// Reset output buffer
+	output.str(std::string());
+	output.clear();
+
+	int x = 10;
+	myLog() << "Value of x: " << LOGVAR(x);
+
+	CHECK(output.str() == "Value of x: x = 10\n");
+}


### PR DESCRIPTION
## Update

Somehow I'm an _idiot_ and totally missed that OpenShot needs the ZmqLogger class visible in the public API, because it's how `logger_libopenshot.py` sets up debug logging. So, on hold pending a solution to that issue. (And because there are other, more pressing things to focus on right now.)

(Actually, I should really break out the Fraction, Point, Coordinate, etc. stream operator templates, which _could_ still go in, and I think are probably worth having independent of logging changes.)

## Original PR

`ZmqLogger` is great, but `AppendDebugMethod` is not. Its use is, to say the least, clunky.

This PR adds some convenience macros to make using the logger more convenient, and adds a new stream-based logging alternative.

### The `ZmqLogger`  macros

* `DebugLog()` is a macro to call `AppendDebugLog()`. It takes care of the ZmqLogger instancing.
* `DEBUGVAR()` is an argument-expansion macro, for the common case of wanting to log a variable name followed by the value.

Used together, they allow cleaner and DRY-er code:
```c++
// Instead of writing this
ZmqLogger::Instance()->AppendDebugMethod("AudioReaderSource::getNextAudioBlock", 
    "number_to_copy", number_to_copy,
    "buffer_samples", buffer_samples,
    "buffer_channels", buffer_channels,
    "info.numSamples", info.numSamples,
    "speed", speed,
    "position", position);

// You can write this (it expands to the exact same thing)
DebugLog("AudioReaderSource::getNextAudioBlock",
    DEBUGVAR(number_to_copy),
    DEBUGVAR(buffer_samples),
    DEBUGVAR(buffer_channels),
    DEBUGVAR(info.numSamples),
    DEBUGVAR(speed),
    DEBUGVAR(position));
```

### The `StreamLog` class and macros

An even more convenient alternative is the `StreamLog`, which allows stream-based logging to the `ZmqLogger` instance. It has a `LOGVAR()` macro which acts like `DEBUGVAR()` but for stream output, and a `zmqLog()` macro to access the stream. Use them like this:
```c++
zmqLog() << "AudioReaderSource::getNextAudioBlock " << LOGVAR(number_to_copy)
        << ", " << LOGVAR(buffer_samples) << ", " << LOGVAR(buffer_channels)
        << ", " << LOGVAR(info.numSamples) << ", " << LOGVAR(speed)
        << ", " << LOGVAR(position);
```
That might output something like:
```text
AudioReaderSource::getNextAudioBlock number_to_copy = 1, buffer_samples = 120, 
buffer_channels = 2, info.numSamples = 1500, speed = 0, position = 120
```
Unlike AppendDebugMethod, formatting of values is _not_ forced to four decimal places, instead the default stream formatting is used. It can be adjusted with the usual stream manipulators if desired.

Commas and spacing are also not automatic, though perhaps something like the automatic space insertion from `qDebug()` would be useful.

### Templated `operator<<` for Coordinate, Fraction, and Point
To facilitate use of stream logging, several classes have been enhanced with `<<` operator templates for any stream-based output class. 
* `Fraction` will output a string such as `Fraction(30000, 1001)`
* `Coordinate` will output a string like `(0.5, 1)`
* `Point` will output a string based on its interpolation type:
    * `co(10, 5) interpolation(LINEAR)` or
    * `co(5, 2.5) interpolation(CONSTANT)` or
    * `co(20, 0.4) interpolation(BEZIER) handle_left(0.5, 1) handle_right(1, 2.5)`

Unit tests are included for the StreamLog class and all `operator<<` templates.

#### Other changes
* Because there was relatively little logging in `AudioReaderSource`, it was switched over to `DebugLog()` and `DEBUGVAR()`.
* The log message `Timeline::GetFrame (Cached frame found)` in `Timeline::GetFrame()` now uses `zmqLog()`. (Just that one message, as an experiment.)
* `openshot::Settings` now has a `GetSettings()` convenience macro to access the instance. 
    ```c++
    // Instead of
    name = openshot::Settings::Instance()->PLAYBACK_AUDIO_DEVICE_NAME;
    // You can write
    name = GetSettings()->PLAYBACK_AUDIO_DEVICE_NAME;
    ```
* An environment variable `LIBOPENSHOT_DEBUG` can now be set to any value, to activate the `DEBUG_TO_STDERR` setting. This makes it convenient to turn on debug output even when running e.g. the unit tests:
    `LIBOPENSHOT_DEBUG=1 cmake --build build --target test`
* A lot of header includes were cleaned up, making use of forward declarations and moving includes from `.h` files to `.cpp` files to reduce compilation times/complexity.
* Because I've removed it from all other header files, and because the `StreamLog` stuff will confuse the bindings, `ZmqLogger.h` is no longer wrapped by SWIG and can be treated as a private header. (Perhaps it should even be removed from the set of installed headers?)
* Oh, almost forgot to mention: Among the changes I made to ZmqLogger was to replace the `juce::CriticalSection` with a `std::recursive_mutex`. They have virtually identical semantics (in fact, Jules is thinking of deprecating `CriticalSection` and just telling people to use `recursive_mutex`), and replacing them eliminated the `ZmqLogger` dependency on JUCE which really made no sense at all.
    In files where we're using JUCE code _anyway_ (particularly the classes based on `juce::Thread`), there's no harm in using their mutexes as well. But in any places where the use of `CriticalSection` is the **only** reason `JuceHeader.h` is included (like `ZmqLogger`), it makes a ton of sense to switch over to the STL mutexes instead.