### PR TITLE
Propagate library defs to swig

### DIFF
--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -58,6 +58,12 @@ endif()
 set_property(SOURCE openshot.i PROPERTY CPLUSPLUS ON)
 set_property(SOURCE openshot.i PROPERTY SWIG_MODULE_NAME openshot)
 
+# Set the SWIG_FLAGS from the library target, IFF its
+# COMPILE_DEFINITIONS property is set (in practice, always true)
+set(defs $<TARGET_PROPERTY:openshot,COMPILE_DEFINITIONS>)
+set_property(SOURCE openshot.i PROPERTY
+  SWIG_FLAGS $<$<BOOL:${defs}>:-D$<JOIN:${defs}, -D>>)
+
 ### Suppress a ton of warnings in the generated SWIG C++ code
 set(SWIG_CXX_FLAGS "-Wno-unused-variable -Wno-unused-function \
   -Wno-deprecated-copy -Wno-class-memaccess -Wno-cast-function-type \

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -60,9 +60,23 @@ set_property(SOURCE openshot.i PROPERTY SWIG_MODULE_NAME openshot)
 
 # Set the SWIG_FLAGS from the library target, IFF its
 # COMPILE_DEFINITIONS property is set (in practice, always true)
-set(defs $<TARGET_PROPERTY:openshot,COMPILE_DEFINITIONS>)
-set_property(SOURCE openshot.i PROPERTY
-  SWIG_FLAGS $<$<BOOL:${defs}>:-D$<JOIN:${defs}, -D>>)
+if(CMAKE_VERSION VERSION_GREATER 3.15)
+  set(_defs
+    $<REMOVE_DUPLICATES:$<TARGET_PROPERTY:openshot,COMPILE_DEFINITIONS>>)
+elseif(CMAKE_VERSION VERSION_GREATER 3.12)
+  set(_defs $<TARGET_PROPERTY:openshot,COMPILE_DEFINITIONS>)
+endif()
+if(DEFINED _defs)
+  set_property(SOURCE openshot.i PROPERTY
+    COMPILE_DEFINITIONS ${_defs})
+else()
+  get_property(_defs TARGET openshot PROPERTY COMPILE_DEFINITIONS)
+  foreach(_d ${_defs})
+    list(APPEND _flags -D${_d})
+  endforeach()
+  set_property(SOURCE openshot.i PROPERTY
+    SWIG_FLAGS ${_flags})
+endif()
 
 ### Suppress a ton of warnings in the generated SWIG C++ code
 set(SWIG_CXX_FLAGS "-Wno-unused-variable -Wno-unused-function \
@@ -71,13 +85,15 @@ set(SWIG_CXX_FLAGS "-Wno-unused-variable -Wno-unused-function \
 separate_arguments(sw_flags UNIX_COMMAND ${SWIG_CXX_FLAGS})
 set_property(SOURCE openshot.i PROPERTY GENERATED_COMPILE_OPTIONS ${sw_flags})
 
-### Take include dirs from target, automatically if possible
-if (CMAKE_VERSION VERSION_GREATER 3.13)
-  set_property(SOURCE openshot.i PROPERTY USE_TARGET_INCLUDE_DIRECTORIES True)
-elseif (CMAKE_VERSION VERSION_GREATER 3.12)
-  set_property(SOURCE openshot.i PROPERTY
-    INCLUDE_DIRECTORIES $<TARGET_PROPERTY:openshot,INCLUDE_DIRECTORIES>)
-endif ()
+### Take include dirs from target
+if(CMAKE_VERSION VERSION_GREATER 3.15)
+  set(_inc $<REMOVE_DUPLICATES:$<TARGET_PROPERTY:openshot,INCLUDE_DIRECTORIES>>)
+elseif(CMAKE_VERSION VERSION_GREATER 3.12)
+  set(_inc $<TARGET_PROPERTY:openshot,INCLUDE_DIRECTORIES>)
+endif()
+if (DEFINED _inc)
+  set_property(SOURCE openshot.i PROPERTY INCLUDE_DIRECTORIES ${_inc})
+endif()
 
 ### Add the SWIG interface file (which defines all the SWIG methods)
 if (CMAKE_VERSION VERSION_LESS 3.8.0)

--- a/bindings/ruby/CMakeLists.txt
+++ b/bindings/ruby/CMakeLists.txt
@@ -76,9 +76,23 @@ set_property(SOURCE openshot.i PROPERTY SWIG_MODULE_NAME openshot)
 
 # Set the SWIG_FLAGS from the library target, IFF its
 # COMPILE_DEFINITIONS property is set (in practice, always true)
-set(defs $<TARGET_PROPERTY:openshot,COMPILE_DEFINITIONS>)
-set_property(SOURCE openshot.i PROPERTY
-  SWIG_FLAGS $<$<BOOL:${defs}>:-D$<JOIN:${defs}, -D>>)
+if(CMAKE_VERSION VERSION_GREATER 3.15)
+  set(_defs
+    $<REMOVE_DUPLICATES:$<TARGET_PROPERTY:openshot,COMPILE_DEFINITIONS>>)
+elseif(CMAKE_VERSION VERSION_GREATER 3.12)
+  set(_defs $<TARGET_PROPERTY:openshot,COMPILE_DEFINITIONS>)
+endif()
+if(DEFINED _defs)
+  set_property(SOURCE openshot.i PROPERTY
+    COMPILE_DEFINITIONS ${_defs})
+else()
+  get_property(_defs TARGET openshot PROPERTY COMPILE_DEFINITIONS)
+  foreach(_d ${_defs})
+    list(APPEND _flags -D${_d})
+  endforeach()
+  set_property(SOURCE openshot.i PROPERTY
+    SWIG_FLAGS ${_flags})
+endif()
 
 ### Suppress a ton of warnings in the generated SWIG C++ code
 set(SWIG_CXX_FLAGS "-Wno-unused-variable -Wno-unused-function \
@@ -87,13 +101,15 @@ set(SWIG_CXX_FLAGS "-Wno-unused-variable -Wno-unused-function \
 separate_arguments(sw_flags UNIX_COMMAND ${SWIG_CXX_FLAGS})
 set_property(SOURCE openshot.i PROPERTY GENERATED_COMPILE_OPTIONS ${sw_flags})
 
-### Take include dirs from target, automatically if possible
-if (CMAKE_VERSION VERSION_GREATER 3.13)
-  set_property(SOURCE openshot.i PROPERTY USE_TARGET_INCLUDE_DIRECTORIES True)
-elseif (CMAKE_VERSION VERSION_GREATER 3.12)
-  set_property(SOURCE openshot.i PROPERTY
-    INCLUDE_DIRECTORIES $<TARGET_PROPERTY:openshot,INCLUDE_DIRECTORIES>)
-endif ()
+### Take include dirs from target
+if(CMAKE_VERSION VERSION_GREATER 3.15)
+  set(_inc $<REMOVE_DUPLICATES:$<TARGET_PROPERTY:openshot,INCLUDE_DIRECTORIES>>)
+elseif(CMAKE_VERSION VERSION_GREATER 3.12)
+  set(_inc $<TARGET_PROPERTY:openshot,INCLUDE_DIRECTORIES>)
+endif()
+if (DEFINED _inc)
+  set_property(SOURCE openshot.i PROPERTY INCLUDE_DIRECTORIES ${_inc})
+endif()
 
 ### Add the SWIG interface file (which defines all the SWIG methods)
 if (CMAKE_VERSION VERSION_LESS 3.8.0)

--- a/bindings/ruby/CMakeLists.txt
+++ b/bindings/ruby/CMakeLists.txt
@@ -74,6 +74,12 @@ endif()
 set_property(SOURCE openshot.i PROPERTY CPLUSPLUS ON)
 set_property(SOURCE openshot.i PROPERTY SWIG_MODULE_NAME openshot)
 
+# Set the SWIG_FLAGS from the library target, IFF its
+# COMPILE_DEFINITIONS property is set (in practice, always true)
+set(defs $<TARGET_PROPERTY:openshot,COMPILE_DEFINITIONS>)
+set_property(SOURCE openshot.i PROPERTY
+  SWIG_FLAGS $<$<BOOL:${defs}>:-D$<JOIN:${defs}, -D>>)
+
 ### Suppress a ton of warnings in the generated SWIG C++ code
 set(SWIG_CXX_FLAGS "-Wno-unused-variable -Wno-unused-function \
   -Wno-deprecated-copy -Wno-class-memaccess -Wno-cast-function-type \
@@ -83,9 +89,9 @@ set_property(SOURCE openshot.i PROPERTY GENERATED_COMPILE_OPTIONS ${sw_flags})
 
 ### Take include dirs from target, automatically if possible
 if (CMAKE_VERSION VERSION_GREATER 3.13)
-	set_property(SOURCE openshot.i PROPERTY USE_TARGET_INCLUDE_DIRECTORIES True)
-else ()
-	set_property(SOURCE openshot.i PROPERTY
+  set_property(SOURCE openshot.i PROPERTY USE_TARGET_INCLUDE_DIRECTORIES True)
+elseif (CMAKE_VERSION VERSION_GREATER 3.12)
+  set_property(SOURCE openshot.i PROPERTY
     INCLUDE_DIRECTORIES $<TARGET_PROPERTY:openshot,INCLUDE_DIRECTORIES>)
 endif ()
 

--- a/cmake/Modules/FindResvg.cmake
+++ b/cmake/Modules/FindResvg.cmake
@@ -50,6 +50,7 @@ endif()
 find_path(Resvg_INCLUDE_DIRS
   ResvgQt.h
   PATHS
+    ${Resvg_ROOT}
     ${RESVGDIR}
     ${RESVGDIR}/include
     $ENV{RESVGDIR}
@@ -65,6 +66,7 @@ find_path(Resvg_INCLUDE_DIRS
 find_library(Resvg_LIBRARIES
   NAMES resvg
   PATHS
+    ${Resvg_ROOT}
     ${RESVGDIR}
     ${RESVGDIR}/lib
     $ENV{RESVGDIR}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -212,7 +212,6 @@ if(ImageMagick_FOUND)
 
   # define a preprocessor macro (used in the C++ source)
   target_compile_definitions(openshot PUBLIC USE_IMAGEMAGICK=1)
-  list(APPEND CMAKE_SWIG_FLAGS -DUSE_IMAGEMAGICK=1)
 
   # Link with ImageMagick library
   target_link_libraries(openshot PUBLIC ImageMagick::Magick++)
@@ -346,8 +345,7 @@ if (TARGET Resvg::Resvg)
   #include_directories(${Resvg_INCLUDE_DIRS})
   target_link_libraries(openshot PUBLIC Resvg::Resvg)
 
-  target_compile_definitions(openshot PUBLIC -DUSE_RESVG=1)
-  list(APPEND CMAKE_SWIG_FLAGS -DUSE_RESVG=1)
+  target_compile_definitions(openshot PUBLIC USE_RESVG=1)
 
   set(HAVE_RESVG TRUE CACHE BOOL "Building with Resvg support" FORCE)
   mark_as_advanced(HAVE_RESVG)
@@ -373,8 +371,7 @@ if (ENABLE_BLACKMAGIC)
     target_link_libraries(openshot PUBLIC ${BLACKMAGIC_LIBRARY_DIR})
 
     # define a preprocessor macro (used in the C++)
-    target_compile_definitions(openshot PUBLIC -DUSE_BLACKMAGIC=1)
-    list(APPEND CMAKE_SWIG_FLAGS -DUSE_BLACKMAGIC=1)
+    target_compile_definitions(openshot PUBLIC USE_BLACKMAGIC=1)
   endif()
 endif()
 


### PR DESCRIPTION
I suspect since the bindings were moved out of the `src/` directory, the `CMAKE_SWIG_FLAGS` haven't been propagating to the `swig` command line that generates the wrapper script. This means that the `#ifdef`s in the `openshot.i` files are all interpreted wrong.

This PR adds generator expression logic to copy _every_ public compile definition from the `openshot` library target over to the `SWIG_FLAGS` of the `openshot.i` file, which should ensure that the bindings are generated correctly.

In my version of CMake, all compile definitions are stored in the target property _without_ the leading `-D`, even if it was originally set. So, the generator expression I added will prepend `-D` to each of the values. I'll have to check whether that holds for older CMake versions as well, otherwise we might end up with `-D-DUSE_RESVG=1` or the like, which would be a problem. The CI runs should be a fair test of that, though. (And just in case, I took the `-D`s out of the definitions _we_ set, at least.)

**Edit:** That wasn't the issue, but older CMakes did have a problem with the generator expressions. Added a workaround using `get_property()`, tested back to CMake 3.5.

Also added a fix to `FindResvg.cmake`, for compatibility with older CMake versions.