### PR TITLE
Thanks to @ferdnyc for the suggestion to better detect alpha channels.

### DIFF
--- a/src/FFmpegUtilities.h
+++ b/src/FFmpegUtilities.h
@@ -127,32 +127,10 @@
 	#endif
 
 	// Does ffmpeg pixel format contain an alpha channel?
-	inline static const bool ffmpeg_has_alpha(PixelFormat pix_fmt)
-	{
-		if (pix_fmt == AV_PIX_FMT_ARGB ||
-		    pix_fmt == AV_PIX_FMT_RGBA ||
-		    pix_fmt == AV_PIX_FMT_ABGR ||
-		    pix_fmt == AV_PIX_FMT_BGRA ||
-		    pix_fmt == AV_PIX_FMT_YUVA420P ||
-		    pix_fmt == AV_PIX_FMT_YA16LE ||
-		    pix_fmt == AV_PIX_FMT_YA16BE ||
-		    pix_fmt == AV_PIX_FMT_YA8 ||
-		    pix_fmt == AV_PIX_FMT_GBRAP ||
-            pix_fmt == AV_PIX_FMT_GBRAP10BE ||
-            pix_fmt == AV_PIX_FMT_GBRAP10LE ||
-            pix_fmt == AV_PIX_FMT_GBRAP12BE ||
-            pix_fmt == AV_PIX_FMT_GBRAP12LE ||
-            pix_fmt == AV_PIX_FMT_GBRAP16BE ||
-            pix_fmt == AV_PIX_FMT_GBRAP16LE ||
-            pix_fmt == AV_PIX_FMT_GBRPF32BE ||
-            pix_fmt == AV_PIX_FMT_GBRPF32LE ||
-            pix_fmt == AV_PIX_FMT_GBRAPF32BE ||
-            pix_fmt == AV_PIX_FMT_GBRAPF32LE) {
-			return true;
-		} else {
-			return false;
-		}
-	}
+    inline static const bool ffmpeg_has_alpha(PixelFormat pix_fmt) {
+        const AVPixFmtDescriptor *fmt_desc = av_pix_fmt_desc_get(pix_fmt);
+        return bool(fmt_desc->flags & AV_PIX_FMT_FLAG_ALPHA);
+    }
 
 	// FFmpeg's libavutil/common.h defines an RSHIFT incompatible with Ruby's
 	// definition in ruby/config.h, so we move it to FF_RSHIFT


### PR DESCRIPTION
Related to https://github.com/OpenShot/libopenshot/pull/609. Implementing a much improved alpha channel detection method, which works on all formats that contain an alpha channel. Shout out to @ferdnyc for the suggestion!