### PR TITLE
Clip: Use QPainter opacity

### DIFF
--- a/src/Clip.cpp
+++ b/src/Clip.cpp
@@ -1150,29 +1150,6 @@ void Clip::apply_keyframes(std::shared_ptr<Frame> frame, int width, int height)
 		frame->AddImage(std::shared_ptr<QImage>(source_image));
 	}
 
-	/* ALPHA & OPACITY */
-	if (alpha.GetValue(frame->number) != 1.0)
-	{
-		float alpha_value = alpha.GetValue(frame->number);
-
-		// Get source image's pixels
-		unsigned char *pixels = source_image->bits();
-
-		// Loop through pixels
-		for (int pixel = 0, byte_index=0; pixel < source_image->width() * source_image->height(); pixel++, byte_index+=4)
-		{
-			// Apply alpha to pixel values (since we use a premultiplied value, we must
-			// multiply the alpha with all colors).
-			pixels[byte_index + 0] *= alpha_value;
-			pixels[byte_index + 1] *= alpha_value;
-			pixels[byte_index + 2] *= alpha_value;
-			pixels[byte_index + 3] *= alpha_value;
-		}
-
-		// Debug output
-		ZmqLogger::Instance()->AppendDebugMethod("Clip::apply_keyframes (Set Alpha & Opacity)", "alpha_value", alpha_value, "frame->number", frame->number);
-	}
-
 	/* RESIZE SOURCE IMAGE - based on scale type */
 	QSize source_size = source_image->size();
 	switch (scale)
@@ -1311,9 +1288,17 @@ void Clip::apply_keyframes(std::shared_ptr<Frame> frame, int width, int height)
 	// Apply transform (translate, rotate, scale)
 	painter.setTransform(transform);
 
+	// Apply transparency
+	painter.setOpacity(alpha.GetValue(frame->number));
+	// Debug output
+	ZmqLogger::Instance()->AppendDebugMethod("Clip::apply_keyframes (Set Alpha & Opacity)", "alpha_value", alpha.GetValue(frame->number), "frame->number", frame->number);
+
 	// Composite a new layer onto the image
 	painter.setCompositionMode(QPainter::CompositionMode_SourceOver);
 	painter.drawImage(0, 0, *source_image);
+
+	// Reset transparency
+	painter.setOpacity(1.0f);
 
 	if (timeline) {
 		Timeline *t = (Timeline *) timeline;

--- a/src/Clip.cpp
+++ b/src/Clip.cpp
@@ -987,7 +987,7 @@ void Clip::SetJsonValue(const Json::Value root) {
 
 				// Create instance of effect
 				if ( (e = EffectInfo().CreateEffect(existing_effect["type"].asString()))) {
-					
+
 					// Load Json into Effect
 					e->SetJsonValue(existing_effect);
 
@@ -1131,7 +1131,7 @@ bool Clip::isEqual(double a, double b)
 void Clip::apply_keyframes(std::shared_ptr<Frame> frame, int width, int height)
 {
 	// Get actual frame image data
-	std::shared_ptr<QImage> source_image = frame->GetImage();
+	auto source_image = frame->GetImage();
 
 	/* REPLACE IMAGE WITH WAVEFORM IMAGE (IF NEEDED) */
 	if (Waveform())
@@ -1146,8 +1146,9 @@ void Clip::apply_keyframes(std::shared_ptr<Frame> frame, int width, int height)
 		int alpha = wave_color.alpha.GetInt(frame->number);
 
 		// Generate Waveform Dynamically (the size of the timeline)
-		source_image = frame->GetWaveform(width, height, red, green, blue, alpha);
-		frame->AddImage(std::shared_ptr<QImage>(source_image));
+		auto wave_image = frame->GetWaveform(width, height, red, green, blue, alpha);
+		frame->AddImage(wave_image);
+		source_image.swap(wave_image);
 	}
 
 	/* RESIZE SOURCE IMAGE - based on scale type */


### PR DESCRIPTION
Hey, I loves me a good bit-banging as much as the next guy.

(OK, that's a lie, I completely hate it and feel like, if we're fiddling with the raw, individual bits of an image, we're way too low-level and should be using better APIs or support classes.)

But I _especially_ can't countenance `openshot::Clip()` _manually applying_ alpha transparency in a `for()` loop, immediately before it uses `QPainter` to draw the resulting image... when **`QPainter` _has_ a `.setOpacity()` method!!**

...So let's just use that, why don't we?

**Edit:** Also, I finally figured out what that one Codacy message was complaining about, with the `source_image` in `Clip::apply_keyframes`. (We were double-encapsulating the waveform `QImage` in a `std::shared_ptr`.) Fixed.