### PR TITLE
Overrides and types

### DIFF
--- a/src/Clip.h
+++ b/src/Clip.h
@@ -186,7 +186,7 @@ namespace openshot {
 		void AddEffect(openshot::EffectBase* effect);
 
 		/// Close the internal reader
-		void Close();
+		void Close() override;
 
 		/// Return the list of effects on the timeline
 		std::list<openshot::EffectBase*> Effects() { return effects; };
@@ -199,7 +199,7 @@ namespace openshot {
 		///
 		/// @returns A new openshot::Frame object
 		/// @param frame_number The frame number (starting at 1) of the clip or effect on the timeline.
-		std::shared_ptr<openshot::Frame> GetFrame(int64_t frame_number);
+		std::shared_ptr<openshot::Frame> GetFrame(int64_t frame_number) override;
 
 		/// @brief Get an openshot::Frame object for a specific frame number of this timeline. The image size and number
 		/// of samples can be customized to match the Timeline, or any custom output. Extra samples will be moved to the

--- a/src/ImageReader.h
+++ b/src/ImageReader.h
@@ -48,6 +48,8 @@
 
 namespace openshot
 {
+	// Forward decls
+	class CacheBase;
 
 	/**
 	 * @brief This class uses the ImageMagick++ libraries, to open image files, and return
@@ -90,7 +92,7 @@ namespace openshot
 		void Close() override;
 
 		/// Get the cache object used by this reader (always returns NULL for this object)
-		CacheMemory* GetCache() override { return NULL; };
+		CacheBase* GetCache() override { return NULL; };
 
 		/// Get an openshot::Frame object for a specific frame number of this reader.  All numbers
 		/// return the same Frame, since they all share the same image data.

--- a/src/QtHtmlReader.h
+++ b/src/QtHtmlReader.h
@@ -49,6 +49,8 @@ class QImage;
 
 namespace openshot
 {
+	// Forward decls
+	class CacheBase;
 
 	/**
 	 * @brief This class uses Qt libraries, to create frames with rendered HTML, and return
@@ -115,7 +117,7 @@ namespace openshot
 		void Close() override;
 
 		/// Get the cache object used by this reader (always returns NULL for this object)
-		openshot::CacheMemory* GetCache() override { return NULL; };
+		CacheBase* GetCache() override { return NULL; };
 
 		/// Get an openshot::Frame object for a specific frame number of this reader.  All numbers
 		/// return the same Frame, since they all share the same image data.

--- a/src/QtImageReader.h
+++ b/src/QtImageReader.h
@@ -42,6 +42,8 @@
 
 namespace openshot
 {
+	// Forward decl
+	class CacheBase;
 
 	/**
 	 * @brief This class uses the Qt library, to open image files, and return
@@ -88,7 +90,7 @@ namespace openshot
 		void Close() override;
 
 		/// Get the cache object used by this reader (always returns NULL for this object)
-		CacheMemory* GetCache() override { return NULL; };
+		CacheBase* GetCache() override { return NULL; };
 
 		/// Get an openshot::Frame object for a specific frame number of this reader.  All numbers
 		/// return the same Frame, since they all share the same image data.

--- a/src/QtTextReader.h
+++ b/src/QtTextReader.h
@@ -49,6 +49,8 @@ class QImage;
 
 namespace openshot
 {
+	// Forward decls
+	class CacheBase;
 
 	/**
 	 * @brief This class uses Qt libraries, to create frames with "Text", and return
@@ -126,7 +128,7 @@ namespace openshot
 		void Close() override;
 
 		/// Get the cache object used by this reader (always returns NULL for this object)
-		openshot::CacheMemory* GetCache() override { return NULL; };
+		CacheBase* GetCache() override { return NULL; };
 
 		/// Get an openshot::Frame object for a specific frame number of this reader.  All numbers
 		/// return the same Frame, since they all share the same image data.

--- a/tests/ImageWriter_Tests.cpp
+++ b/tests/ImageWriter_Tests.cpp
@@ -85,7 +85,7 @@ TEST(Gif)
 	// Basic Reader state queries
 	CHECK_EQUAL("ImageReader", r1.Name());
 
-	CacheMemory* c = r1.GetCache();
+	CacheBase* c = r1.GetCache();
 	CHECK_EQUAL(true, c == nullptr);
 
 	CHECK_EQUAL(false, r1.IsOpen());


### PR DESCRIPTION
This PR fixes the return type for `GetCache()` in various readers, and fixes some Clip methods that were missing `override`.