### PR TITLE
Add Exceptions.h include to new effects

### DIFF
--- a/src/effects/ObjectDetection.cpp
+++ b/src/effects/ObjectDetection.cpp
@@ -30,6 +30,7 @@
 
 #include "effects/ObjectDetection.h"
 #include "effects/Tracker.h"
+#include "Exceptions.h"
 
 using namespace std;
 using namespace openshot;

--- a/src/effects/Stabilizer.cpp
+++ b/src/effects/Stabilizer.cpp
@@ -29,6 +29,7 @@
  */
 
 #include "effects/Stabilizer.h"
+#include "Exceptions.h"
 #include <google/protobuf/util/time_util.h>
 
 using namespace std;

--- a/src/effects/Tracker.cpp
+++ b/src/effects/Tracker.cpp
@@ -29,6 +29,7 @@
  */
 
 #include "effects/Tracker.h"
+#include "Exceptions.h"
 #include <google/protobuf/util/time_util.h>
 
 using namespace std;


### PR DESCRIPTION
The new effects were picking up the definition of `InvalidJSON` from one of the other headers, which no longer `#include "Exceptions.h"`. So, they should include it directly.