### PR TITLE
Add Exceptions.h back to OpenShot.h

### DIFF
--- a/src/OpenShot.h
+++ b/src/OpenShot.h
@@ -118,7 +118,7 @@
 #include "Effects.h"
 #include "EffectInfo.h"
 #include "Enums.h"
-
+#include "Exceptions.h"
 #include "ReaderBase.h"
 #include "WriterBase.h"
 #include "FFmpegReader.h"


### PR DESCRIPTION
I hadn't actually intended to remove `#include "Exceptions.h"` from `OpenShot.h`, that was an overzealous find-and-replace on my part. I'm fine with `OpenShot.h` being the only header that _does_ automatically include it, even though for most practical applications I feel `OpenShot.h` is now far too heavy to actually use.

(Our own unit tests have stopped using it in favor of targeted includes, for example, because it'd been building in this direction for a while, and OpenCV was the tipping point on `#include "OpenShot.h"` bringing in way too much stuff and excessively slowing down each source file's compilation. Still, for convenience it's "fine", and should include the exception definitions as well.)