### PR TITLE
Refresh Codecov configs

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,10 +1,8 @@
-codecov:
-  branch: default
 coverage:
   status:
     project:
       default:
-        base: pr # Only post a status to pull requests
+        only_pulls: true # Only post a status to pull requests
         informational: true # Don't block PRs based on coverage stats (yet?)
 ignore:
   - "examples"


### PR DESCRIPTION
The `base` argument to `coverage.status.project.<name>` is now deprecated, and AFAICT `codecov.branch` just doesn't exist as a parameter; it looks like I just made it up or something.

Hoping this will fix the repo's Dashboard display on Codecov's site always showing no data.
