### PR TITLE
Fixing a missing header file in the opencv branch, due to a bad merge…

### DIFF
--- a/src/OpenShot.h
+++ b/src/OpenShot.h
@@ -118,7 +118,7 @@
 #include "Effects.h"
 #include "EffectInfo.h"
 #include "Enums.h"
-
+#include "Exceptions.h"
 #include "ReaderBase.h"
 #include "WriterBase.h"
 #include "FFmpegReader.h"

--- a/src/OpenShot.h
+++ b/src/OpenShot.h
@@ -118,7 +118,6 @@
 #include "Effects.h"
 #include "EffectInfo.h"
 #include "Enums.h"
-#include "Exceptions.h"
 #include "ReaderBase.h"
 #include "WriterBase.h"
 #include "FFmpegReader.h"

--- a/src/effects/Stabilizer.cpp
+++ b/src/effects/Stabilizer.cpp
@@ -29,6 +29,7 @@
  */
 
 #include "effects/Stabilizer.h"
+#include "Exceptions.h"
 #include <google/protobuf/util/time_util.h>
 
 using namespace std;


### PR DESCRIPTION
Fixing a missing header file in the opencv branch, due to a bad merge with develop. ... Testing this out on the build servers.

Related to: 
- https://github.com/OpenShot/libopenshot/pull/623
- https://github.com/OpenShot/libopenshot/pull/585