### PR TITLE
Add CODECOV_TOKEN envvar to Github CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,8 @@ jobs:
         compiler: [gcc, clang]
     env:
       CC: ${{ matrix.compiler }}
+      CODECOV_TOKEN: 'dc94d508-39d3-4369-b1c6-321749f96f7c'
+
     steps:
     - uses: actions/checkout@v2
 


### PR DESCRIPTION
A message in their UI seemed to indicate it would make our data show up (it hasn't been, on their site).