### PR TITLE
Fixing an issue caused by timeline::GetClip returning a ClipBase* instead of Clip*

### DIFF
--- a/bindings/python/openshot.i
+++ b/bindings/python/openshot.i
@@ -219,6 +219,7 @@
 %include "effects/Bars.h"
 %include "effects/Blur.h"
 %include "effects/Brightness.h"
+%include "effects/Caption.h"
 %include "effects/ChromaKey.h"
 %include "effects/ColorShift.h"
 %include "effects/Crop.h"

--- a/bindings/ruby/openshot.i
+++ b/bindings/ruby/openshot.i
@@ -206,6 +206,7 @@
 %include "effects/Bars.h"
 %include "effects/Blur.h"
 %include "effects/Brightness.h"
+%include "effects/Caption.h"
 %include "effects/ChromaKey.h"
 %include "effects/ColorShift.h"
 %include "effects/Crop.h"

--- a/src/Timeline.cpp
+++ b/src/Timeline.cpp
@@ -289,7 +289,7 @@ void Timeline::RemoveClip(Clip* clip)
 }
 
 // Look up a clip
-openshot::ClipBase* Timeline::GetClip(const std::string& id)
+openshot::Clip* Timeline::GetClip(const std::string& id)
 {
 	// Find the matching clip (if any)
 	for (const auto& clip : clips) {

--- a/src/Timeline.h
+++ b/src/Timeline.h
@@ -265,7 +265,7 @@ namespace openshot {
 		std::list<openshot::Clip*> Clips() { return clips; };
 
 		/// Look up a single clip by ID
-		openshot::ClipBase* GetClip(const std::string& id);
+		openshot::Clip* GetClip(const std::string& id);
 
 		/// Look up a clip effect by ID
 		openshot::EffectBase* GetClipEffect(const std::string& id);


### PR DESCRIPTION
Fixing an issue caused by timeline::GetClip returning a ClipBase instead of a Clip (broke waveform generation). 
Also adding a swig definition for the Caption effect.