### PR TITLE
Tweak the Python bindings for KeyFrame, Fraction

### DIFF
--- a/bindings/python/openshot.i
+++ b/bindings/python/openshot.i
@@ -156,6 +156,7 @@
 %{
 	#include <sstream>
 	#include <map>
+	#include <vector>
 
 	static std::vector<std::string> _keys{"num", "den"};
 	static int fracError = 0;
@@ -179,7 +180,7 @@
 		}
 	}
 	const std::string __getitem__(int index) {
-		if (index < _keys.size()) {
+		if (index < static_cast<int>(_keys.size())) {
 			return _keys[index];
 		}
 		/* Otherwise, raise an exception */

--- a/bindings/python/openshot.i
+++ b/bindings/python/openshot.i
@@ -206,7 +206,7 @@
 		return map1;
 	}
 	/* Display methods */
-	const std::string __string__() {
+	const std::string __str__() {
 		std::ostringstream result;
 		result << $self->num << ":" << $self->den;
 		return result.str();

--- a/src/KeyFrame.cpp
+++ b/src/KeyFrame.cpp
@@ -128,13 +128,6 @@ Keyframe::Keyframe(double value) {
 // Constructor which takes a vector of Points
 Keyframe::Keyframe(const std::vector<openshot::Point>& points) : Points(points) {};
 
-// Constructor which takes a vector of std::pair tuples (and adds them all)
-Keyframe::Keyframe(const std::vector<openshot::Coordinate>& coordinates) {
-	for (const auto& co : coordinates) {
-		AddPoint(Point(co));
-	}
-}
-
 // Add a new point on the key-frame.  Each point has a primary coordinate,
 // a left handle, and a right handle.
 void Keyframe::AddPoint(Point p) {

--- a/src/KeyFrame.h
+++ b/src/KeyFrame.h
@@ -62,9 +62,6 @@ namespace openshot {
 		std::vector<Point> Points;			///< Vector of all Points
 
 	public:
-		using CoordinateVec = std::vector<Coordinate>;
-		using PointsVec = std::vector<Point>;
-
 		/// Default constructor for the Keyframe class
 		Keyframe() = default;
 
@@ -72,10 +69,7 @@ namespace openshot {
 		Keyframe(double value);
 
 		/// Constructor which adds a supplied vector of Points
-		Keyframe(const PointsVec& points);
-
-		/// Constructor which takes a vector of std::pair tuples
-		Keyframe(const CoordinateVec& coordinates);
+		Keyframe(const std::vector<openshot::Point>& points);
 
 		/// Add a new point on the key-frame.  Each point has a primary coordinate, a left handle, and a right handle.
 		void AddPoint(Point p);

--- a/tests/KeyFrame_Tests.cpp
+++ b/tests/KeyFrame_Tests.cpp
@@ -510,18 +510,4 @@ TEST(Point_Vector_Constructor)
 	CHECK_CLOSE(30.0f, k1.GetValue(10), 0.0001);
 }
 
-TEST(Coordinate_Vector_Constructor)
-{
-	std::vector<Coordinate> coordinates{
-		Coordinate(1, 100), Coordinate(10, 500), Coordinate(1000, 80000)
-	};
-	Keyframe k1(coordinates);
-
-	CHECK_EQUAL(1001, k1.GetLength());
-
-	auto p1 = k1.GetPoint(2);
-	CHECK_CLOSE(80000.0f, p1.co.Y, 0.00001);
-}
-
-
 };  // SUITE


### PR DESCRIPTION
I screwed up the slot name for Fraction's string representation (`__str__` not `__string__`, dummy!), so this PR fixes that.

It also gets rid of the `Keyframe(std::vector<Coordinate>)` constructor, which as SWIG points out in an emitted warning will shadow `Keyframe(std::vector<Point>)` or vice versa, and the `Point` version is far more useful. The aliased names for the arguments are also removed, on the off chance they're part of what's messing up SWIG on Ubuntu 16.04.