### PR TITLE
Huge performance improvements (43% faster FFmpegReader, 34% faster Timeline)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,6 @@
 .project
 .cproject
 /.metadata/
+cmake-build-debug/*
 tags
 *~
-

--- a/examples/Example.cpp
+++ b/examples/Example.cpp
@@ -39,51 +39,52 @@ using namespace openshot;
 
 int main(int argc, char* argv[]) {
 
-    Settings *s = Settings::Instance();
-    s->HARDWARE_DECODER = 2; // 1 VA-API, 2 NVDEC, 6 VDPAU
-    s->HW_DE_DEVICE_SET = 0;
+    // Types for storing time durations in whole and fractional milliseconds
+    using ms = std::chrono::milliseconds;
+    using s = std::chrono::seconds;
+    using double_ms = std::chrono::duration<double, ms::period>;
 
-    std::string input_filepath = TEST_MEDIA_PATH;
-    input_filepath += "sintel_trailer-720p.mp4";
+    // Track total time
+    const auto total_time = double_ms(0.0);
 
-    FFmpegReader r9(input_filepath);
+    // FFmpeg Reader performance test
+    const auto total_1 = std::chrono::high_resolution_clock::now();
+    FFmpegReader r9("/home/jonathan/Videos/sintel_trailer-1080p.mp4");
     r9.Open();
-    r9.DisplayInfo();
-
-    /* WRITER ---------------- */
-    FFmpegWriter w9("metadata.mp4");
-
-    // Set options
-    w9.SetAudioOptions(true, "libmp3lame", r9.info.sample_rate, r9.info.channels, r9.info.channel_layout, 128000);
-    w9.SetVideoOptions(true, "libx264", r9.info.fps, 1024, 576, Fraction(1,1), false, false, 3000000);
-
-    w9.info.metadata["title"] = "testtest";
-	w9.info.metadata["artist"] = "aaa";
-	w9.info.metadata["album"] = "bbb";
-	w9.info.metadata["year"] = "2015";
-	w9.info.metadata["description"] = "ddd";
-	w9.info.metadata["comment"] = "eee";
-	w9.info.metadata["comment"] = "comment";
-    w9.info.metadata["copyright"] = "copyright OpenShot!";
-
-    // Open writer
-    w9.Open();
-
-    for (long int frame = 1; frame <= 100; frame++)
+    for (long int frame = 1; frame <= 1000; frame++)
     {
-        //int frame_number = (rand() % 750) + 1;
-        int frame_number = frame;
-        std::shared_ptr<Frame> f = r9.GetFrame(frame_number);
-        w9.WriteFrame(f);
+        const auto time1 = std::chrono::high_resolution_clock::now();
+        std::shared_ptr<Frame> f = r9.GetFrame(frame);
+        const auto time2 = std::chrono::high_resolution_clock::now();
+        std::cout << "FFmpegReader: " << frame << " (" << double_ms(time2 - time1).count() << " ms)" << std::endl;
     }
-
-    // Close writer & reader
-    w9.Close();
-
-    // Close timeline
+    const auto total_2 = std::chrono::high_resolution_clock::now();
+    auto total_sec = std::chrono::duration_cast<ms>(total_2 - total_1);
+    std::cout << "FFmpegReader TOTAL: " << total_sec.count() << " ms" << std::endl;
     r9.Close();
 
-	std::cout << "Completed successfully!" << std::endl;
+
+
+    // Timeline Reader performance test
+    Timeline tm(r9.info.width, r9.info.height, r9.info.fps, r9.info.sample_rate, r9.info.channels, r9.info.channel_layout);
+    Clip *c = new Clip(&r9);
+    tm.AddClip(c);
+    tm.Open();
+
+    const auto total_3 = std::chrono::high_resolution_clock::now();
+    for (long int frame = 1; frame <= 1000; frame++)
+    {
+        const auto time1 = std::chrono::high_resolution_clock::now();
+        std::shared_ptr<Frame> f = tm.GetFrame(frame);
+        const auto time2 = std::chrono::high_resolution_clock::now();
+        std::cout << "Timeline: " << frame << " (" << double_ms(time2 - time1).count() << " ms)" << std::endl;
+    }
+    const auto total_4 = std::chrono::high_resolution_clock::now();
+    total_sec = std::chrono::duration_cast<ms>(total_4 - total_3);
+    std::cout << "Timeline TOTAL: " << total_sec.count() << " ms" << std::endl;
+    tm.Close();
+
+    std::cout << "Completed successfully!" << std::endl;
 
     return 0;
 }

--- a/examples/Example.cpp
+++ b/examples/Example.cpp
@@ -44,9 +44,6 @@ int main(int argc, char* argv[]) {
     using s = std::chrono::seconds;
     using double_ms = std::chrono::duration<double, ms::period>;
 
-    // Track total time
-    const auto total_time = double_ms(0.0);
-
     // FFmpeg Reader performance test
     const auto total_1 = std::chrono::high_resolution_clock::now();
     FFmpegReader r9("/home/jonathan/Videos/sintel_trailer-1080p.mp4");
@@ -62,7 +59,6 @@ int main(int argc, char* argv[]) {
     auto total_sec = std::chrono::duration_cast<ms>(total_2 - total_1);
     std::cout << "FFmpegReader TOTAL: " << total_sec.count() << " ms" << std::endl;
     r9.Close();
-
 
 
     // Timeline Reader performance test

--- a/examples/qt-demo/main.cpp
+++ b/examples/qt-demo/main.cpp
@@ -29,11 +29,16 @@
  */
 
 #include "Qt/PlayerDemo.h"
-
+#include "ZmqLogger.h"
 #include <QApplication>
 
 int main(int argc, char *argv[])
 {
+    // Enable logging for openshot-player since this is primarily used for
+    // profiling and debugging video playback issues.
+    openshot::ZmqLogger::Instance()->Enable(true);
+    openshot::ZmqLogger::Instance()->Path("./player.log");
+
     QApplication app(argc, argv);
     PlayerDemo demo;
     demo.show();

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -35,8 +35,8 @@ if (POLICY CMP0057)
 endif()
 
 ###############  PROFILING  #################
-#set(PROFILER "/usr/lib//usr/lib/libprofiler.so.0.4.5")
-#set(PROFILER "/usr/lib/libtcmalloc.so.4")
+#set(PROFILER "/usr/lib/x86_64-linux-gnu/libprofiler.so.0")
+#set(PROFILER "/usr/lib/x86_64-linux-gnu/libtcmalloc.so.4")
 
 if(CMAKE_VERSION VERSION_LESS 3.3)
   # IWYU wasn't supported internally in 3.2

--- a/src/Clip.cpp
+++ b/src/Clip.cpp
@@ -354,18 +354,6 @@ std::shared_ptr<Frame> Clip::GetFrame(std::shared_ptr<openshot::Frame> backgroun
 		// Adjust out of bounds frame number
 		frame_number = adjust_frame_number_minimum(frame_number);
 
-		// Adjust has_video and has_audio overrides
-		int enabled_audio = has_audio.GetInt(frame_number);
-		if (enabled_audio == -1 && reader && reader->info.has_audio)
-			enabled_audio = 1;
-		else if (enabled_audio == -1 && reader && !reader->info.has_audio)
-			enabled_audio = 0;
-		int enabled_video = has_video.GetInt(frame_number);
-		if (enabled_video == -1 && reader && reader->info.has_video)
-			enabled_video = 1;
-		else if (enabled_video == -1 && reader && !reader->info.has_video)
-			enabled_video = 0;
-
 		// Is a time map detected
 		int64_t new_frame_number = frame_number;
 		int64_t time_mapped_number = adjust_frame_number_minimum(time.GetLong(frame_number));
@@ -381,19 +369,6 @@ std::shared_ptr<Frame> Clip::GetFrame(std::shared_ptr<openshot::Frame> backgroun
 
 		// Apply effects to the frame (if any)
 		apply_effects(original_frame);
-
-		// Determine size of image (from Timeline or Reader)
-		int width = 0;
-		int height = 0;
-		if (timeline) {
-			// Use timeline size (if available)
-			width = timeline->preview_width;
-			height = timeline->preview_height;
-		} else {
-			// Fallback to clip size
-			width = reader->info.width;
-			height = reader->info.height;
-		}
 
 		// Apply keyframe / transforms
 		apply_keyframes(original_frame, background_frame->GetImage());

--- a/src/Clip.h
+++ b/src/Clip.h
@@ -139,8 +139,11 @@ namespace openshot {
 		/// Apply effects to the source frame (if any)
 		void apply_effects(std::shared_ptr<openshot::Frame> frame);
 
-		/// Apply keyframes to the source frame (if any)
-		void apply_keyframes(std::shared_ptr<openshot::Frame> frame, int width, int height);
+        /// Apply keyframes to an openshot::Frame and use an existing QImage as a background image (if any)
+        void apply_keyframes(std::shared_ptr<Frame> frame, std::shared_ptr<QImage> background_canvas);
+
+        /// Get QTransform from keyframes
+        QTransform get_transform(std::shared_ptr<Frame> frame, int width, int height);
 
 		/// Get file extension
 		std::string get_file_extension(std::string path);
@@ -226,9 +229,9 @@ namespace openshot {
 		/// rendered.
 		///
 		/// @returns The modified openshot::Frame object
-		/// @param frame This is ignored on Clip, due to caching optimizations. This frame instance is clobbered with the source frame.
+		/// @param background_frame The frame object to use as a background canvas (i.e. an existing Timeline openshot::Frame instance)
 		/// @param frame_number The frame number (starting at 1) of the clip or effect on the timeline.
-		std::shared_ptr<openshot::Frame> GetFrame(std::shared_ptr<openshot::Frame> frame, int64_t frame_number) override;
+		std::shared_ptr<openshot::Frame> GetFrame(std::shared_ptr<openshot::Frame> background_frame, int64_t frame_number);
 
 		/// Open the internal reader
 		void Open() override;

--- a/src/Clip.h
+++ b/src/Clip.h
@@ -192,8 +192,8 @@ namespace openshot {
 		/// Destructor
 		virtual ~Clip();
 
-		/// Get the cache object used by this clip
-		CacheMemory* GetCache() override { return &cache; };
+        /// Get the cache object (always return NULL for this reader)
+        openshot::CacheMemory* GetCache() override { return NULL; };
 
 		/// Determine if reader is open or closed
 		bool IsOpen() override { return is_open; };

--- a/src/ClipBase.h
+++ b/src/ClipBase.h
@@ -95,11 +95,11 @@ namespace openshot {
 		/// @brief This method is required for all derived classes of ClipBase, and returns a
 		/// modified openshot::Frame object
 		///
-		/// The frame object is passed into this method and used as a starting point (pixels and audio).
+		/// The frame object is passed into this method and used as a starting point / background (pixels).
 		/// All Clip keyframes and effects are resolved into pixels.
 		///
 		/// @returns The modified openshot::Frame object
-		/// @param frame The frame object that needs the clip or effect applied to it
+		/// @param frame This is ignored on Clip, due to caching optimizations. This frame instance is clobbered with the source frame.
 		/// @param frame_number The frame number (starting at 1) of the clip or effect on the timeline.
 		virtual std::shared_ptr<openshot::Frame> GetFrame(std::shared_ptr<openshot::Frame> frame, int64_t frame_number) = 0;
 

--- a/src/FFmpegReader.cpp
+++ b/src/FFmpegReader.cpp
@@ -1244,7 +1244,6 @@ void FFmpegReader::ProcessVideoPacket(int64_t requested_frame) {
 
 	// Create variables for a RGB Frame (since most videos are not in RGB, we must convert it)
 	AVFrame *pFrameRGB = NULL;
-	int numBytes;
 	uint8_t *buffer = NULL;
 
 	// Allocate an AVFrame structure
@@ -1318,7 +1317,6 @@ void FFmpegReader::ProcessVideoPacket(int64_t requested_frame) {
 	}
 
 	// Determine required buffer size and allocate buffer
-	numBytes = AV_GET_IMAGE_SIZE(PIX_FMT_RGBA, width, height);
 	const int bytes_per_pixel = 4;
 	int buffer_size = width * height * bytes_per_pixel;
 	buffer = new unsigned char[buffer_size]();
@@ -2169,7 +2167,7 @@ void FFmpegReader::CheckWorkingFrames(bool end_of_stream, int64_t requested_fram
 			break;
 
 		// Remove frames which are too old
-		if (f && f->number < (requested_frame - (max_concurrent_frames * 2))) {
+		if (f->number < (requested_frame - (max_concurrent_frames * 2))) {
 			working_cache.Remove(f->number);
 		}
 

--- a/src/FFmpegReader.cpp
+++ b/src/FFmpegReader.cpp
@@ -95,12 +95,6 @@ FFmpegReader::FFmpegReader(const std::string& path, bool inspect_reader)
 		  current_video_frame(0), has_missing_frames(false), num_packets_since_video_frame(0), num_checks_since_final(0),
 		  packet(NULL), max_concurrent_frames(OPEN_MP_NUM_PROCESSORS) {
 
-	// Configure OpenMP parallelism
-	// Default number of threads per section
-	omp_set_num_threads(max_concurrent_frames);
-	// Allow nested parallel sections as deeply as supported
-	omp_set_max_active_levels(OPEN_MP_MAX_ACTIVE);
-
 	// Initialize FFMpeg, and register all formats and codecs
 	AV_REGISTER_ALL
 	AVCODEC_REGISTER_ALL
@@ -847,47 +841,44 @@ std::shared_ptr<Frame> FFmpegReader::GetFrame(int64_t requested_frame) {
 		// Return the cached frame
 		return frame;
 	} else {
-#pragma omp critical (ReadStream)
-		{
-			// Check the cache a 2nd time (due to a potential previous lock)
-			frame = final_cache.GetFrame(requested_frame);
-			if (frame) {
-				// Debug output
-				ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::GetFrame", "returned cached frame on 2nd look", requested_frame);
+        // Check the cache a 2nd time (due to a potential previous lock)
+        frame = final_cache.GetFrame(requested_frame);
+        if (frame) {
+            // Debug output
+            ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::GetFrame", "returned cached frame on 2nd look", requested_frame);
 
-				// Return the cached frame
-			} else {
-				// Frame is not in cache
-				// Reset seek count
-				seek_count = 0;
+            // Return the cached frame
+        } else {
+            // Frame is not in cache
+            // Reset seek count
+            seek_count = 0;
 
-				// Check for first frame (always need to get frame 1 before other frames, to correctly calculate offsets)
-				if (last_frame == 0 && requested_frame != 1)
-					// Get first frame
-					ReadStream(1);
+            // Check for first frame (always need to get frame 1 before other frames, to correctly calculate offsets)
+            if (last_frame == 0 && requested_frame != 1)
+                // Get first frame
+                ReadStream(1);
 
-				// Are we within X frames of the requested frame?
-				int64_t diff = requested_frame - last_frame;
-				if (diff >= 1 && diff <= 20) {
-					// Continue walking the stream
-					frame = ReadStream(requested_frame);
-				} else {
-					// Greater than 30 frames away, or backwards, we need to seek to the nearest key frame
-					if (enable_seek)
-						// Only seek if enabled
-						Seek(requested_frame);
+            // Are we within X frames of the requested frame?
+            int64_t diff = requested_frame - last_frame;
+            if (diff >= 1 && diff <= 20) {
+                // Continue walking the stream
+                frame = ReadStream(requested_frame);
+            } else {
+                // Greater than 30 frames away, or backwards, we need to seek to the nearest key frame
+                if (enable_seek)
+                    // Only seek if enabled
+                    Seek(requested_frame);
 
-					else if (!enable_seek && diff < 0) {
-						// Start over, since we can't seek, and the requested frame is smaller than our position
-						Close();
-						Open();
-					}
+                else if (!enable_seek && diff < 0) {
+                    // Start over, since we can't seek, and the requested frame is smaller than our position
+                    Close();
+                    Open();
+                }
 
-					// Then continue walking the stream
-					frame = ReadStream(requested_frame);
-				}
-			}
-		} //omp critical
+                // Then continue walking the stream
+                frame = ReadStream(requested_frame);
+            }
+        }
 		return frame;
 	}
 }
@@ -902,141 +893,129 @@ std::shared_ptr<Frame> FFmpegReader::ReadStream(int64_t requested_frame) {
 
 	// Minimum number of packets to process (for performance reasons)
 	int packets_processed = 0;
-	int minimum_packets = max_concurrent_frames;
+	int minimum_packets = 1;
 	int max_packets = 4096;
 
 	// Debug output
 	ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::ReadStream", "requested_frame", requested_frame, "max_concurrent_frames", max_concurrent_frames);
 
-#pragma omp parallel
-	{
-#pragma omp single
+	// Loop through the stream until the correct frame is found
+	while (true) {
+		// Get the next packet into a local variable called packet
+		packet_error = GetNextPacket();
+
+		int processing_video_frames_size = 0;
+		int processing_audio_frames_size = 0;
 		{
-			// Loop through the stream until the correct frame is found
-			while (true) {
-				// Get the next packet into a local variable called packet
-				packet_error = GetNextPacket();
+			const GenericScopedLock <CriticalSection> lock(processingCriticalSection);
+			processing_video_frames_size = processing_video_frames.size();
+			processing_audio_frames_size = processing_audio_frames.size();
+		}
 
-				int processing_video_frames_size = 0;
-				int processing_audio_frames_size = 0;
-				{
-					const GenericScopedLock <CriticalSection> lock(processingCriticalSection);
-					processing_video_frames_size = processing_video_frames.size();
-					processing_audio_frames_size = processing_audio_frames.size();
-				}
+		// Wait if too many frames are being processed
+		while (processing_video_frames_size + processing_audio_frames_size >= minimum_packets) {
+			std::this_thread::sleep_for(std::chrono::milliseconds(3));
+			const GenericScopedLock <CriticalSection> lock(processingCriticalSection);
+			processing_video_frames_size = processing_video_frames.size();
+			processing_audio_frames_size = processing_audio_frames.size();
+		}
 
-				// Wait if too many frames are being processed
-				while (processing_video_frames_size + processing_audio_frames_size >= minimum_packets) {
-					std::this_thread::sleep_for(std::chrono::milliseconds(3));
-					const GenericScopedLock <CriticalSection> lock(processingCriticalSection);
-					processing_video_frames_size = processing_video_frames.size();
-					processing_audio_frames_size = processing_audio_frames.size();
-				}
+		// Get the next packet (if any)
+		if (packet_error < 0) {
+			// Break loop when no more packets found
+			end_of_stream = true;
+			break;
+		}
 
-				// Get the next packet (if any)
-				if (packet_error < 0) {
-					// Break loop when no more packets found
-					end_of_stream = true;
-					break;
-				}
+		// Debug output
+		ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::ReadStream (GetNextPacket)", "requested_frame", requested_frame, "processing_video_frames_size", processing_video_frames_size, "processing_audio_frames_size", processing_audio_frames_size, "minimum_packets", minimum_packets, "packets_processed", packets_processed, "is_seeking", is_seeking);
 
-				// Debug output
-				ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::ReadStream (GetNextPacket)", "requested_frame", requested_frame, "processing_video_frames_size", processing_video_frames_size, "processing_audio_frames_size", processing_audio_frames_size, "minimum_packets", minimum_packets, "packets_processed", packets_processed, "is_seeking", is_seeking);
+		// Video packet
+		if (info.has_video && packet->stream_index == videoStream) {
+			// Reset this counter, since we have a video packet
+			num_packets_since_video_frame = 0;
 
-				// Video packet
-				if (info.has_video && packet->stream_index == videoStream) {
-					// Reset this counter, since we have a video packet
-					num_packets_since_video_frame = 0;
+			// Check the status of a seek (if any)
+			if (is_seeking) {
+				check_seek = CheckSeek(true);
+			} else {
+				check_seek = false;
+			}
 
-					// Check the status of a seek (if any)
-					if (is_seeking)
-#pragma omp critical (openshot_seek)
-						check_seek = CheckSeek(true);
-					else
-						check_seek = false;
+			if (check_seek) {
+				// Jump to the next iteration of this loop
+				continue;
+			}
 
-					if (check_seek) {
-						// Jump to the next iteration of this loop
-						continue;
-					}
+			// Packet may become NULL on Close inside Seek if CheckSeek returns false
+			if (!packet) {
+				// Jump to the next iteration of this loop
+				continue;
+			}
 
-					// Packet may become NULL on Close inside Seek if CheckSeek returns false
-					if (!packet)
-						// Jump to the next iteration of this loop
-						continue;
+			// Get the AVFrame from the current packet
+			frame_finished = GetAVFrame();
 
-					// Get the AVFrame from the current packet
-					frame_finished = GetAVFrame();
+			// Check if the AVFrame is finished and set it
+			if (frame_finished) {
+				// Update PTS / Frame Offset (if any)
+				UpdatePTSOffset(true);
 
-					// Check if the AVFrame is finished and set it
-					if (frame_finished) {
-						// Update PTS / Frame Offset (if any)
-						UpdatePTSOffset(true);
+				// Process Video Packet
+				ProcessVideoPacket(requested_frame);
+			}
 
-						// Process Video Packet
-						ProcessVideoPacket(requested_frame);
+		}
+			// Audio packet
+		else if (info.has_audio && packet->stream_index == audioStream) {
+			// Increment this (to track # of packets since the last video packet)
+			num_packets_since_video_frame++;
 
-						if (openshot::Settings::Instance()->WAIT_FOR_VIDEO_PROCESSING_TASK) {
-							// Wait on each OMP task to complete before moving on to the next one. This slows
-							// down processing considerably, but might be more stable on some systems.
-#pragma omp taskwait
-						}
-					}
+			// Check the status of a seek (if any)
+			if (is_seeking) {
+				check_seek = CheckSeek(false);
+			} else {
+				check_seek = false;
+			}
 
-				}
-				// Audio packet
-				else if (info.has_audio && packet->stream_index == audioStream) {
-					// Increment this (to track # of packets since the last video packet)
-					num_packets_since_video_frame++;
+			if (check_seek) {
+				// Jump to the next iteration of this loop
+				continue;
+			}
 
-					// Check the status of a seek (if any)
-					if (is_seeking)
-#pragma omp critical (openshot_seek)
-						check_seek = CheckSeek(false);
-					else
-						check_seek = false;
+			// Packet may become NULL on Close inside Seek if CheckSeek returns false
+			if (!packet) {
+				// Jump to the next iteration of this loop
+				continue;
+			}
 
-					if (check_seek) {
-						// Jump to the next iteration of this loop
-						continue;
-					}
+			// Update PTS / Frame Offset (if any)
+			UpdatePTSOffset(false);
 
-					// Packet may become NULL on Close inside Seek if CheckSeek returns false
-					if (!packet)
-						// Jump to the next iteration of this loop
-						continue;
+			// Determine related video frame and starting sample # from audio PTS
+			AudioLocation location = GetAudioPTSLocation(packet->pts);
 
-					// Update PTS / Frame Offset (if any)
-					UpdatePTSOffset(false);
+			// Process Audio Packet
+			ProcessAudioPacket(requested_frame, location.frame, location.sample_start);
+		}
 
-					// Determine related video frame and starting sample # from audio PTS
-					AudioLocation location = GetAudioPTSLocation(packet->pts);
+		// Check if working frames are 'finished'
+		if (!is_seeking) {
+			// Check for final frames
+			CheckWorkingFrames(false, requested_frame);
+		}
 
-					// Process Audio Packet
-					ProcessAudioPacket(requested_frame, location.frame, location.sample_start);
-				}
+		// Check if requested 'final' frame is available
+		bool is_cache_found = (final_cache.GetFrame(requested_frame) != NULL);
 
-				// Check if working frames are 'finished'
-				if (!is_seeking) {
-					// Check for final frames
-					CheckWorkingFrames(false, requested_frame);
-				}
+		// Increment frames processed
+		packets_processed++;
 
-				// Check if requested 'final' frame is available
-				bool is_cache_found = (final_cache.GetFrame(requested_frame) != NULL);
+		// Break once the frame is found
+		if ((is_cache_found && packets_processed >= minimum_packets) || packets_processed > max_packets)
+			break;
 
-				// Increment frames processed
-				packets_processed++;
-
-				// Break once the frame is found
-				if ((is_cache_found && packets_processed >= minimum_packets) || packets_processed > max_packets)
-					break;
-
-			} // end while
-
-		} // end omp single
-
-	} // end omp parallel
+	} // end while
 
 	// Debug output
 	ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::ReadStream (Completed)", "packets_processed", packets_processed, "end_of_stream", end_of_stream, "largest_frame_processed", largest_frame_processed, "Working Cache Count", working_cache.Count());
@@ -1072,24 +1051,19 @@ std::shared_ptr<Frame> FFmpegReader::ReadStream(int64_t requested_frame) {
 int FFmpegReader::GetNextPacket() {
 	int found_packet = 0;
 	AVPacket *next_packet;
-#pragma omp critical(getnextpacket)
-	{
-		next_packet = new AVPacket();
-		found_packet = av_read_frame(pFormatCtx, next_packet);
+	next_packet = new AVPacket();
+	found_packet = av_read_frame(pFormatCtx, next_packet);
 
-
-		if (packet) {
-			// Remove previous packet before getting next one
-			RemoveAVPacket(packet);
-			packet = NULL;
-		}
-
-		if (found_packet >= 0) {
-			// Update current packet pointer
-			packet = next_packet;
-		}
-        else
-            delete next_packet;
+	if (packet) {
+		// Remove previous packet before getting next one
+		RemoveAVPacket(packet);
+		packet = NULL;
+	}
+	if (found_packet >= 0) {
+		// Update current packet pointer
+		packet = next_packet;
+	} else {
+		delete next_packet;
 	}
 	// Return if packet was found (or error number)
 	return found_packet;
@@ -1102,12 +1076,10 @@ bool FFmpegReader::GetAVFrame() {
 
 	// Decode video frame
 	AVFrame *next_frame = AV_ALLOCATE_FRAME();
-#pragma omp critical (packet_cache)
-	{
-#if IS_FFMPEG_3_2
-		frameFinished = 0;
 
-		ret = avcodec_send_packet(pCodecCtx, packet);
+#if IS_FFMPEG_3_2
+	frameFinished = 0;
+	ret = avcodec_send_packet(pCodecCtx, packet);
 
 	#if HAVE_HW_ACCEL
 		// Get the format from the variables set in get_hw_dec_format
@@ -1186,7 +1158,6 @@ bool FFmpegReader::GetAVFrame() {
 							info.height);
 		}
 #endif // IS_FFMPEG_3_2
-	}
 
 	// deallocate the frame
 	AV_FREE_FRAME(&next_frame);
@@ -1271,142 +1242,135 @@ void FFmpegReader::ProcessVideoPacket(int64_t requested_frame) {
 	const GenericScopedLock <CriticalSection> lock(processingCriticalSection);
 	processing_video_frames[current_frame] = current_frame;
 
-#pragma omp task firstprivate(current_frame, my_frame, height, width, video_length, pix_fmt)
-	{
-		// Create variables for a RGB Frame (since most videos are not in RGB, we must convert it)
-		AVFrame *pFrameRGB = NULL;
-		int numBytes;
-		uint8_t *buffer = NULL;
+	// Create variables for a RGB Frame (since most videos are not in RGB, we must convert it)
+	AVFrame *pFrameRGB = NULL;
+	int numBytes;
+	uint8_t *buffer = NULL;
 
-		// Allocate an AVFrame structure
-		pFrameRGB = AV_ALLOCATE_FRAME();
-		if (pFrameRGB == NULL)
-			throw OutOfBoundsFrame("Convert Image Broke!", current_frame, video_length);
+	// Allocate an AVFrame structure
+	pFrameRGB = AV_ALLOCATE_FRAME();
+	if (pFrameRGB == NULL)
+		throw OutOfBoundsFrame("Convert Image Broke!", current_frame, video_length);
 
-		// Determine the max size of this source image (based on the timeline's size, the scaling mode,
-		// and the scaling keyframes). This is a performance improvement, to keep the images as small as possible,
-		// without losing quality. NOTE: We cannot go smaller than the timeline itself, or the add_layer timeline
-		// method will scale it back to timeline size before scaling it smaller again. This needs to be fixed in
-		// the future.
-		int max_width = info.width;
-		int max_height = info.height;
+	// Determine the max size of this source image (based on the timeline's size, the scaling mode,
+	// and the scaling keyframes). This is a performance improvement, to keep the images as small as possible,
+	// without losing quality. NOTE: We cannot go smaller than the timeline itself, or the add_layer timeline
+	// method will scale it back to timeline size before scaling it smaller again. This needs to be fixed in
+	// the future.
+	int max_width = info.width;
+	int max_height = info.height;
 
-		Clip *parent = (Clip *) ParentClip();
-		if (parent) {
-			if (parent->ParentTimeline()) {
-				// Set max width/height based on parent clip's timeline (if attached to a timeline)
-				max_width = parent->ParentTimeline()->preview_width;
-				max_height = parent->ParentTimeline()->preview_height;
-			}
-			if (parent->scale == SCALE_FIT || parent->scale == SCALE_STRETCH) {
-				// Best fit or Stretch scaling (based on max timeline size * scaling keyframes)
-				float max_scale_x = parent->scale_x.GetMaxPoint().co.Y;
-				float max_scale_y = parent->scale_y.GetMaxPoint().co.Y;
-				max_width = std::max(float(max_width), max_width * max_scale_x);
-				max_height = std::max(float(max_height), max_height * max_scale_y);
+	Clip *parent = (Clip *) ParentClip();
+	if (parent) {
+		if (parent->ParentTimeline()) {
+			// Set max width/height based on parent clip's timeline (if attached to a timeline)
+			max_width = parent->ParentTimeline()->preview_width;
+			max_height = parent->ParentTimeline()->preview_height;
+		}
+		if (parent->scale == SCALE_FIT || parent->scale == SCALE_STRETCH) {
+			// Best fit or Stretch scaling (based on max timeline size * scaling keyframes)
+			float max_scale_x = parent->scale_x.GetMaxPoint().co.Y;
+			float max_scale_y = parent->scale_y.GetMaxPoint().co.Y;
+			max_width = std::max(float(max_width), max_width * max_scale_x);
+			max_height = std::max(float(max_height), max_height * max_scale_y);
 
-			} else if (parent->scale == SCALE_CROP) {
-				// Cropping scale mode (based on max timeline size * cropped size * scaling keyframes)
-				float max_scale_x = parent->scale_x.GetMaxPoint().co.Y;
-				float max_scale_y = parent->scale_y.GetMaxPoint().co.Y;
-				QSize width_size(max_width * max_scale_x,
-								 round(max_width / (float(info.width) / float(info.height))));
-				QSize height_size(round(max_height / (float(info.height) / float(info.width))),
-								  max_height * max_scale_y);
-				// respect aspect ratio
-				if (width_size.width() >= max_width && width_size.height() >= max_height) {
-					max_width = std::max(max_width, width_size.width());
-					max_height = std::max(max_height, width_size.height());
-				} else {
-					max_width = std::max(max_width, height_size.width());
-					max_height = std::max(max_height, height_size.height());
-				}
-
+		} else if (parent->scale == SCALE_CROP) {
+			// Cropping scale mode (based on max timeline size * cropped size * scaling keyframes)
+			float max_scale_x = parent->scale_x.GetMaxPoint().co.Y;
+			float max_scale_y = parent->scale_y.GetMaxPoint().co.Y;
+			QSize width_size(max_width * max_scale_x,
+							 round(max_width / (float(info.width) / float(info.height))));
+			QSize height_size(round(max_height / (float(info.height) / float(info.width))),
+							  max_height * max_scale_y);
+			// respect aspect ratio
+			if (width_size.width() >= max_width && width_size.height() >= max_height) {
+				max_width = std::max(max_width, width_size.width());
+				max_height = std::max(max_height, width_size.height());
 			} else {
-				// No scaling, use original image size (slower)
-				max_width = info.width;
-				max_height = info.height;
+				max_width = std::max(max_width, height_size.width());
+				max_height = std::max(max_height, height_size.height());
 			}
-		}
 
-		// Determine if image needs to be scaled (for performance reasons)
-		int original_height = height;
-		if (max_width != 0 && max_height != 0 && max_width < width && max_height < height) {
-			// Override width and height (but maintain aspect ratio)
-			float ratio = float(width) / float(height);
-			int possible_width = round(max_height * ratio);
-			int possible_height = round(max_width / ratio);
-
-			if (possible_width <= max_width) {
-				// use calculated width, and max_height
-				width = possible_width;
-				height = max_height;
-			} else {
-				// use max_width, and calculated height
-				width = max_width;
-				height = possible_height;
-			}
-		}
-
-		// Determine required buffer size and allocate buffer
-		numBytes = AV_GET_IMAGE_SIZE(PIX_FMT_RGBA, width, height);
-
-#pragma omp critical (video_buffer)
-		buffer = (uint8_t *) av_malloc(numBytes * sizeof(uint8_t));
-
-		// Copy picture data from one AVFrame (or AVPicture) to another one.
-		AV_COPY_PICTURE_DATA(pFrameRGB, buffer, PIX_FMT_RGBA, width, height);
-
-		int scale_mode = SWS_FAST_BILINEAR;
-		if (openshot::Settings::Instance()->HIGH_QUALITY_SCALING) {
-			scale_mode = SWS_BICUBIC;
-		}
-		SwsContext *img_convert_ctx = sws_getContext(info.width, info.height, AV_GET_CODEC_PIXEL_FORMAT(pStream, pCodecCtx), width,
-															  height, PIX_FMT_RGBA, scale_mode, NULL, NULL, NULL);
-
-		// Resize / Convert to RGB
-		sws_scale(img_convert_ctx, my_frame->data, my_frame->linesize, 0,
-				  original_height, pFrameRGB->data, pFrameRGB->linesize);
-
-		// Create or get the existing frame object
-		std::shared_ptr<Frame> f = CreateFrame(current_frame);
-
-		// Add Image data to frame
-		if (!ffmpeg_has_alpha(AV_GET_CODEC_PIXEL_FORMAT(pStream, pCodecCtx))) {
-			// Add image with no alpha channel, Speed optimization
-			f->AddImage(width, height, 4, QImage::Format_RGBA8888_Premultiplied, buffer);
 		} else {
-			// Add image with alpha channel (this will be converted to premultipled when needed, but is slower)
-			f->AddImage(width, height, 4, QImage::Format_RGBA8888, buffer);
+			// No scaling, use original image size (slower)
+			max_width = info.width;
+			max_height = info.height;
 		}
+	}
 
-		// Update working cache
-		working_cache.Add(f);
+	// Determine if image needs to be scaled (for performance reasons)
+	int original_height = height;
+	if (max_width != 0 && max_height != 0 && max_width < width && max_height < height) {
+		// Override width and height (but maintain aspect ratio)
+		float ratio = float(width) / float(height);
+		int possible_width = round(max_height * ratio);
+		int possible_height = round(max_width / ratio);
 
-		// Keep track of last last_video_frame
-#pragma omp critical (video_buffer)
-		last_video_frame = f;
-
-		// Free the RGB image
-		av_free(buffer);
-		AV_FREE_FRAME(&pFrameRGB);
-
-		// Remove frame and packet
-		RemoveAVFrame(my_frame);
-		sws_freeContext(img_convert_ctx);
-
-		// Remove video frame from list of processing video frames
-		{
-			const GenericScopedLock <CriticalSection> lock(processingCriticalSection);
-			processing_video_frames.erase(current_frame);
-			processed_video_frames[current_frame] = current_frame;
+		if (possible_width <= max_width) {
+			// use calculated width, and max_height
+			width = possible_width;
+			height = max_height;
+		} else {
+			// use max_width, and calculated height
+			width = max_width;
+			height = possible_height;
 		}
+	}
 
-		// Debug output
-		ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::ProcessVideoPacket (After)", "requested_frame", requested_frame, "current_frame", current_frame, "f->number", f->number);
+	// Determine required buffer size and allocate buffer
+	numBytes = AV_GET_IMAGE_SIZE(PIX_FMT_RGBA, width, height);
+	const int bytes_per_pixel = 4;
+	int buffer_size = width * height * bytes_per_pixel;
+	buffer = new unsigned char[buffer_size]();
 
-	} // end omp task
+	// Copy picture data from one AVFrame (or AVPicture) to another one.
+	AV_COPY_PICTURE_DATA(pFrameRGB, buffer, PIX_FMT_RGBA, width, height);
 
+	int scale_mode = SWS_FAST_BILINEAR;
+	if (openshot::Settings::Instance()->HIGH_QUALITY_SCALING) {
+		scale_mode = SWS_BICUBIC;
+	}
+	SwsContext *img_convert_ctx = sws_getContext(info.width, info.height, AV_GET_CODEC_PIXEL_FORMAT(pStream, pCodecCtx), width,
+												 height, PIX_FMT_RGBA, scale_mode, NULL, NULL, NULL);
+
+	// Resize / Convert to RGB
+	sws_scale(img_convert_ctx, my_frame->data, my_frame->linesize, 0,
+			  original_height, pFrameRGB->data, pFrameRGB->linesize);
+
+	// Create or get the existing frame object
+	std::shared_ptr<Frame> f = CreateFrame(current_frame);
+
+	// Add Image data to frame
+	if (!ffmpeg_has_alpha(AV_GET_CODEC_PIXEL_FORMAT(pStream, pCodecCtx))) {
+		// Add image with no alpha channel, Speed optimization
+		f->AddImage(width, height, bytes_per_pixel, QImage::Format_RGBA8888_Premultiplied, buffer);
+	} else {
+		// Add image with alpha channel (this will be converted to premultipled when needed, but is slower)
+		f->AddImage(width, height, bytes_per_pixel, QImage::Format_RGBA8888, buffer);
+	}
+
+	// Update working cache
+	working_cache.Add(f);
+
+	// Keep track of last last_video_frame
+	last_video_frame = f;
+
+	// Free the RGB image
+	AV_FREE_FRAME(&pFrameRGB);
+
+	// Remove frame and packet
+	RemoveAVFrame(my_frame);
+	sws_freeContext(img_convert_ctx);
+
+	// Remove video frame from list of processing video frames
+	{
+		const GenericScopedLock <CriticalSection> lock(processingCriticalSection);
+		processing_video_frames.erase(current_frame);
+		processed_video_frames[current_frame] = current_frame;
+	}
+
+	// Debug output
+	ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::ProcessVideoPacket (After)", "requested_frame", requested_frame, "current_frame", current_frame, "f->number", f->number);
 }
 
 // Process an audio packet
@@ -1435,8 +1399,6 @@ void FFmpegReader::ProcessAudioPacket(int64_t requested_frame, int64_t target_fr
 	int packet_samples = 0;
 	int data_size = 0;
 
-#pragma omp critical (ProcessAudioPacket)
-	{
 #if IS_FFMPEG_3_2
 		int ret = 0;
 		frame_finished = 1;
@@ -1467,7 +1429,6 @@ void FFmpegReader::ProcessAudioPacket(int64_t requested_frame, int64_t target_fr
 #else
 		int used = avcodec_decode_audio4(aCodecCtx, audio_frame, &frame_finished, packet);
 #endif
-	}
 
 	if (frame_finished) {
 
@@ -2416,13 +2377,10 @@ void FFmpegReader::RemoveAVFrame(AVFrame *remove_frame) {
 	// Remove pFrame (if exists)
 	if (remove_frame) {
 		// Free memory
-#pragma omp critical (packet_cache)
-		{
-			av_freep(&remove_frame->data[0]);
+		av_freep(&remove_frame->data[0]);
 #ifndef WIN32
-			AV_FREE_FRAME(&remove_frame);
+		AV_FREE_FRAME(&remove_frame);
 #endif
-		}
 	}
 }
 

--- a/src/FFmpegReader.h
+++ b/src/FFmpegReader.h
@@ -108,6 +108,7 @@ namespace openshot {
 		bool check_interlace;
 		bool check_fps;
 		bool has_missing_frames;
+		int max_concurrent_frames;
 
 		CacheMemory working_cache;
 		CacheMemory missing_frames;

--- a/src/Frame.cpp
+++ b/src/Frame.cpp
@@ -203,16 +203,8 @@ std::shared_ptr<QImage> Frame::GetWaveform(int width, int height, int Red, int G
 				float value = samples[sample] * 100.0;
 
 				// Append a line segment for each sample
-				if (value != 0.0) {
-					// LINE
-					lines.push_back(QPointF(X,Y));
-					lines.push_back(QPointF(X,Y-value));
-				}
-				else {
-					// DOT
-					lines.push_back(QPointF(X,Y));
-					lines.push_back(QPointF(X,Y));
-				}
+                lines.push_back(QPointF(X,Y+1.0));
+                lines.push_back(QPointF(X,(Y-value)+1.0));
 			}
 
 			// Add Channel Label Coordinate
@@ -235,7 +227,7 @@ std::shared_ptr<QImage> Frame::GetWaveform(int width, int height, int Red, int G
         QPen pen;
         pen.setColor(QColor(Red, Green, Blue, Alpha));
         pen.setWidthF(1.0);
-        pen.setStyle(Qt::NoPen);
+        pen.setStyle(Qt::SolidLine);
         painter.setPen(pen);
 
 		// Draw the waveform
@@ -244,7 +236,7 @@ std::shared_ptr<QImage> Frame::GetWaveform(int width, int height, int Red, int G
 
 		// Resize Image (if requested)
 		if (width != total_width || height != total_height) {
-			QImage scaled_wave_image = wave_image->scaled(width, height, Qt::IgnoreAspectRatio, Qt::FastTransformation);
+			QImage scaled_wave_image = wave_image->scaled(width, height, Qt::IgnoreAspectRatio, Qt::SmoothTransformation);
 			wave_image = std::make_shared<QImage>(scaled_wave_image);
 		}
 	}

--- a/src/Frame.cpp
+++ b/src/Frame.cpp
@@ -189,10 +189,10 @@ std::shared_ptr<QImage> Frame::GetWaveform(int width, int height, int Red, int G
 		int total_width = 0;
 
 		// Loop through each audio channel
-		int Y = 100;
+		float Y = 100.0;
 		for (int channel = 0; channel < audio->getNumChannels(); channel++)
 		{
-			int X = 0;
+			float X = 0.0;
 
 			// Get audio for this channel
 			const float *samples = audio->getReadPointer(channel);
@@ -200,7 +200,7 @@ std::shared_ptr<QImage> Frame::GetWaveform(int width, int height, int Red, int G
 			for (int sample = 0; sample < GetAudioSamplesCount(); sample++, X++)
 			{
 				// Sample value (scaled to -100 to 100)
-				float value = samples[sample] * 100;
+				float value = samples[sample] * 100.0;
 
 				// Append a line segment for each sample
 				if (value != 0.0) {
@@ -216,7 +216,7 @@ std::shared_ptr<QImage> Frame::GetWaveform(int width, int height, int Red, int G
 			}
 
 			// Add Channel Label Coordinate
-			labels.push_back(QPointF(5, Y - 5));
+			labels.push_back(QPointF(5.0, Y - 5.0));
 
 			// Increment Y
 			Y += (200 + height_padding);
@@ -232,20 +232,15 @@ std::shared_ptr<QImage> Frame::GetWaveform(int width, int height, int Red, int G
 		QPainter painter(wave_image.get());
 
 		// Set pen color
-		painter.setPen(QColor(Red, Green, Blue, Alpha));
+        QPen pen;
+        pen.setColor(QColor(Red, Green, Blue, Alpha));
+        pen.setWidthF(1.0);
+        pen.setStyle(Qt::NoPen);
+        painter.setPen(pen);
 
 		// Draw the waveform
 		painter.drawLines(lines);
 		painter.end();
-
-		// Loop through the channels labels (and draw the text)
-		// TODO: Configure Fonts in Qt5 correctly, so the drawText method does not crash
-//		painter.setFont(QFont(QString("Arial"), 16, 1, false));
-//		for (int channel = 0; channel < labels.size(); channel++) {
-//			stringstream label;
-//			label << "Channel " << channel;
-//		    painter.drawText(labels.at(channel), QString::fromStdString(label.str()));
-//		}
 
 		// Resize Image (if requested)
 		if (width != total_width || height != total_height) {

--- a/src/KeyFrame.cpp
+++ b/src/KeyFrame.cpp
@@ -97,6 +97,7 @@ namespace {
 		case CONSTANT: return left.co.Y;
 		case LINEAR: return InterpolateLinearCurve(left, right, target);
 		case BEZIER: return InterpolateBezierCurve(left, right, target, allowed_error);
+		default: return InterpolateLinearCurve(left, right, target);
 		}
 	}
 

--- a/src/Qt/VideoCacheThread.cpp
+++ b/src/Qt/VideoCacheThread.cpp
@@ -40,7 +40,7 @@ namespace openshot
 	// Constructor
 	VideoCacheThread::VideoCacheThread()
 	: Thread("video-cache"), speed(1), is_playing(false), position(1)
-	, reader(NULL), max_frames(std::min(OPEN_MP_NUM_PROCESSORS * 8, 64)), current_display_frame(1)
+	, reader(NULL), max_concurrent_frames(OPEN_MP_NUM_PROCESSORS * 4), current_display_frame(1)
     {
     }
 
@@ -98,13 +98,13 @@ namespace openshot
 			// Cache frames up to the max frames. Reset to current position
 			// if cache gets too far away from display frame. Cache frames
 			// even when player is paused (i.e. speed 0).
-			while (((position - current_display_frame) < max_frames) && is_playing)
+			while (((position - current_display_frame) < max_concurrent_frames) && is_playing)
 			{
-				// Only cache up till the max_frames amount... then sleep
+				// Only cache up till the max_concurrent_frames amount... then sleep
 				try
 				{
 					if (reader) {
-						ZmqLogger::Instance()->AppendDebugMethod("VideoCacheThread::run (cache frame)", "position", position, "current_display_frame", current_display_frame, "max_frames", max_frames, "needed_frames", (position - current_display_frame));
+						ZmqLogger::Instance()->AppendDebugMethod("VideoCacheThread::run (cache frame)", "position", position, "current_display_frame", current_display_frame, "max_concurrent_frames", max_concurrent_frames, "needed_frames", (position - current_display_frame));
 
 						// Force the frame to be generated
 						if (reader->GetCache()->GetSmallestFrame()) {

--- a/src/Qt/VideoCacheThread.h
+++ b/src/Qt/VideoCacheThread.h
@@ -54,7 +54,7 @@ namespace openshot
 	bool is_playing;
 	int64_t current_display_frame;
 	ReaderBase *reader;
-	int max_frames;
+	int max_concurrent_frames;
 
 	/// Constructor
 	VideoCacheThread();

--- a/src/QtPlayer.cpp
+++ b/src/QtPlayer.cpp
@@ -90,7 +90,23 @@ namespace openshot
     	FFmpegReader *ffreader = new FFmpegReader(source);
     	ffreader->DisplayInfo();
 
-    	reader = new Timeline(ffreader->info.width, ffreader->info.height, ffreader->info.fps, ffreader->info.sample_rate, ffreader->info.channels, ffreader->info.channel_layout);
+    	// Use default sample rate (or use the FFmpegReader's audio settings if any)
+    	int sample_rate = 44100;
+    	if (ffreader->info.sample_rate > 0)
+    	    sample_rate = ffreader->info.sample_rate;
+
+        // Use default channels (or use the FFmpegReader's audio settings if any)
+    	int channels = 2;
+    	if (ffreader->info.channels > 0)
+    	    channels = ffreader->info.channels;
+
+        // Use default channel layout (or use the FFmpegReader's audio settings if any)
+    	openshot::ChannelLayout channel_layout = openshot::LAYOUT_STEREO;
+    	if (channels != 2)
+            channel_layout = ffreader->info.channel_layout;
+
+    	// Create timeline instance (720p, since we have no re-scaling in this player yet)
+    	reader = new Timeline(1280, 720, ffreader->info.fps, sample_rate, channels, channel_layout);
     	Clip *c = new Clip(source);
 
     	Timeline* tm = (Timeline*)reader;

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -45,7 +45,6 @@ Settings *Settings::Instance()
 		m_pInstance = new Settings;
 		m_pInstance->HARDWARE_DECODER = 0;
 		m_pInstance->HIGH_QUALITY_SCALING = false;
-		m_pInstance->WAIT_FOR_VIDEO_PROCESSING_TASK = false;
 		m_pInstance->OMP_THREADS = 12;
 		m_pInstance->FF_THREADS = 8;
 		m_pInstance->DE_LIMIT_HEIGHT_MAX = 1100;

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -94,15 +94,6 @@ namespace openshot {
 		/// Scale mode used in FFmpeg decoding and encoding (used as an optimization for faster previews)
 		bool HIGH_QUALITY_SCALING = false;
 
-		/// Maximum width for image data (useful for optimzing for a smaller preview or render)
-		int MAX_WIDTH = 0;
-
-		/// Maximum height for image data (useful for optimzing for a smaller preview or render)
-		int MAX_HEIGHT = 0;
-
-		/// Wait for OpenMP task to finish before continuing (used to limit threads on slower systems)
-		bool WAIT_FOR_VIDEO_PROCESSING_TASK = false;
-
 		/// Number of threads of OpenMP
 		int OMP_THREADS = 12;
 

--- a/src/Timeline.cpp
+++ b/src/Timeline.cpp
@@ -726,7 +726,8 @@ std::shared_ptr<Frame> Timeline::GetFrame(int64_t requested_frame)
 		}
 
 		// Minimum number of frames to process (for performance reasons)
-		int minimum_frames = max_concurrent_frames;
+		// Too many causes stuttering, too few causes stuttering
+		int minimum_frames = std::min(max_concurrent_frames / 2, 4);
 
 		// Get a list of clips that intersect with the requested section of timeline
 		// This also opens the readers for intersecting clips, and marks non-intersecting clips as 'needs closing'

--- a/src/Timeline.cpp
+++ b/src/Timeline.cpp
@@ -1176,12 +1176,6 @@ void Timeline::apply_json_to_effects(Json::Value change, EffectBase* existing_ef
 
 			// Add Effect to Timeline
 			AddEffect(e);
-
-			// Clear cache on parent clip (if any)
-			Clip* parent_clip = (Clip*) e->ParentClip();
-			if (parent_clip && parent_clip->GetCache()) {
-				parent_clip->GetCache()->Clear();
-			}
 		}
 
 	} else if (change_type == "update") {
@@ -1193,12 +1187,6 @@ void Timeline::apply_json_to_effects(Json::Value change, EffectBase* existing_ef
 			int64_t old_starting_frame = (existing_effect->Position() * info.fps.ToDouble()) + 1;
 			int64_t old_ending_frame = ((existing_effect->Position() + existing_effect->Duration()) * info.fps.ToDouble()) + 1;
 			final_cache->Remove(old_starting_frame - 8, old_ending_frame + 8);
-
-			// Clear cache on parent clip (if any)
-			Clip* parent_clip = (Clip*) existing_effect->ParentClip();
-			if (parent_clip && parent_clip->GetCache()) {
-				parent_clip->GetCache()->Clear();
-			}
 
 			// Update effect properties from JSON
 			existing_effect->SetJsonValue(change["value"]);
@@ -1213,12 +1201,6 @@ void Timeline::apply_json_to_effects(Json::Value change, EffectBase* existing_ef
 			int64_t old_starting_frame = (existing_effect->Position() * info.fps.ToDouble()) + 1;
 			int64_t old_ending_frame = ((existing_effect->Position() + existing_effect->Duration()) * info.fps.ToDouble()) + 1;
 			final_cache->Remove(old_starting_frame - 8, old_ending_frame + 8);
-
-			// Clear cache on parent clip (if any)
-			Clip* parent_clip = (Clip*) existing_effect->ParentClip();
-			if (parent_clip && parent_clip->GetCache()) {
-				parent_clip->GetCache()->Clear();
-			}
 
 			// Remove effect from timeline
 			RemoveEffect(existing_effect);
@@ -1363,7 +1345,6 @@ void Timeline::ClearAllCache() {
     for (auto clip : clips)
     {
         // Clear cache on clip
-		clip->GetCache()->Clear();
         clip->Reader()->GetCache()->Clear();
 
         // Clear nested Reader (if any)

--- a/src/Timeline.cpp
+++ b/src/Timeline.cpp
@@ -74,12 +74,6 @@ Timeline::Timeline(int width, int height, Fraction fps, int sample_rate, int cha
     // Init cache
     final_cache = new CacheMemory();
 
-	// Configure OpenMP parallelism
-	// Default number of threads per block
-	omp_set_num_threads(max_concurrent_frames);
-	// Allow nested parallel sections as deeply as supported
-	omp_set_max_active_levels(OPEN_MP_MAX_ACTIVE);
-
 	// Init max image size
 	SetMaxSize(info.width, info.height);
 }
@@ -206,12 +200,6 @@ Timeline::Timeline(const std::string& projectPath, bool convert_absolute_paths) 
 
     // Init cache
     final_cache = new CacheMemory();
-
-	// Configure OpenMP parallelism
-	// Default number of threads per section
-	omp_set_num_threads(max_concurrent_frames);
-	// Allow nested parallel sections as deeply as supported
-	omp_set_max_active_levels(OPEN_MP_MAX_ACTIVE);
 
 	// Init max image size
 	SetMaxSize(info.width, info.height);
@@ -442,7 +430,7 @@ std::shared_ptr<Frame> Timeline::apply_effects(std::shared_ptr<Frame> frame, int
 }
 
 // Get or generate a blank frame
-std::shared_ptr<Frame> Timeline::GetOrCreateFrame(Clip* clip, int64_t number)
+std::shared_ptr<Frame> Timeline::GetOrCreateFrame(std::shared_ptr<Frame> background_frame, Clip* clip, int64_t number)
 {
 	std::shared_ptr<Frame> new_frame;
 
@@ -454,8 +442,7 @@ std::shared_ptr<Frame> Timeline::GetOrCreateFrame(Clip* clip, int64_t number)
 		ZmqLogger::Instance()->AppendDebugMethod("Timeline::GetOrCreateFrame (from reader)", "number", number, "samples_in_frame", samples_in_frame);
 
 		// Attempt to get a frame (but this could fail if a reader has just been closed)
-		#pragma omp critical (T_GetOtCreateFrame)
-		new_frame = std::shared_ptr<Frame>(clip->GetFrame(number));
+		new_frame = std::shared_ptr<Frame>(clip->GetFrame(background_frame, number));
 
 		// Return real frame
 		return new_frame;
@@ -470,23 +457,15 @@ std::shared_ptr<Frame> Timeline::GetOrCreateFrame(Clip* clip, int64_t number)
 	ZmqLogger::Instance()->AppendDebugMethod("Timeline::GetOrCreateFrame (create blank)", "number", number, "samples_in_frame", samples_in_frame);
 
 	// Create blank frame
-	new_frame = std::make_shared<Frame>(number, preview_width, preview_height, "#000000", samples_in_frame, info.channels);
-	#pragma omp critical (T_GetOtCreateFrame)
-	{
-        new_frame->AddAudioSilence(samples_in_frame);
-		new_frame->SampleRate(info.sample_rate);
-		new_frame->ChannelsLayout(info.channel_layout);
-	}
 	return new_frame;
 }
 
 // Process a new layer of video or audio
 void Timeline::add_layer(std::shared_ptr<Frame> new_frame, Clip* source_clip, int64_t clip_frame_number, int64_t timeline_frame_number, bool is_top_clip, float max_volume)
 {
-	// Get the clip's frame & image
+	// Get the clip's frame, composited on top of the current timeline frame
 	std::shared_ptr<Frame> source_frame;
-	#pragma omp critical (T_addLayer)
-	source_frame = GetOrCreateFrame(source_clip, clip_frame_number);
+	source_frame = GetOrCreateFrame(new_frame, source_clip, clip_frame_number);
 
 	// No frame found... so bail
 	if (!source_frame)
@@ -498,12 +477,8 @@ void Timeline::add_layer(std::shared_ptr<Frame> new_frame, Clip* source_clip, in
 	/* Apply effects to the source frame (if any). If multiple clips are overlapping, only process the
 	 * effects on the top clip. */
 	if (is_top_clip) {
-		#pragma omp critical (T_addLayer)
 		source_frame = apply_effects(source_frame, timeline_frame_number, source_clip->Layer());
 	}
-
-	// Declare an image to hold the source frame's image
-	std::shared_ptr<QImage> source_image;
 
 	/* COPY AUDIO - with correct volume */
 	if (source_clip->Reader()->info.has_audio) {
@@ -553,50 +528,16 @@ void Timeline::add_layer(std::shared_ptr<Frame> new_frame, Clip* source_clip, in
 				// This is a crude solution at best. =)
 				if (new_frame->GetAudioSamplesCount() != source_frame->GetAudioSamplesCount()){
 					// Force timeline frame to match the source frame
-					#pragma omp critical (T_addLayer)
-
 					new_frame->ResizeAudio(info.channels, source_frame->GetAudioSamplesCount(), info.sample_rate, info.channel_layout);
 				}
 				// Copy audio samples (and set initial volume).  Mix samples with existing audio samples.  The gains are added together, to
 				// be sure to set the gain's correctly, so the sum does not exceed 1.0 (of audio distortion will happen).
-				#pragma omp critical (T_addLayer)
 				new_frame->AddAudio(false, channel_mapping, 0, source_frame->GetAudioSamples(channel), source_frame->GetAudioSamplesCount(), 1.0);
-
 			}
 		else
 			// Debug output
 			ZmqLogger::Instance()->AppendDebugMethod("Timeline::add_layer (No Audio Copied - Wrong # of Channels)", "source_clip->Reader()->info.has_audio", source_clip->Reader()->info.has_audio, "source_frame->GetAudioChannelsCount()", source_frame->GetAudioChannelsCount(), "info.channels", info.channels, "clip_frame_number", clip_frame_number, "timeline_frame_number", timeline_frame_number);
 	}
-
-	// Skip out if video was disabled or only an audio frame (no visualisation in use)
-	if (source_clip->has_video.GetInt(clip_frame_number) == 0 ||
-	    (!source_clip->Waveform() && !source_clip->Reader()->info.has_video))
-		// Skip the rest of the image processing for performance reasons
-		return;
-
-	// Debug output
-	ZmqLogger::Instance()->AppendDebugMethod("Timeline::add_layer (Get Source Image)", "source_frame->number", source_frame->number, "source_clip->Waveform()", source_clip->Waveform(), "clip_frame_number", clip_frame_number);
-
-	// Get actual frame image data
-	source_image = source_frame->GetImage();
-
-	// Debug output
-	ZmqLogger::Instance()->AppendDebugMethod("Timeline::add_layer (Transform: Composite Image Layer: Prepare)", "source_frame->number", source_frame->number, "new_frame->GetImage()->width()", new_frame->GetImage()->width(), "source_image->width()", source_image->width());
-
-	/* COMPOSITE SOURCE IMAGE (LAYER) ONTO FINAL IMAGE */
-	std::shared_ptr<QImage> new_image;
-	new_image = new_frame->GetImage();
-
-	// Load timeline's new frame image into a QPainter
-	QPainter painter(new_image.get());
-
-	// Composite a new layer onto the image
-	painter.setCompositionMode(QPainter::CompositionMode_SourceOver);
-	painter.drawImage(0, 0, *source_image, 0, 0, source_image->width(), source_image->height());
-	painter.end();
-
-	// Add new QImage to frame
-	new_frame->AddImage(new_image);
 
 	// Debug output
 	ZmqLogger::Instance()->AppendDebugMethod("Timeline::add_layer (Transform: Composite Image Layer: Completed)", "source_frame->number", source_frame->number, "new_frame->GetImage()->width()", new_frame->GetImage()->width());
@@ -696,7 +637,6 @@ std::shared_ptr<Frame> Timeline::GetFrame(int64_t requested_frame)
 	// Check cache
 	std::shared_ptr<Frame> frame;
 	std::lock_guard<std::mutex> guard(get_frame_mutex);
-	#pragma omp critical (T_GetFrame)
 	frame = final_cache->GetFrame(requested_frame);
 	if (frame) {
 		// Debug output
@@ -715,7 +655,6 @@ std::shared_ptr<Frame> Timeline::GetFrame(int64_t requested_frame)
 			throw ReaderClosed("The Timeline is closed.  Call Open() before calling this method.");
 
 		// Check cache again (due to locking)
-		#pragma omp critical (T_GetFrame)
 		frame = final_cache->GetFrame(requested_frame);
 		if (frame) {
 			// Debug output
@@ -725,146 +664,100 @@ std::shared_ptr<Frame> Timeline::GetFrame(int64_t requested_frame)
 			return frame;
 		}
 
-		// Minimum number of frames to process (for performance reasons)
-		// Too many causes stuttering, too few causes stuttering
-		int minimum_frames = std::min(max_concurrent_frames / 2, 4);
-
 		// Get a list of clips that intersect with the requested section of timeline
 		// This also opens the readers for intersecting clips, and marks non-intersecting clips as 'needs closing'
 		std::vector<Clip*> nearby_clips;
-		#pragma omp critical (T_GetFrame)
-		nearby_clips = find_intersecting_clips(requested_frame, minimum_frames, true);
+		nearby_clips = find_intersecting_clips(requested_frame, 1, true);
 
-		// Debug output
-		ZmqLogger::Instance()->AppendDebugMethod("Timeline::GetFrame", "requested_frame", requested_frame, "minimum_frames", minimum_frames, "max_concurrent_frames", max_concurrent_frames);
+        // Debug output
+        ZmqLogger::Instance()->AppendDebugMethod("Timeline::GetFrame (processing frame)", "requested_frame", requested_frame, "omp_get_thread_num()", omp_get_thread_num());
 
-		// GENERATE CACHE FOR CLIPS (IN FRAME # SEQUENCE)
-		// Determine all clip frames, and request them in order (to keep resampled audio in sequence)
-		for (int64_t frame_number = requested_frame; frame_number < requested_frame + minimum_frames; frame_number++)
-		{
-			// Loop through clips
-			for (auto clip : nearby_clips)
-			{
-                long clip_start_position = round(clip->Position() * info.fps.ToDouble()) + 1;
-                long clip_end_position = round((clip->Position() + clip->Duration()) * info.fps.ToDouble()) + 1;
+        // Init some basic properties about this frame
+        int samples_in_frame = Frame::GetSamplesPerFrame(requested_frame, info.fps, info.sample_rate, info.channels);
 
-				bool does_clip_intersect = (clip_start_position <= frame_number && clip_end_position >= frame_number);
-				if (does_clip_intersect)
-				{
-					// Get clip frame #
-                    long clip_start_frame = (clip->Start() * info.fps.ToDouble()) + 1;
-					long clip_frame_number = frame_number - clip_start_position + clip_start_frame;
+        // Create blank frame (which will become the requested frame)
+        std::shared_ptr<Frame> new_frame(std::make_shared<Frame>(requested_frame, preview_width, preview_height, "#000000", samples_in_frame, info.channels));
+        new_frame->AddAudioSilence(samples_in_frame);
+        new_frame->SampleRate(info.sample_rate);
+        new_frame->ChannelsLayout(info.channel_layout);
 
-					// Cache clip object
-					clip->GetFrame(clip_frame_number);
-				}
-			}
-		}
+        // Debug output
+        ZmqLogger::Instance()->AppendDebugMethod("Timeline::GetFrame (Adding solid color)", "requested_frame", requested_frame, "info.width", info.width, "info.height", info.height);
 
-		#pragma omp parallel
-		{
-			// Loop through all requested frames
-			#pragma omp for ordered firstprivate(nearby_clips, requested_frame, minimum_frames) schedule(static,1)
-			for (int64_t frame_number = requested_frame; frame_number < requested_frame + minimum_frames; frame_number++)
-			{
-				// Debug output
-				ZmqLogger::Instance()->AppendDebugMethod("Timeline::GetFrame (processing frame)", "frame_number", frame_number, "omp_get_thread_num()", omp_get_thread_num());
+        // Add Background Color to 1st layer (if animated or not black)
+        if ((color.red.GetCount() > 1 || color.green.GetCount() > 1 || color.blue.GetCount() > 1) ||
+            (color.red.GetValue(requested_frame) != 0.0 || color.green.GetValue(requested_frame) != 0.0 || color.blue.GetValue(requested_frame) != 0.0))
+        new_frame->AddColor(preview_width, preview_height, color.GetColorHex(requested_frame));
 
-				// Init some basic properties about this frame
-				int samples_in_frame = Frame::GetSamplesPerFrame(frame_number, info.fps, info.sample_rate, info.channels);
+        // Debug output
+        ZmqLogger::Instance()->AppendDebugMethod("Timeline::GetFrame (Loop through clips)", "requested_frame", requested_frame, "clips.size()", clips.size(), "nearby_clips.size()", nearby_clips.size());
 
-				// Create blank frame (which will become the requested frame)
-				std::shared_ptr<Frame> new_frame(std::make_shared<Frame>(frame_number, preview_width, preview_height, "#000000", samples_in_frame, info.channels));
-				#pragma omp critical (T_GetFrame)
-				{
-					new_frame->AddAudioSilence(samples_in_frame);
-					new_frame->SampleRate(info.sample_rate);
-					new_frame->ChannelsLayout(info.channel_layout);
-				}
+        // Find Clips near this time
+        for (auto clip : nearby_clips)
+        {
+            long clip_start_position = round(clip->Position() * info.fps.ToDouble()) + 1;
+            long clip_end_position = round((clip->Position() + clip->Duration()) * info.fps.ToDouble()) + 1;
 
-				// Debug output
-				ZmqLogger::Instance()->AppendDebugMethod("Timeline::GetFrame (Adding solid color)", "frame_number", frame_number, "info.width", info.width, "info.height", info.height);
+            bool does_clip_intersect = (clip_start_position <= requested_frame && clip_end_position >= requested_frame);
 
-				// Add Background Color to 1st layer (if animated or not black)
-				if ((color.red.GetCount() > 1 || color.green.GetCount() > 1 || color.blue.GetCount() > 1) ||
-					(color.red.GetValue(frame_number) != 0.0 || color.green.GetValue(frame_number) != 0.0 || color.blue.GetValue(frame_number) != 0.0))
-				new_frame->AddColor(preview_width, preview_height, color.GetColorHex(frame_number));
+            // Debug output
+            ZmqLogger::Instance()->AppendDebugMethod("Timeline::GetFrame (Does clip intersect)", "requested_frame", requested_frame, "clip->Position()", clip->Position(), "clip->Duration()", clip->Duration(), "does_clip_intersect", does_clip_intersect);
 
-				// Debug output
-				ZmqLogger::Instance()->AppendDebugMethod("Timeline::GetFrame (Loop through clips)", "frame_number", frame_number, "clips.size()", clips.size(), "nearby_clips.size()", nearby_clips.size());
+            // Clip is visible
+            if (does_clip_intersect)
+            {
+                // Determine if clip is "top" clip on this layer (only happens when multiple clips are overlapping)
+                bool is_top_clip = true;
+                float max_volume = 0.0;
+                for (auto nearby_clip : nearby_clips)
+                {
+                    long nearby_clip_start_position = round(nearby_clip->Position() * info.fps.ToDouble()) + 1;
+                    long nearby_clip_end_position = round((nearby_clip->Position() + nearby_clip->Duration()) * info.fps.ToDouble()) + 1;
+                    long nearby_clip_start_frame = (nearby_clip->Start() * info.fps.ToDouble()) + 1;
+                    long nearby_clip_frame_number = requested_frame - nearby_clip_start_position + nearby_clip_start_frame;
 
-				// Find Clips near this time
-				for (auto clip : nearby_clips)
-				{
-                    long clip_start_position = round(clip->Position() * info.fps.ToDouble()) + 1;
-                    long clip_end_position = round((clip->Position() + clip->Duration()) * info.fps.ToDouble()) + 1;
+                    // Determine if top clip
+                    if (clip->Id() != nearby_clip->Id() && clip->Layer() == nearby_clip->Layer() &&
+                            nearby_clip_start_position <= requested_frame && nearby_clip_end_position >= requested_frame &&
+                            nearby_clip_start_position > clip_start_position && is_top_clip == true) {
+                        is_top_clip = false;
+                    }
 
-                    bool does_clip_intersect = (clip_start_position <= frame_number && clip_end_position >= frame_number);
+                    // Determine max volume of overlapping clips
+                    if (nearby_clip->Reader() && nearby_clip->Reader()->info.has_audio &&
+                            nearby_clip->has_audio.GetInt(nearby_clip_frame_number) != 0 &&
+                            nearby_clip_start_position <= requested_frame && nearby_clip_end_position >= requested_frame) {
+                            max_volume += nearby_clip->volume.GetValue(nearby_clip_frame_number);
+                    }
+                }
 
-					// Debug output
-					ZmqLogger::Instance()->AppendDebugMethod("Timeline::GetFrame (Does clip intersect)", "frame_number", frame_number, "clip->Position()", clip->Position(), "clip->Duration()", clip->Duration(), "does_clip_intersect", does_clip_intersect);
+                // Determine the frame needed for this clip (based on the position on the timeline)
+                long clip_start_frame = (clip->Start() * info.fps.ToDouble()) + 1;
+                long clip_frame_number = requested_frame - clip_start_position + clip_start_frame;
 
-					// Clip is visible
-					if (does_clip_intersect)
-					{
-						// Determine if clip is "top" clip on this layer (only happens when multiple clips are overlapping)
-						bool is_top_clip = true;
-						float max_volume = 0.0;
-						for (auto nearby_clip : nearby_clips)
-						{
-                            long nearby_clip_start_position = round(nearby_clip->Position() * info.fps.ToDouble()) + 1;
-                            long nearby_clip_end_position = round((nearby_clip->Position() + nearby_clip->Duration()) * info.fps.ToDouble()) + 1;
-							long nearby_clip_start_frame = (nearby_clip->Start() * info.fps.ToDouble()) + 1;
-							long nearby_clip_frame_number = frame_number - nearby_clip_start_position + nearby_clip_start_frame;
+                // Debug output
+                ZmqLogger::Instance()->AppendDebugMethod("Timeline::GetFrame (Calculate clip's frame #)", "clip->Position()", clip->Position(), "clip->Start()", clip->Start(), "info.fps.ToFloat()", info.fps.ToFloat(), "clip_frame_number", clip_frame_number);
 
-							// Determine if top clip
-							if (clip->Id() != nearby_clip->Id() && clip->Layer() == nearby_clip->Layer() &&
-                                    nearby_clip_start_position <= frame_number && nearby_clip_end_position >= frame_number &&
-                                    nearby_clip_start_position > clip_start_position && is_top_clip == true) {
-								is_top_clip = false;
-							}
+                // Add clip's frame as layer
+                add_layer(new_frame, clip, clip_frame_number, requested_frame, is_top_clip, max_volume);
 
-							// Determine max volume of overlapping clips
-							if (nearby_clip->Reader() && nearby_clip->Reader()->info.has_audio &&
-									nearby_clip->has_audio.GetInt(nearby_clip_frame_number) != 0 &&
-									nearby_clip_start_position <= frame_number && nearby_clip_end_position >= frame_number) {
-									max_volume += nearby_clip->volume.GetValue(nearby_clip_frame_number);
-							}
-						}
+            } else {
+                // Debug output
+                ZmqLogger::Instance()->AppendDebugMethod("Timeline::GetFrame (clip does not intersect)",
+                                                         "requested_frame", requested_frame, "does_clip_intersect",
+                                                         does_clip_intersect);
+            }
 
-						// Determine the frame needed for this clip (based on the position on the timeline)
-                        long clip_start_frame = (clip->Start() * info.fps.ToDouble()) + 1;
-						long clip_frame_number = frame_number - clip_start_position + clip_start_frame;
+        } // end clip loop
 
-						// Debug output
-						ZmqLogger::Instance()->AppendDebugMethod("Timeline::GetFrame (Calculate clip's frame #)", "clip->Position()", clip->Position(), "clip->Start()", clip->Start(), "info.fps.ToFloat()", info.fps.ToFloat(), "clip_frame_number", clip_frame_number);
+        // Debug output
+        ZmqLogger::Instance()->AppendDebugMethod("Timeline::GetFrame (Add frame to cache)", "requested_frame", requested_frame, "info.width", info.width, "info.height", info.height);
 
-						// Add clip's frame as layer
-						add_layer(new_frame, clip, clip_frame_number, frame_number, is_top_clip, max_volume);
+        // Set frame # on mapped frame
+        new_frame->SetFrameNumber(requested_frame);
 
-					} else
-						// Debug output
-						ZmqLogger::Instance()->AppendDebugMethod("Timeline::GetFrame (clip does not intersect)", "frame_number", frame_number, "does_clip_intersect", does_clip_intersect);
-
-				} // end clip loop
-
-				// Debug output
-				ZmqLogger::Instance()->AppendDebugMethod("Timeline::GetFrame (Add frame to cache)", "frame_number", frame_number, "info.width", info.width, "info.height", info.height);
-
-				// Set frame # on mapped frame
-				#pragma omp ordered
-				{
-					new_frame->SetFrameNumber(frame_number);
-
-					// Add final frame to cache
-					final_cache->Add(new_frame);
-				}
-
-			} // end frame loop
-		} // end parallel
-
-		// Debug output
-		ZmqLogger::Instance()->AppendDebugMethod("Timeline::GetFrame (end parallel region)", "requested_frame", requested_frame, "omp_get_thread_num()", omp_get_thread_num());
+        // Add final frame to cache
+        final_cache->Add(new_frame);
 
 		// Return frame (or blank frame)
 		return final_cache->GetFrame(requested_frame);
@@ -900,7 +793,6 @@ std::vector<Clip*> Timeline::find_intersecting_clips(int64_t requested_frame, in
 		ZmqLogger::Instance()->AppendDebugMethod("Timeline::find_intersecting_clips (Is clip near or intersecting)", "requested_frame", requested_frame, "min_requested_frame", min_requested_frame, "max_requested_frame", max_requested_frame, "clip->Position()", clip->Position(), "does_clip_intersect", does_clip_intersect);
 
 		// Open (or schedule for closing) this clip, based on if it's intersecting or not
-		#pragma omp critical (reader_lock)
 		update_open_clips(clip, does_clip_intersect);
 
 		// Clip is visible

--- a/src/Timeline.h
+++ b/src/Timeline.h
@@ -177,6 +177,7 @@ namespace openshot {
 		bool managed_cache; ///< Does this timeline instance manage the cache object
 		std::string path; ///< Optional path of loaded UTF-8 OpenShot JSON project file
 		std::mutex get_frame_mutex; ///< Mutex to protect GetFrame method from different threads calling it
+		int max_concurrent_frames; ///< Max concurrent frames to process at one time
 
 		/// Process a new layer of video or audio
 		void add_layer(std::shared_ptr<openshot::Frame> new_frame, openshot::Clip* source_clip, int64_t clip_frame_number, int64_t timeline_frame_number, bool is_top_clip, float max_volume);

--- a/src/Timeline.h
+++ b/src/Timeline.h
@@ -202,8 +202,8 @@ namespace openshot {
 		/// @param include Include or Exclude intersecting clips
 		std::vector<openshot::Clip*> find_intersecting_clips(int64_t requested_frame, int number_of_frames, bool include);
 
-		/// Get or generate a blank frame
-		std::shared_ptr<openshot::Frame> GetOrCreateFrame(openshot::Clip* clip, int64_t number);
+		/// Get a clip's frame or generate a blank frame
+		std::shared_ptr<openshot::Frame> GetOrCreateFrame(std::shared_ptr<Frame> background_frame, openshot::Clip* clip, int64_t number);
 
 		/// Apply effects to the source frame (if any)
 		std::shared_ptr<openshot::Frame> apply_effects(std::shared_ptr<openshot::Frame> frame, int64_t timeline_frame_number, int layer);

--- a/src/ZmqLogger.cpp
+++ b/src/ZmqLogger.cpp
@@ -126,16 +126,16 @@ void ZmqLogger::Log(std::string message)
 	// Create a scoped lock, allowing only a single thread to run the following code at one time
 	const juce::GenericScopedLock<juce::CriticalSection> lock(loggerCriticalSection);
 
-	// Send message over socket (ZeroMQ)
-	zmq::message_t reply (message.length());
-	std::memcpy (reply.data(), message.c_str(), message.length());
-
-#if ZMQ_VERSION > ZMQ_MAKE_VERSION(4, 3, 1)
-	// Set flags for immediate delivery (new API)
-	publisher->send(reply, zmq::send_flags::dontwait);
-#else
-	publisher->send(reply);
-#endif
+//	// Send message over socket (ZeroMQ)
+//	zmq::message_t reply (message.length());
+//	std::memcpy (reply.data(), message.c_str(), message.length());
+//
+//#if ZMQ_VERSION > ZMQ_MAKE_VERSION(4, 3, 1)
+//	// Set flags for immediate delivery (new API)
+//	publisher->send(reply, zmq::send_flags::dontwait);
+//#else
+//	publisher->send(reply);
+//#endif
 
 	// Also log to file, if open
 	LogToFile(message);

--- a/src/ZmqLogger.cpp
+++ b/src/ZmqLogger.cpp
@@ -126,16 +126,16 @@ void ZmqLogger::Log(std::string message)
 	// Create a scoped lock, allowing only a single thread to run the following code at one time
 	const juce::GenericScopedLock<juce::CriticalSection> lock(loggerCriticalSection);
 
-//	// Send message over socket (ZeroMQ)
-//	zmq::message_t reply (message.length());
-//	std::memcpy (reply.data(), message.c_str(), message.length());
-//
-//#if ZMQ_VERSION > ZMQ_MAKE_VERSION(4, 3, 1)
-//	// Set flags for immediate delivery (new API)
-//	publisher->send(reply, zmq::send_flags::dontwait);
-//#else
-//	publisher->send(reply);
-//#endif
+	// Send message over socket (ZeroMQ)
+	zmq::message_t reply (message.length());
+	std::memcpy (reply.data(), message.c_str(), message.length());
+
+#if ZMQ_VERSION > ZMQ_MAKE_VERSION(4, 3, 1)
+	// Set flags for immediate delivery (new API)
+	publisher->send(reply, zmq::send_flags::dontwait);
+#else
+	publisher->send(reply);
+#endif
 
 	// Also log to file, if open
 	LogToFile(message);

--- a/tests/Clip_Tests.cpp
+++ b/tests/Clip_Tests.cpp
@@ -258,7 +258,7 @@ TEST(Verify_Parent_Timeline)
 
 	// Check size of frame image (with an associated timeline)
 	CHECK_EQUAL(c1.GetFrame(1)->GetImage()->width(), 640);
-	CHECK_EQUAL(c1.GetFrame(1)->GetImage()->height(), 480);
+	CHECK_EQUAL(c1.GetFrame(1)->GetImage()->height(), 360);
 }
 
 } // SUITE

--- a/tests/Settings_Tests.cpp
+++ b/tests/Settings_Tests.cpp
@@ -43,7 +43,6 @@ TEST(Settings_Default_Constructor)
 
 	CHECK_EQUAL(12, s->OMP_THREADS);
 	CHECK_EQUAL(false, s->HIGH_QUALITY_SCALING);
-	CHECK_EQUAL(false, s->WAIT_FOR_VIDEO_PROCESSING_TASK);
 }
 
 TEST(Settings_Change_Settings)
@@ -52,13 +51,10 @@ TEST(Settings_Change_Settings)
 	Settings *s = Settings::Instance();
 	s->OMP_THREADS = 8;
 	s->HIGH_QUALITY_SCALING = true;
-	s->WAIT_FOR_VIDEO_PROCESSING_TASK = true;
 
 	CHECK_EQUAL(8, s->OMP_THREADS);
 	CHECK_EQUAL(true, s->HIGH_QUALITY_SCALING);
-	CHECK_EQUAL(true, s->WAIT_FOR_VIDEO_PROCESSING_TASK);
 
 	CHECK_EQUAL(8, Settings::Instance()->OMP_THREADS);
 	CHECK_EQUAL(true, Settings::Instance()->HIGH_QUALITY_SCALING);
-	CHECK_EQUAL(true, Settings::Instance()->WAIT_FOR_VIDEO_PROCESSING_TASK);
 }


### PR DESCRIPTION
After some extensive profiling using a variety of tools, we have found a few interesting and actionable issues. Bottom line, OpenMP is not actually providing us any improvement where we need it, and instead, it's adding additional overhead, by spinning up many threads, waiting for threads to finish, shutting down threads, etc... 

Related openshot-qt PR: https://github.com/OpenShot/openshot-qt/pull/4012

**Improvements:**
 - I've removed **OpenMP** from `Timeline`, `FFmpegReader` classes. These are now optimized to return the first matching frame as quickly as possible (no more attempting to process a bunch of Frame instances in multiple threads).
 - I've refactored Clip::GetFrame, including an override that allows the Timeline to pass in the current Frame (to be used as a background image). This prevents calling `QPainter::drawImage` multiple times (and saves a bunch of CPU)
 - Reduced some unneeded memory copying and allocating

**Testing:**
 - I did many tests on many different machines, including A/B testing with the current stable release of OpenShot. 
 - I tested on Chromebook, Windows, Mac, and Linux (to verify the performance gains on a variety of different machines, some very powerful, some borderline decent).