### PR TITLE
KeyFrame.h: Avoid shadowing SWIG templates

### DIFF
--- a/bindings/python/openshot.i
+++ b/bindings/python/openshot.i
@@ -141,6 +141,16 @@
 %template() std::pair<double, double>;
 %template() std::pair<float, float>;
 
+/* Wrap std templates (list, vector, etc...) */
+%template(ClipList) std::list<openshot::Clip *>;
+%template(EffectBaseList) std::list<openshot::EffectBase *>;
+%template(CoordinateVector) std::vector<openshot::Coordinate>;
+%template(PointsVector) std::vector<openshot::Point>;
+%template(FieldVector) std::vector<openshot::Field>;
+%template(MappedFrameVector) std::vector<openshot::MappedFrame>;
+%template(MetadataMap) std::map<std::string, std::string>;
+%template(AudioDeviceInfoVector) std::vector<openshot::AudioDeviceInfo>;
+
 /* Make openshot.Fraction more Pythonic */
 %extend openshot::Fraction {
 %{
@@ -311,12 +321,3 @@
 #endif
 
 
-/* Wrap std templates (list, vector, etc...) */
-%template(ClipList) std::list<openshot::Clip *>;
-%template(EffectBaseList) std::list<openshot::EffectBase *>;
-%template(CoordinateVector) std::vector<openshot::Coordinate>;
-%template(PointsVector) std::vector<openshot::Point>;
-%template(FieldVector) std::vector<openshot::Field>;
-%template(MappedFrameVector) std::vector<openshot::MappedFrame>;
-%template(MetadataMap) std::map<std::string, std::string>;
-%template(AudioDeviceInfoVector) std::vector<openshot::AudioDeviceInfo>;

--- a/src/KeyFrame.cpp
+++ b/src/KeyFrame.cpp
@@ -126,10 +126,10 @@ Keyframe::Keyframe(double value) {
 }
 
 // Constructor which takes a vector of Points
-Keyframe::Keyframe(const std::vector<Point>& points) : Points(points) {};
+Keyframe::Keyframe(const std::vector<openshot::Point>& points) : Points(points) {};
 
 // Constructor which takes a vector of std::pair tuples (and adds them all)
-Keyframe::Keyframe(const std::vector<Coordinate>& coordinates) {
+Keyframe::Keyframe(const std::vector<openshot::Coordinate>& coordinates) {
 	for (const auto& co : coordinates) {
 		AddPoint(Point(co));
 	}

--- a/src/KeyFrame.h
+++ b/src/KeyFrame.h
@@ -62,8 +62,8 @@ namespace openshot {
 		std::vector<Point> Points;			///< Vector of all Points
 
 	public:
-		using CoordinateVector = std::vector<Coordinate>;
-		using PointsVector = std::vector<Point>;
+		using CoordinateVec = std::vector<Coordinate>;
+		using PointsVec = std::vector<Point>;
 
 		/// Default constructor for the Keyframe class
 		Keyframe() = default;
@@ -72,10 +72,10 @@ namespace openshot {
 		Keyframe(double value);
 
 		/// Constructor which adds a supplied vector of Points
-		Keyframe(const PointsVector& points);
+		Keyframe(const PointsVec& points);
 
 		/// Constructor which takes a vector of std::pair tuples
-		Keyframe(const CoordinateVector& coordinates);
+		Keyframe(const CoordinateVec& coordinates);
 
 		/// Add a new point on the key-frame.  Each point has a primary coordinate, a left handle, and a right handle.
 		void AddPoint(Point p);


### PR DESCRIPTION
Hopefully this will fix the SWIG build on launchpad.