### PR TITLE
Deprecate TooManySeeks, instead of removing

### DIFF
--- a/src/AudioReaderSource.cpp
+++ b/src/AudioReaderSource.cpp
@@ -29,6 +29,7 @@
  */
 
 #include "AudioReaderSource.h"
+#include "Exceptions.h"
 
 using namespace std;
 using namespace openshot;

--- a/src/AudioResampler.h
+++ b/src/AudioResampler.h
@@ -32,7 +32,6 @@
 #define OPENSHOT_RESAMPLER_H
 
 #include "AudioBufferSource.h"
-#include "Exceptions.h"
 #include "JuceHeader.h"
 
 namespace openshot {

--- a/src/CacheBase.h
+++ b/src/CacheBase.h
@@ -34,7 +34,6 @@
 #include <memory>
 #include <cstdlib>
 #include "Frame.h"
-#include "Exceptions.h"
 #include "Json.h"
 
 namespace openshot {

--- a/src/CacheDisk.cpp
+++ b/src/CacheDisk.cpp
@@ -29,6 +29,7 @@
  */
 
 #include "CacheDisk.h"
+#include "Exceptions.h"
 #include "QtUtilities.h"
 #include <Qt>
 #include <QString>

--- a/src/CacheDisk.h
+++ b/src/CacheDisk.h
@@ -36,7 +36,6 @@
 #include <memory>
 #include "CacheBase.h"
 #include "Frame.h"
-#include "Exceptions.h"
 #include <QDir>
 
 namespace openshot {

--- a/src/CacheMemory.cpp
+++ b/src/CacheMemory.cpp
@@ -29,6 +29,7 @@
  */
 
 #include "CacheMemory.h"
+#include "Exceptions.h"
 
 using namespace std;
 using namespace openshot;

--- a/src/CacheMemory.h
+++ b/src/CacheMemory.h
@@ -36,7 +36,6 @@
 #include <memory>
 #include "CacheBase.h"
 #include "Frame.h"
-#include "Exceptions.h"
 
 namespace openshot {
 

--- a/src/ChunkReader.cpp
+++ b/src/ChunkReader.cpp
@@ -29,6 +29,7 @@
  */
 
 #include "ChunkReader.h"
+#include "Exceptions.h"
 #include "FFmpegReader.h"
 
 #include <QDir>

--- a/src/ChunkWriter.cpp
+++ b/src/ChunkWriter.cpp
@@ -29,6 +29,7 @@
  */
 
 #include "ChunkWriter.h"
+#include "Exceptions.h"
 
 using namespace openshot;
 

--- a/src/ChunkWriter.h
+++ b/src/ChunkWriter.h
@@ -35,7 +35,6 @@
 #include "WriterBase.h"
 #include "FFmpegWriter.h"
 #include "CacheMemory.h"
-#include "Exceptions.h"
 #include "Json.h"
 
 #include <cmath>

--- a/src/Clip.cpp
+++ b/src/Clip.cpp
@@ -29,6 +29,7 @@
  */
 
 #include "Clip.h"
+#include "Exceptions.h"
 #include "FFmpegReader.h"
 #include "FrameMapper.h"
 #ifdef USE_IMAGEMAGICK

--- a/src/ClipBase.h
+++ b/src/ClipBase.h
@@ -34,7 +34,6 @@
 #include <memory>
 #include <sstream>
 #include "CacheMemory.h"
-#include "Exceptions.h"
 #include "Frame.h"
 #include "Point.h"
 #include "KeyFrame.h"

--- a/src/Color.cpp
+++ b/src/Color.cpp
@@ -29,6 +29,7 @@
  */
 
 #include "Color.h"
+#include "Exceptions.h"
 
 using namespace openshot;
 

--- a/src/Coordinate.cpp
+++ b/src/Coordinate.cpp
@@ -29,6 +29,7 @@
  */
 
 #include "Coordinate.h"
+#include "Exceptions.h"
 
 using namespace std;
 using namespace openshot;

--- a/src/Coordinate.h
+++ b/src/Coordinate.h
@@ -32,7 +32,6 @@
 #define OPENSHOT_COORDINATE_H
 
 #include <iostream>
-#include "Exceptions.h"
 #include "Fraction.h"
 #include "Json.h"
 

--- a/src/DecklinkReader.cpp
+++ b/src/DecklinkReader.cpp
@@ -29,6 +29,7 @@
  */
 
 #include "DecklinkReader.h"
+#include "Exceptions.h"
 
 using namespace openshot;
 

--- a/src/DecklinkReader.h
+++ b/src/DecklinkReader.h
@@ -46,7 +46,6 @@
 #include <unistd.h>
 
 #include "CacheMemory.h"
-#include "Exceptions.h"
 #include "Frame.h"
 #include "DecklinkInput.h"
 

--- a/src/DecklinkWriter.h
+++ b/src/DecklinkWriter.h
@@ -46,7 +46,6 @@
 #include <unistd.h>
 
 #include "CacheMemory.h"
-#include "Exceptions.h"
 #include "Frame.h"
 #include "DecklinkOutput.h"
 

--- a/src/DummyReader.cpp
+++ b/src/DummyReader.cpp
@@ -29,6 +29,7 @@
  */
 
 #include "DummyReader.h"
+#include "Exceptions.h"
 
 using namespace openshot;
 

--- a/src/DummyReader.h
+++ b/src/DummyReader.h
@@ -40,7 +40,6 @@
 #include <stdio.h>
 #include <memory>
 #include "CacheMemory.h"
-#include "Exceptions.h"
 #include "Fraction.h"
 
 namespace openshot

--- a/src/EffectBase.cpp
+++ b/src/EffectBase.cpp
@@ -29,6 +29,7 @@
  */
 
 #include "EffectBase.h"
+#include "Exceptions.h"
 
 using namespace openshot;
 

--- a/src/Exceptions.h
+++ b/src/Exceptions.h
@@ -382,7 +382,9 @@ namespace openshot {
 		 * @param file_path (optional) The input file being processed
 		 */
 		TooManySeeks(std::string message, std::string file_path="")
+#ifndef SWIG
 		__attribute__ ((deprecated (TMS_DEP_MSG) ))
+#endif
 			: ExceptionBase(message), file_path(file_path) { }
 		virtual ~TooManySeeks() noexcept {}
 	};

--- a/src/Exceptions.h
+++ b/src/Exceptions.h
@@ -365,6 +365,29 @@ namespace openshot {
 		virtual ~ResampleError() noexcept {}
 	};
 
+#define TMS_DEP_MSG "The library no longer throws this exception. It will be removed in a future release."
+
+#ifndef SWIG
+	/// Exception when too many seek attempts happen
+	class
+	__attribute__ ((deprecated (TMS_DEP_MSG) ))
+	TooManySeeks : public ExceptionBase
+	{
+	public:
+		std::string file_path;
+		/**
+		 * @brief Constructor
+		 *
+		 * @param message A message to accompany the exception
+		 * @param file_path (optional) The input file being processed
+		 */
+		TooManySeeks(std::string message, std::string file_path="")
+		__attribute__ ((deprecated (TMS_DEP_MSG) ))
+			: ExceptionBase(message), file_path(file_path) { }
+		virtual ~TooManySeeks() noexcept {}
+	};
+#endif
+
 	/// Exception when a writer is closed, and a frame is requested
 	class WriterClosed : public ExceptionBase
 	{

--- a/src/FFmpegReader.cpp
+++ b/src/FFmpegReader.cpp
@@ -32,6 +32,7 @@
  */
 
 #include "FFmpegReader.h"
+#include "Exceptions.h"
 
 #include <thread>    // for std::this_thread::sleep_for
 #include <chrono>    // for std::chrono::milliseconds

--- a/src/FFmpegReader.h
+++ b/src/FFmpegReader.h
@@ -46,7 +46,6 @@
 #include <memory>
 #include "CacheMemory.h"
 #include "Clip.h"
-#include "Exceptions.h"
 #include "OpenMPUtilities.h"
 #include "Settings.h"
 

--- a/src/FFmpegWriter.cpp
+++ b/src/FFmpegWriter.cpp
@@ -32,6 +32,7 @@
  */
 
 #include "FFmpegWriter.h"
+#include "Exceptions.h"
 
 #include <iostream>
 

--- a/src/FFmpegWriter.h
+++ b/src/FFmpegWriter.h
@@ -49,7 +49,6 @@
 #include <ctime>
 #include <unistd.h>
 #include "CacheMemory.h"
-#include "Exceptions.h"
 #include "OpenMPUtilities.h"
 #include "ZmqLogger.h"
 #include "Settings.h"

--- a/src/FrameMapper.cpp
+++ b/src/FrameMapper.cpp
@@ -29,6 +29,7 @@
  */
 
 #include "FrameMapper.h"
+#include "Exceptions.h"
 #include "Clip.h"
 
 using namespace std;

--- a/src/FrameMapper.h
+++ b/src/FrameMapper.h
@@ -40,7 +40,6 @@
 #include "ReaderBase.h"
 #include "Frame.h"
 #include "Fraction.h"
-#include "Exceptions.h"
 #include "KeyFrame.h"
 
 

--- a/src/ImageReader.cpp
+++ b/src/ImageReader.cpp
@@ -32,6 +32,7 @@
 #ifdef USE_IMAGEMAGICK
 
 #include "ImageReader.h"
+#include "Exceptions.h"
 
 using namespace openshot;
 

--- a/src/ImageReader.h
+++ b/src/ImageReader.h
@@ -43,7 +43,7 @@
 #include <stdio.h>
 #include <memory>
 #include "CacheMemory.h"
-#include "Exceptions.h"
+
 #include "MagickUtilities.h"
 
 namespace openshot

--- a/src/ImageWriter.cpp
+++ b/src/ImageWriter.cpp
@@ -35,6 +35,7 @@
 #ifdef USE_IMAGEMAGICK
 
 #include "ImageWriter.h"
+#include "Exceptions.h"
 
 using namespace openshot;
 

--- a/src/ImageWriter.h
+++ b/src/ImageWriter.h
@@ -49,7 +49,7 @@
 #include <stdio.h>
 #include <unistd.h>
 #include "CacheMemory.h"
-#include "Exceptions.h"
+
 #include "OpenMPUtilities.h"
 #include "MagickUtilities.h"
 

--- a/src/Json.cpp
+++ b/src/Json.cpp
@@ -29,6 +29,7 @@
  */
 
 #include "Json.h"
+#include "Exceptions.h"
 
 const Json::Value openshot::stringToJson(const std::string value) {
 

--- a/src/Json.h
+++ b/src/Json.h
@@ -33,7 +33,7 @@
 
 #include <string>
 #include "json/json.h"
-#include "Exceptions.h"
+
 
 namespace openshot {
     const Json::Value stringToJson(const std::string value);

--- a/src/KeyFrame.cpp
+++ b/src/KeyFrame.cpp
@@ -29,6 +29,7 @@
  */
 
 #include "KeyFrame.h"
+#include "Exceptions.h"
 #include <algorithm>
 #include <functional>
 #include <utility>

--- a/src/KeyFrame.h
+++ b/src/KeyFrame.h
@@ -36,7 +36,7 @@
 #include <cmath>
 #include <assert.h>
 #include <vector>
-#include "Exceptions.h"
+
 #include "Fraction.h"
 #include "Coordinate.h"
 #include "Point.h"

--- a/src/OpenShot.h
+++ b/src/OpenShot.h
@@ -118,7 +118,7 @@
 #include "Effects.h"
 #include "EffectInfo.h"
 #include "Enums.h"
-#include "Exceptions.h"
+
 #include "ReaderBase.h"
 #include "WriterBase.h"
 #include "FFmpegReader.h"

--- a/src/Point.cpp
+++ b/src/Point.cpp
@@ -29,6 +29,7 @@
  */
 
 #include "Point.h"
+#include "Exceptions.h"
 
 using namespace std;
 using namespace openshot;

--- a/src/Point.h
+++ b/src/Point.h
@@ -32,7 +32,7 @@
 #define OPENSHOT_POINT_H
 
 #include "Coordinate.h"
-#include "Exceptions.h"
+
 #include "Json.h"
 
 namespace openshot

--- a/src/Profiles.cpp
+++ b/src/Profiles.cpp
@@ -29,6 +29,7 @@
  */
 
 #include "Profiles.h"
+#include "Exceptions.h"
 
 using namespace openshot;
 

--- a/src/Profiles.h
+++ b/src/Profiles.h
@@ -41,7 +41,6 @@
 #include <QTextStream>
 #include <cstdio>
 #include <cstdlib>
-#include "Exceptions.h"
 #include "Fraction.h"
 #include "Json.h"
 

--- a/src/Qt/PlayerPrivate.cpp
+++ b/src/Qt/PlayerPrivate.cpp
@@ -30,6 +30,7 @@
  */
 
 #include "PlayerPrivate.h"
+#include "Exceptions.h"
 
 #include <thread>    // for std::this_thread::sleep_for
 #include <chrono>    // for std::chrono milliseconds, high_resolution_clock

--- a/src/Qt/VideoCacheThread.cpp
+++ b/src/Qt/VideoCacheThread.cpp
@@ -29,6 +29,7 @@
  */
 
 #include "VideoCacheThread.h"
+#include "Exceptions.h"
 #include <algorithm>
 
 #include <thread>    // for std::this_thread::sleep_for

--- a/src/QtHtmlReader.cpp
+++ b/src/QtHtmlReader.cpp
@@ -31,6 +31,7 @@
  */
 
 #include "QtHtmlReader.h"
+#include "Exceptions.h"
 #include <QImage>
 #include <QPainter>
 #include <QTextDocument>

--- a/src/QtHtmlReader.h
+++ b/src/QtHtmlReader.h
@@ -43,7 +43,7 @@
 #include <memory>
 #include "CacheMemory.h"
 #include "Enums.h"
-#include "Exceptions.h"
+
 
 class QImage;
 

--- a/src/QtImageReader.cpp
+++ b/src/QtImageReader.cpp
@@ -29,6 +29,7 @@
  */
 
 #include "QtImageReader.h"
+#include "Exceptions.h"
 #include "Settings.h"
 #include "Clip.h"
 #include "CacheMemory.h"

--- a/src/QtImageReader.h
+++ b/src/QtImageReader.h
@@ -37,7 +37,7 @@
 #include <omp.h>
 #include <stdio.h>
 #include <memory>
-#include "Exceptions.h"
+
 #include "ReaderBase.h"
 
 namespace openshot

--- a/src/QtTextReader.cpp
+++ b/src/QtTextReader.cpp
@@ -31,6 +31,7 @@
  */
 
 #include "QtTextReader.h"
+#include "Exceptions.h"
 #include <QImage>
 #include <QPainter>
 

--- a/src/QtTextReader.h
+++ b/src/QtTextReader.h
@@ -43,7 +43,7 @@
 #include <memory>
 #include "CacheMemory.h"
 #include "Enums.h"
-#include "Exceptions.h"
+
 
 class QImage;
 

--- a/src/TextReader.cpp
+++ b/src/TextReader.cpp
@@ -32,6 +32,7 @@
 #ifdef USE_IMAGEMAGICK
 
 #include "TextReader.h"
+#include "Exceptions.h"
 
 using namespace openshot;
 

--- a/src/TextReader.h
+++ b/src/TextReader.h
@@ -44,7 +44,7 @@
 #include <memory>
 #include "CacheMemory.h"
 #include "Enums.h"
-#include "Exceptions.h"
+
 #include "MagickUtilities.h"
 
 namespace openshot

--- a/src/Timeline.cpp
+++ b/src/Timeline.cpp
@@ -29,6 +29,7 @@
  */
 
 #include "Timeline.h"
+#include "Exceptions.h"
 
 using namespace openshot;
 

--- a/src/WriterBase.cpp
+++ b/src/WriterBase.cpp
@@ -29,6 +29,7 @@
  */
 
 #include "WriterBase.h"
+#include "Exceptions.h"
 
 using namespace openshot;
 

--- a/src/ZmqLogger.cpp
+++ b/src/ZmqLogger.cpp
@@ -29,6 +29,7 @@
  */
 
 #include "ZmqLogger.h"
+#include "Exceptions.h"
 
 #if USE_RESVG == 1
 	#include "ResvgQt.h"

--- a/src/effects/Bars.cpp
+++ b/src/effects/Bars.cpp
@@ -29,6 +29,7 @@
  */
 
 #include "Bars.h"
+#include "Exceptions.h"
 
 using namespace openshot;
 
@@ -62,7 +63,7 @@ void Bars::init_effect_details()
 
 // This method is required for all derived classes of EffectBase, and returns a
 // modified openshot::Frame object
-std::shared_ptr<Frame> Bars::GetFrame(std::shared_ptr<Frame> frame, int64_t frame_number)
+std::shared_ptr<openshot::Frame> Bars::GetFrame(std::shared_ptr<openshot::Frame> frame, int64_t frame_number)
 {
 	// Get the frame's image
 	std::shared_ptr<QImage> frame_image = frame->GetImage();

--- a/src/effects/Blur.cpp
+++ b/src/effects/Blur.cpp
@@ -29,6 +29,7 @@
  */
 
 #include "Blur.h"
+#include "Exceptions.h"
 
 using namespace openshot;
 
@@ -63,7 +64,7 @@ void Blur::init_effect_details()
 
 // This method is required for all derived classes of EffectBase, and returns a
 // modified openshot::Frame object
-std::shared_ptr<Frame> Blur::GetFrame(std::shared_ptr<Frame> frame, int64_t frame_number)
+std::shared_ptr<openshot::Frame> Blur::GetFrame(std::shared_ptr<openshot::Frame> frame, int64_t frame_number)
 {
 	// Get the frame's image
 	std::shared_ptr<QImage> frame_image = frame->GetImage();

--- a/src/effects/Brightness.cpp
+++ b/src/effects/Brightness.cpp
@@ -29,6 +29,7 @@
  */
 
 #include "Brightness.h"
+#include "Exceptions.h"
 
 using namespace openshot;
 
@@ -61,7 +62,7 @@ void Brightness::init_effect_details()
 
 // This method is required for all derived classes of EffectBase, and returns a
 // modified openshot::Frame object
-std::shared_ptr<Frame> Brightness::GetFrame(std::shared_ptr<Frame> frame, int64_t frame_number)
+std::shared_ptr<openshot::Frame> Brightness::GetFrame(std::shared_ptr<openshot::Frame> frame, int64_t frame_number)
 {
 	// Get the frame's image
 	std::shared_ptr<QImage> frame_image = frame->GetImage();

--- a/src/effects/Caption.cpp
+++ b/src/effects/Caption.cpp
@@ -29,6 +29,7 @@
  */
 
 #include "Caption.h"
+#include "Exceptions.h"
 #include "../Clip.h"
 #include "../Timeline.h"
 

--- a/src/effects/ChromaKey.cpp
+++ b/src/effects/ChromaKey.cpp
@@ -29,6 +29,7 @@
  */
 
 #include "ChromaKey.h"
+#include "Exceptions.h"
 
 using namespace openshot;
 
@@ -66,7 +67,7 @@ void ChromaKey::init_effect_details()
 
 // This method is required for all derived classes of EffectBase, and returns a
 // modified openshot::Frame object
-std::shared_ptr<Frame> ChromaKey::GetFrame(std::shared_ptr<Frame> frame, int64_t frame_number)
+std::shared_ptr<openshot::Frame> ChromaKey::GetFrame(std::shared_ptr<openshot::Frame> frame, int64_t frame_number)
 {
 	// Determine the current HSL (Hue, Saturation, Lightness) for the Chrome
 	int threshold = fuzz.GetInt(frame_number);

--- a/src/effects/ColorShift.cpp
+++ b/src/effects/ColorShift.cpp
@@ -29,6 +29,7 @@
  */
 
 #include "ColorShift.h"
+#include "Exceptions.h"
 
 using namespace openshot;
 
@@ -62,7 +63,7 @@ void ColorShift::init_effect_details()
 
 // This method is required for all derived classes of EffectBase, and returns a
 // modified openshot::Frame object
-std::shared_ptr<Frame> ColorShift::GetFrame(std::shared_ptr<Frame> frame, int64_t frame_number)
+std::shared_ptr<openshot::Frame> ColorShift::GetFrame(std::shared_ptr<openshot::Frame> frame, int64_t frame_number)
 {
 	// Get the frame's image
 	std::shared_ptr<QImage> frame_image = frame->GetImage();

--- a/src/effects/Crop.cpp
+++ b/src/effects/Crop.cpp
@@ -29,6 +29,7 @@
  */
 
 #include "Crop.h"
+#include "Exceptions.h"
 
 using namespace openshot;
 
@@ -62,7 +63,7 @@ void Crop::init_effect_details()
 
 // This method is required for all derived classes of EffectBase, and returns a
 // modified openshot::Frame object
-std::shared_ptr<Frame> Crop::GetFrame(std::shared_ptr<Frame> frame, int64_t frame_number)
+std::shared_ptr<openshot::Frame> Crop::GetFrame(std::shared_ptr<openshot::Frame> frame, int64_t frame_number)
 {
 	// Get the frame's image
 	std::shared_ptr<QImage> frame_image = frame->GetImage();

--- a/src/effects/Deinterlace.cpp
+++ b/src/effects/Deinterlace.cpp
@@ -29,6 +29,7 @@
  */
 
 #include "Deinterlace.h"
+#include "Exceptions.h"
 
 using namespace openshot;
 
@@ -62,7 +63,7 @@ void Deinterlace::init_effect_details()
 
 // This method is required for all derived classes of EffectBase, and returns a
 // modified openshot::Frame object
-std::shared_ptr<Frame> Deinterlace::GetFrame(std::shared_ptr<Frame> frame, int64_t frame_number)
+std::shared_ptr<openshot::Frame> Deinterlace::GetFrame(std::shared_ptr<openshot::Frame> frame, int64_t frame_number)
 {
 	// Get original size of frame's image
 	int original_width = frame->GetImage()->width();

--- a/src/effects/Hue.cpp
+++ b/src/effects/Hue.cpp
@@ -29,6 +29,7 @@
  */
 
 #include "Hue.h"
+#include "Exceptions.h"
 
 using namespace openshot;
 
@@ -61,7 +62,7 @@ void Hue::init_effect_details()
 
 // This method is required for all derived classes of EffectBase, and returns a
 // modified openshot::Frame object
-std::shared_ptr<Frame> Hue::GetFrame(std::shared_ptr<Frame> frame, int64_t frame_number)
+std::shared_ptr<openshot::Frame> Hue::GetFrame(std::shared_ptr<openshot::Frame> frame, int64_t frame_number)
 {
 	// Get the frame's image
 	std::shared_ptr<QImage> frame_image = frame->GetImage();

--- a/src/effects/Mask.cpp
+++ b/src/effects/Mask.cpp
@@ -29,6 +29,7 @@
  */
 
 #include "Mask.h"
+#include "Exceptions.h"
 #include "FFmpegReader.h"
 #ifdef USE_IMAGEMAGICK
 	#include "ImageReader.h"
@@ -67,7 +68,7 @@ void Mask::init_effect_details()
 
 // This method is required for all derived classes of EffectBase, and returns a
 // modified openshot::Frame object
-std::shared_ptr<Frame> Mask::GetFrame(std::shared_ptr<Frame> frame, int64_t frame_number) {
+std::shared_ptr<openshot::Frame> Mask::GetFrame(std::shared_ptr<openshot::Frame> frame, int64_t frame_number) {
 	// Get the mask image (from the mask reader)
 	std::shared_ptr<QImage> frame_image = frame->GetImage();
 

--- a/src/effects/Negate.cpp
+++ b/src/effects/Negate.cpp
@@ -29,6 +29,7 @@
  */
 
 #include "Negate.h"
+#include "Exceptions.h"
 
 using namespace openshot;
 
@@ -48,7 +49,7 @@ Negate::Negate()
 
 // This method is required for all derived classes of EffectBase, and returns a
 // modified openshot::Frame object
-std::shared_ptr<Frame> Negate::GetFrame(std::shared_ptr<Frame> frame, int64_t frame_number)
+std::shared_ptr<openshot::Frame> Negate::GetFrame(std::shared_ptr<openshot::Frame> frame, int64_t frame_number)
 {
 	// Make a negative of the images pixels
 	frame->GetImage()->invertPixels();

--- a/src/effects/Pixelate.cpp
+++ b/src/effects/Pixelate.cpp
@@ -29,6 +29,7 @@
  */
 
 #include "Pixelate.h"
+#include "Exceptions.h"
 #include "Json.h"
 
 #include <QImage>

--- a/src/effects/Saturation.cpp
+++ b/src/effects/Saturation.cpp
@@ -29,6 +29,7 @@
  */
 
 #include "Saturation.h"
+#include "Exceptions.h"
 
 using namespace openshot;
 
@@ -62,7 +63,7 @@ void Saturation::init_effect_details()
 
 // This method is required for all derived classes of EffectBase, and returns a
 // modified openshot::Frame object
-std::shared_ptr<Frame> Saturation::GetFrame(std::shared_ptr<Frame> frame, int64_t frame_number)
+std::shared_ptr<openshot::Frame> Saturation::GetFrame(std::shared_ptr<openshot::Frame> frame, int64_t frame_number)
 {
 	// Get the frame's image
 	std::shared_ptr<QImage> frame_image = frame->GetImage();

--- a/src/effects/Shift.cpp
+++ b/src/effects/Shift.cpp
@@ -29,6 +29,7 @@
  */
 
 #include "Shift.h"
+#include "Exceptions.h"
 
 using namespace openshot;
 
@@ -61,7 +62,7 @@ void Shift::init_effect_details()
 
 // This method is required for all derived classes of EffectBase, and returns a
 // modified openshot::Frame object
-std::shared_ptr<Frame> Shift::GetFrame(std::shared_ptr<Frame> frame, int64_t frame_number)
+std::shared_ptr<openshot::Frame> Shift::GetFrame(std::shared_ptr<openshot::Frame> frame, int64_t frame_number)
 {
 	// Get the frame's image
 	std::shared_ptr<QImage> frame_image = frame->GetImage();

--- a/src/effects/Wave.cpp
+++ b/src/effects/Wave.cpp
@@ -29,6 +29,7 @@
  */
 
 #include "Wave.h"
+#include "Exceptions.h"
 
 using namespace openshot;
 
@@ -63,7 +64,7 @@ void Wave::init_effect_details()
 
 // This method is required for all derived classes of EffectBase, and returns a
 // modified openshot::Frame object
-std::shared_ptr<Frame> Wave::GetFrame(std::shared_ptr<Frame> frame, int64_t frame_number)
+std::shared_ptr<openshot::Frame> Wave::GetFrame(std::shared_ptr<openshot::Frame> frame, int64_t frame_number)
 {
 	// Get the frame's image
 	std::shared_ptr<QImage> frame_image = frame->GetImage();

--- a/src/effects/Wave.h
+++ b/src/effects/Wave.h
@@ -83,7 +83,7 @@ namespace openshot
 		///
 		/// @returns A new openshot::Frame object
 		/// @param frame_number The frame number (starting at 1) of the clip or effect on the timeline.
-		std::shared_ptr<openshot::Frame> GetFrame(int64_t frame_number) override { return GetFrame(std::shared_ptr<Frame> (new Frame()), frame_number); }
+		std::shared_ptr<openshot::Frame> GetFrame(int64_t frame_number) override { return GetFrame(std::shared_ptr<openshot::Frame> (new Frame()), frame_number); }
 
 		/// @brief This method is required for all derived classes of ClipBase, and returns a
 		/// modified openshot::Frame object

--- a/tests/Color_Tests.cpp
+++ b/tests/Color_Tests.cpp
@@ -35,6 +35,7 @@
 // Prevent name clashes with juce::UnitTest
 #define DONT_SET_USING_JUCE_NAMESPACE 1
 #include "Color.h"
+#include "Exceptions.h"
 #include "KeyFrame.h"
 #include "Json.h"
 

--- a/tests/DummyReader_Tests.cpp
+++ b/tests/DummyReader_Tests.cpp
@@ -35,6 +35,7 @@
 #define DONT_SET_USING_JUCE_NAMESPACE 1
 
 #include "DummyReader.h"
+#include "Exceptions.h"
 #include "CacheMemory.h"
 #include "Fraction.h"
 #include "Frame.h"

--- a/tests/FFmpegReader_Tests.cpp
+++ b/tests/FFmpegReader_Tests.cpp
@@ -35,6 +35,7 @@
 // Prevent name clashes with juce::UnitTest
 #define DONT_SET_USING_JUCE_NAMESPACE 1
 #include "FFmpegReader.h"
+#include "Exceptions.h"
 #include "Frame.h"
 #include "Timeline.h"
 #include "Json.h"

--- a/tests/FFmpegWriter_Tests.cpp
+++ b/tests/FFmpegWriter_Tests.cpp
@@ -35,6 +35,7 @@
 // Prevent name clashes with juce::UnitTest
 #define DONT_SET_USING_JUCE_NAMESPACE 1
 #include "FFmpegWriter.h"
+#include "Exceptions.h"
 #include "FFmpegReader.h"
 #include "Fraction.h"
 #include "Frame.h"

--- a/tests/ImageWriter_Tests.cpp
+++ b/tests/ImageWriter_Tests.cpp
@@ -37,6 +37,7 @@
 
 #ifdef USE_IMAGEMAGICK
 #include "ImageWriter.h"
+#include "Exceptions.h"
 #include "ImageReader.h"
 #include "FFmpegReader.h"
 #include "Frame.h"

--- a/tests/KeyFrame_Tests.cpp
+++ b/tests/KeyFrame_Tests.cpp
@@ -32,6 +32,7 @@
 // Prevent name clashes with juce::UnitTest
 #define DONT_SET_USING_JUCE_NAMESPACE 1
 #include "KeyFrame.h"
+#include "Exceptions.h"
 #include "Coordinate.h"
 #include "Fraction.h"
 #include "Point.h"


### PR DESCRIPTION
Recently (in #611) I removed the TooManySeeks exception, which has been unused in the code since 2015.

But, just because _we_ don't use it doesn't mean that nobody ELSE uses it. So, in case any of the library's consumers are still catching `TooManySeeks` (as we no longer do), to avoid breaking their code this PR restores the exception. However, both the class and the constructor are marked as deprecated, causing both `g++` and `clang++` to emit a warning if it's used:

`g++`:
```text
[ 60%] Building CXX object src/CMakeFiles/openshot.dir/Qt/PlayerPrivate.cpp.o
src/Qt/PlayerPrivate.cpp: In member function ‘std::shared_ptr<openshot::Frame> openshot::PlayerPrivate::getFrame()’:
src/Qt/PlayerPrivate.cpp:178:35: warning: ‘TooManySeeks’ is deprecated: The library no longer throws this exception. It will be removed in a future release. [-Wdeprecated-declarations]
  178 |     } catch (const TooManySeeks & e) {
      |                                   ^
In file included from src/Qt/PlayerPrivate.cpp:33:
src/Exceptions.h:375:2: note: declared here
  375 |  TooManySeeks : public ExceptionBase
      |  ^~~~~~~~~~~~
```

`clang++`:
```text
[ 61%] Building CXX object src/CMakeFiles/openshot.dir/Qt/PlayerPrivate.cpp.o
src/Qt/PlayerPrivate.cpp:178:20: warning: 'TooManySeeks' is deprecated: The library no longer throws this exception. It will be removed in a future release. [-Wdeprecated-declarations]
    } catch (const TooManySeeks & e) {
                   ^
src/Exceptions.h:373:18: note: 'TooManySeeks' has been explicitly marked deprecated here
        __attribute__ ((deprecated (TMS_DEP_MSG) ))
                        ^
1 warning generated.
```

`TooManySeeks` is also excluded from the SWIG bindings entirely using `#ifndef SWIG`.

A separate commit in this PR moves most (all?) `#include "Exceptions.h"` lines from the header files to their corresponding `.cpp` files, to reduce unnecessary recompilations and header bloat.
