### PR TITLE
Unit tests: Don't use OpenShot.h header

### DIFF
--- a/tests/Cache_Tests.cpp
+++ b/tests/Cache_Tests.cpp
@@ -28,11 +28,16 @@
  * along with OpenShot Library. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <memory>
+
 #include "UnitTest++.h"
 // Prevent name clashes with juce::UnitTest
 #define DONT_SET_USING_JUCE_NAMESPACE 1
-#include "OpenShot.h"
+#include "CacheDisk.h"
+#include "CacheMemory.h"
 #include "Json.h"
+
+#include <QDir>
 
 using namespace openshot;
 

--- a/tests/Clip_Tests.cpp
+++ b/tests/Clip_Tests.cpp
@@ -28,6 +28,9 @@
  * along with OpenShot Library. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <sstream>
+#include <memory>
+
 #include "UnitTest++.h"
 
 // Work around older versions of UnitTest++ without REQUIRE
@@ -37,7 +40,11 @@
 
 // Prevent name clashes with juce::UnitTest
 #define DONT_SET_USING_JUCE_NAMESPACE 1
-#include "OpenShot.h"
+#include "Clip.h"
+#include "Frame.h"
+#include "Fraction.h"
+#include "Timeline.h"
+#include "Json.h"
 
 using namespace openshot;
 
@@ -255,4 +262,3 @@ TEST(Verify_Parent_Timeline)
 }
 
 } // SUITE
-

--- a/tests/Color_Tests.cpp
+++ b/tests/Color_Tests.cpp
@@ -28,10 +28,15 @@
  * along with OpenShot Library. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <string>
+#include <vector>
+
 #include "UnitTest++.h"
 // Prevent name clashes with juce::UnitTest
 #define DONT_SET_USING_JUCE_NAMESPACE 1
-#include "OpenShot.h"
+#include "Color.h"
+#include "KeyFrame.h"
+#include "Json.h"
 
 SUITE(Color) {
 

--- a/tests/Coordinate_Tests.cpp
+++ b/tests/Coordinate_Tests.cpp
@@ -31,9 +31,8 @@
 #include "UnitTest++.h"
 // Prevent name clashes with juce::UnitTest
 #define DONT_SET_USING_JUCE_NAMESPACE 1
-#include "OpenShot.h"
+#include "Coordinate.h"
 
-using namespace std;
 using namespace openshot;
 
 TEST(Coordinate_Default_Constructor)

--- a/tests/DummyReader_Tests.cpp
+++ b/tests/DummyReader_Tests.cpp
@@ -28,11 +28,16 @@
  * along with OpenShot Library. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <memory>
+
 #include "UnitTest++.h"
 // Prevent name clashes with juce::UnitTest
 #define DONT_SET_USING_JUCE_NAMESPACE 1
 
-#include "OpenShot.h"
+#include "DummyReader.h"
+#include "CacheMemory.h"
+#include "Fraction.h"
+#include "Frame.h"
 
 using namespace std;
 using namespace openshot;

--- a/tests/FFmpegReader_Tests.cpp
+++ b/tests/FFmpegReader_Tests.cpp
@@ -28,10 +28,16 @@
  * along with OpenShot Library. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <sstream>
+#include <memory>
+
 #include "UnitTest++.h"
 // Prevent name clashes with juce::UnitTest
 #define DONT_SET_USING_JUCE_NAMESPACE 1
-#include "OpenShot.h"
+#include "FFmpegReader.h"
+#include "Frame.h"
+#include "Timeline.h"
+#include "Json.h"
 
 using namespace std;
 using namespace openshot;
@@ -272,4 +278,3 @@ TEST(Verify_Parent_Timeline)
 }
 
 } // SUITE(FFmpegReader)
-

--- a/tests/FFmpegWriter_Tests.cpp
+++ b/tests/FFmpegWriter_Tests.cpp
@@ -28,10 +28,16 @@
  * along with OpenShot Library. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <sstream>
+#include <memory>
+
 #include "UnitTest++.h"
 // Prevent name clashes with juce::UnitTest
 #define DONT_SET_USING_JUCE_NAMESPACE 1
-#include "OpenShot.h"
+#include "FFmpegWriter.h"
+#include "FFmpegReader.h"
+#include "Fraction.h"
+#include "Frame.h"
 
 using namespace std;
 using namespace openshot;

--- a/tests/Fraction_Tests.cpp
+++ b/tests/Fraction_Tests.cpp
@@ -31,7 +31,7 @@
 #include "UnitTest++.h"
 // Prevent name clashes with juce::UnitTest
 #define DONT_SET_USING_JUCE_NAMESPACE 1
-#include "OpenShot.h"
+#include "Fraction.h"
 
 using namespace std;
 using namespace openshot;

--- a/tests/Frame_Tests.cpp
+++ b/tests/Frame_Tests.cpp
@@ -29,10 +29,15 @@
  * along with OpenShot Library. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <sstream>
+#include <memory>
+
 #include "UnitTest++.h"
 // Prevent name clashes with juce::UnitTest
 #define DONT_SET_USING_JUCE_NAMESPACE 1
-#include "OpenShot.h"
+#include "Frame.h"
+#include "Clip.h"
+#include "Fraction.h"
 
 #include <QImage>
 

--- a/tests/ImageWriter_Tests.cpp
+++ b/tests/ImageWriter_Tests.cpp
@@ -28,15 +28,22 @@
  * along with OpenShot Library. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <sstream>
+#include <memory>
+
 #include "UnitTest++.h"
 // Prevent name clashes with juce::UnitTest
 #define DONT_SET_USING_JUCE_NAMESPACE 1
-#include "OpenShot.h"
+
+#ifdef USE_IMAGEMAGICK
+#include "ImageWriter.h"
+#include "ImageReader.h"
+#include "FFmpegReader.h"
+#include "Frame.h"
 
 using namespace std;
 using namespace openshot;
 
-#ifdef USE_IMAGEMAGICK
 SUITE(ImageWriter)
 {
 

--- a/tests/KeyFrame_Tests.cpp
+++ b/tests/KeyFrame_Tests.cpp
@@ -31,7 +31,10 @@
 #include "UnitTest++.h"
 // Prevent name clashes with juce::UnitTest
 #define DONT_SET_USING_JUCE_NAMESPACE 1
-#include "OpenShot.h"
+#include "KeyFrame.h"
+#include "Coordinate.h"
+#include "Fraction.h"
+#include "Point.h"
 
 using namespace std;
 using namespace openshot;

--- a/tests/Point_Tests.cpp
+++ b/tests/Point_Tests.cpp
@@ -31,7 +31,10 @@
 #include "UnitTest++.h"
 // Prevent name clashes with juce::UnitTest
 #define DONT_SET_USING_JUCE_NAMESPACE 1
-#include "OpenShot.h"
+#include "Point.h"
+#include "Enums.h"
+#include "Coordinate.h"
+#include "Json.h"
 
 SUITE(POINT) {
 

--- a/tests/ReaderBase_Tests.cpp
+++ b/tests/ReaderBase_Tests.cpp
@@ -28,10 +28,15 @@
  * along with OpenShot Library. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <memory>
+
 #include "UnitTest++.h"
 // Prevent name clashes with juce::UnitTest
 #define DONT_SET_USING_JUCE_NAMESPACE 1
-#include "OpenShot.h"
+#include "ReaderBase.h"
+#include "CacheBase.h"
+#include "Frame.h"
+#include "Json.h"
 
 using namespace std;
 using namespace openshot;

--- a/tests/Settings_Tests.cpp
+++ b/tests/Settings_Tests.cpp
@@ -31,7 +31,7 @@
 #include "UnitTest++.h"
 // Prevent name clashes with juce::UnitTest
 #define DONT_SET_USING_JUCE_NAMESPACE 1
-#include "OpenShot.h"
+#include "Settings.h"
 
 using namespace std;
 using namespace openshot;

--- a/tests/Timeline_Tests.cpp
+++ b/tests/Timeline_Tests.cpp
@@ -28,10 +28,19 @@
  * along with OpenShot Library. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <sstream>
+#include <memory>
+#include <list>
+
 #include "UnitTest++.h"
 // Prevent name clashes with juce::UnitTest
 #define DONT_SET_USING_JUCE_NAMESPACE 1
-#include "OpenShot.h"
+#include "Timeline.h"
+#include "Clip.h"
+#include "Frame.h"
+#include "Fraction.h"
+#include "effects/Blur.h"
+#include "effects/Negate.h"
 
 using namespace std;
 using namespace openshot;


### PR DESCRIPTION
To prevent slow compiles of unit tests, this PR replaces all of the `#include "OpenShot.h"` invocations with includes of the individual headers actually needed by each test file. This has little effect on files like `Clip_Tests.cpp` and `Frame_Tests.cpp`, but **hugely** speeds up the compilation (and reduces the size) of files like `Coordinate_Tests.cpp` and `Fraction_Tests.cpp`.