### PR TITLE
Revert cache-busting-on-seek Experiment

### DIFF
--- a/src/Timeline.cpp
+++ b/src/Timeline.cpp
@@ -725,15 +725,6 @@ std::shared_ptr<Frame> Timeline::GetFrame(int64_t requested_frame)
 			return frame;
 		}
 
-		// Check if previous frame was cached? (if not, assume we are seeking somewhere else on the Timeline, and need
-		// to clear all cache (for continuity sake). For example, jumping back to a previous spot can cause issues with audio
-		// data where the new jump location doesn't match up with the previously cached audio data.
-		std::shared_ptr<Frame> previous_frame = final_cache->GetFrame(requested_frame - 1);
-		if (!previous_frame) {
-			// Seeking to new place on timeline (destroy cache)
-			ClearAllCache();
-		}
-
 		// Minimum number of frames to process (for performance reasons)
 		int minimum_frames = OPEN_MP_NUM_PROCESSORS;
 


### PR DESCRIPTION
Reverting 'clear the cache when the user seeks' experiment. It was a failed experiment, not to mention that it destroys performance on the "Transform" tool. In theory, I was worried about boundaries between seek blocks. But I think having some inconsistent moments between blocks of separately decoded frames is okay during a real-time preview scenario. When final render is happening, we don't seek randomly around, and so this is not a problem.