### PR TITLE
Fix videos with alpha channel

### DIFF
--- a/src/FFmpegReader.cpp
+++ b/src/FFmpegReader.cpp
@@ -1352,7 +1352,13 @@ void FFmpegReader::ProcessVideoPacket(int64_t requested_frame) {
 		std::shared_ptr<Frame> f = CreateFrame(current_frame);
 
 		// Add Image data to frame
-		f->AddImage(width, height, 4, QImage::Format_RGBA8888_Premultiplied, buffer);
+		if (!ffmpeg_has_alpha(AV_GET_CODEC_PIXEL_FORMAT(pStream, pCodecCtx))) {
+			// Add image with no alpha channel, Speed optimization
+			f->AddImage(width, height, 4, QImage::Format_RGBA8888_Premultiplied, buffer);
+		} else {
+			// Add image with alpha channel (this will be converted to premultipled when needed, but is slower)
+			f->AddImage(width, height, 4, QImage::Format_RGBA8888, buffer);
+		}
 
 		// Update working cache
 		working_cache.Add(f);

--- a/src/FFmpegUtilities.h
+++ b/src/FFmpegUtilities.h
@@ -126,6 +126,16 @@
 		#define PIX_FMT_YUV444P AV_PIX_FMT_YUV444P
 	#endif
 
+	// Does ffmpeg pixel format contain an alpha channel?
+	inline static const bool ffmpeg_has_alpha(PixelFormat pix_fmt)
+	{
+		if (pix_fmt == AV_PIX_FMT_ARGB || pix_fmt == AV_PIX_FMT_RGBA || pix_fmt == AV_PIX_FMT_ABGR || pix_fmt == AV_PIX_FMT_BGRA || pix_fmt == AV_PIX_FMT_YUVA420P) {
+			return true;
+		} else {
+			return false;
+		}
+	}
+
 	// FFmpeg's libavutil/common.h defines an RSHIFT incompatible with Ruby's
 	// definition in ruby/config.h, so we move it to FF_RSHIFT
 	#ifdef RSHIFT


### PR DESCRIPTION
This is a regression from using premultiplied colorspace in Qt. If a video has an alpha channel, we need to convert the RGBA correctly to premultiplied (which is slower), but without the conversion, all the alpha values are wildly wrong.