### PR TITLE
Documentation comment fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
 
     - uses: haya14busa/action-cond@v1
       id: coverage

--- a/Doxyfile.in
+++ b/Doxyfile.in
@@ -1,4 +1,4 @@
-# Doxyfile 1.8.15
+# Doxyfile 1.8.20
 
 # This file describes the settings to be used by the documentation system
 # doxygen (www.doxygen.org) for a project.
@@ -187,6 +187,16 @@ SHORT_NAMES            = NO
 
 JAVADOC_AUTOBRIEF      = NO
 
+# If the JAVADOC_BANNER tag is set to YES then doxygen will interpret a line
+# such as
+# /***************
+# as being the beginning of a Javadoc-style comment "banner". If set to NO, the
+# Javadoc-style will behave just like regular comments and it will not be
+# interpreted by doxygen.
+# The default value is: NO.
+
+JAVADOC_BANNER         = NO
+
 # If the QT_AUTOBRIEF tag is set to YES then doxygen will interpret the first
 # line (until the first dot) of a Qt-style comment as the brief description. If
 # set to NO, the Qt-style will behave just like regular Qt-style comments (thus
@@ -206,6 +216,14 @@ QT_AUTOBRIEF           = NO
 # The default value is: NO.
 
 MULTILINE_CPP_IS_BRIEF = NO
+
+# By default Python docstrings are displayed as preformatted text and doxygen's
+# special commands cannot be used. By setting PYTHON_DOCSTRING to NO the
+# doxygen's special commands can be used and the contents of the docstring
+# documentation blocks is shown as doxygen documentation.
+# The default value is: YES.
+
+PYTHON_DOCSTRING       = YES
 
 # If the INHERIT_DOCS tag is set to YES then an undocumented member inherits the
 # documentation from any documented member that it re-implements.
@@ -242,12 +260,6 @@ TAB_SIZE               = 8
 # a double escape (\\{ and \\})
 
 ALIASES                =
-
-# This tag can be used to specify a number of word-keyword mappings (TCL only).
-# A mapping has the form "name=value". For example adding "class=itcl::class"
-# will allow you to use the command class in the itcl::class meaning.
-
-TCL_SUBST              =
 
 # Set the OPTIMIZE_OUTPUT_FOR_C tag to YES if your project consists of C sources
 # only. Doxygen will then generate output that is more tailored for C. For
@@ -289,14 +301,14 @@ OPTIMIZE_OUTPUT_SLICE  = NO
 # parses. With this tag you can assign which parser to use for a given
 # extension. Doxygen has a built-in mapping, but you can override or extend it
 # using this tag. The format is ext=language, where ext is a file extension, and
-# language is one of the parsers supported by doxygen: IDL, Java, Javascript,
-# Csharp (C#), C, C++, D, PHP, md (Markdown), Objective-C, Python, Slice,
+# language is one of the parsers supported by doxygen: IDL, Java, JavaScript,
+# Csharp (C#), C, C++, D, PHP, md (Markdown), Objective-C, Python, Slice, VHDL,
 # Fortran (fixed format Fortran: FortranFixed, free formatted Fortran:
 # FortranFree, unknown formatted Fortran: Fortran. In the later case the parser
 # tries to guess whether the code is fixed or free formatted code, this is the
-# default for Fortran type files), VHDL, tcl. For instance to make doxygen treat
-# .inc files as Fortran files (default is PHP), and .f files as C (default is
-# Fortran), use: inc=Fortran f=C.
+# default for Fortran type files). For instance to make doxygen treat .inc files
+# as Fortran files (default is PHP), and .f files as C (default is Fortran),
+# use: inc=Fortran f=C.
 #
 # Note: For files without extension you can use no_extension as a placeholder.
 #
@@ -319,7 +331,7 @@ MARKDOWN_SUPPORT       = YES
 # to that level are automatically included in the table of contents, even if
 # they do not have an id attribute.
 # Note: This feature currently applies only to Markdown headings.
-# Minimum value: 0, maximum value: 99, default value: 0.
+# Minimum value: 0, maximum value: 99, default value: 5.
 # This tag requires that the tag MARKDOWN_SUPPORT is set to YES.
 
 TOC_INCLUDE_HEADINGS   = 0
@@ -435,6 +447,19 @@ TYPEDEF_HIDES_STRUCT   = NO
 
 LOOKUP_CACHE_SIZE      = 0
 
+# The NUM_PROC_THREADS specifies the number threads doxygen is allowed to use
+# during processing. When set to 0 doxygen will based this on the number of
+# cores available in the system. You can set it explicitly to a value larger
+# than 0 to get more control over the balance between CPU load and processing
+# speed. At this moment only the input processing can be done using multiple
+# threads. Since this is still an experimental feature the default is set to 1,
+# which efficively disables parallel processing. Please report any issues you
+# encounter. Generating dot graphs in parallel is controlled by the
+# DOT_NUM_THREADS setting.
+# Minimum value: 0, maximum value: 32, default value: 1.
+
+NUM_PROC_THREADS       = 1
+
 #---------------------------------------------------------------------------
 # Build related configuration options
 #---------------------------------------------------------------------------
@@ -454,6 +479,12 @@ EXTRACT_ALL            = YES
 # The default value is: NO.
 
 EXTRACT_PRIVATE        = NO
+
+# If the EXTRACT_PRIV_VIRTUAL tag is set to YES, documented private virtual
+# methods of a class will be included in the documentation.
+# The default value is: NO.
+
+EXTRACT_PRIV_VIRTUAL   = NO
 
 # If the EXTRACT_PACKAGE tag is set to YES, all members with package or internal
 # scope will be included in the documentation.
@@ -509,8 +540,8 @@ HIDE_UNDOC_MEMBERS     = NO
 HIDE_UNDOC_CLASSES     = NO
 
 # If the HIDE_FRIEND_COMPOUNDS tag is set to YES, doxygen will hide all friend
-# (class|struct|union) declarations. If set to NO, these declarations will be
-# included in the documentation.
+# declarations. If set to NO, these declarations will be included in the
+# documentation.
 # The default value is: NO.
 
 HIDE_FRIEND_COMPOUNDS  = NO
@@ -533,7 +564,7 @@ INTERNAL_DOCS          = NO
 # names in lower-case letters. If set to YES, upper-case letters are also
 # allowed. This is useful if you have classes or files whose names only differ
 # in case and if your file system supports case sensitive file names. Windows
-# and Mac users are advised to set this option to NO.
+# (including Cygwin) and Mac users are advised to set this option to NO.
 # The default value is: system dependent.
 
 CASE_SENSE_NAMES       = YES
@@ -805,7 +836,7 @@ WARN_LOGFILE           =
 
 INPUT                  = "@PROJECT_SOURCE_DIR@/src" \
                          "@PROJECT_SOURCE_DIR@/doc" \
-			 "@PROJECT_BINARY_DIR@/src/OpenShotVersion.h"
+                         "@PROJECT_BINARY_DIR@/src/OpenShotVersion.h"
 
 
 # This tag can be used to specify the character encoding of the source files
@@ -828,8 +859,10 @@ INPUT_ENCODING         = UTF-8
 # If left blank the following patterns are tested:*.c, *.cc, *.cxx, *.cpp,
 # *.c++, *.java, *.ii, *.ixx, *.ipp, *.i++, *.inl, *.idl, *.ddl, *.odl, *.h,
 # *.hh, *.hxx, *.hpp, *.h++, *.cs, *.d, *.php, *.php4, *.php5, *.phtml, *.inc,
-# *.m, *.markdown, *.md, *.mm, *.dox, *.py, *.pyw, *.f90, *.f95, *.f03, *.f08,
-# *.f, *.for, *.tcl, *.vhd, *.vhdl, *.ucf, *.qsf and *.ice.
+# *.m, *.markdown, *.md, *.mm, *.dox (to be provided as doxygen C comment),
+# *.doc (to be provided as doxygen C comment), *.txt (to be provided as doxygen
+# C comment), *.py, *.pyw, *.f90, *.f95, *.f03, *.f08, *.f18, *.f, *.for, *.vhd,
+# *.vhdl, *.ucf, *.qsf and *.ice.
 
 FILE_PATTERNS          =
 
@@ -1043,6 +1076,38 @@ USE_HTAGS              = NO
 
 VERBATIM_HEADERS       = YES
 
+# If the CLANG_ASSISTED_PARSING tag is set to YES then doxygen will use the
+# clang parser (see: http://clang.llvm.org/) for more accurate parsing at the
+# cost of reduced performance. This can be particularly helpful with template
+# rich C++ code for which doxygen's built-in parser lacks the necessary type
+# information.
+# Note: The availability of this option depends on whether or not doxygen was
+# generated with the -Duse_libclang=ON option for CMake.
+# The default value is: NO.
+
+CLANG_ASSISTED_PARSING = NO
+
+# If clang assisted parsing is enabled you can provide the compiler with command
+# line options that you would normally use when invoking the compiler. Note that
+# the include paths will already be set by doxygen for the files and directories
+# specified with INPUT and INCLUDE_PATH.
+# This tag requires that the tag CLANG_ASSISTED_PARSING is set to YES.
+
+CLANG_OPTIONS          =
+
+# If clang assisted parsing is enabled you can provide the clang parser with the
+# path to the directory containing a file called compile_commands.json. This
+# file is the compilation database (see:
+# http://clang.llvm.org/docs/HowToSetupToolingForLLVM.html) containing the
+# options used when the source files were built. This is equivalent to
+# specifying the "-p" option to a clang tool, such as clang-check. These options
+# will then be passed to the parser. Any options specified with CLANG_OPTIONS
+# will be added as well.
+# Note: The availability of this option depends on whether or not doxygen was
+# generated with the -Duse_libclang=ON option for CMake.
+
+CLANG_DATABASE_PATH    =
+
 #---------------------------------------------------------------------------
 # Configuration options related to the alphabetical class index
 #---------------------------------------------------------------------------
@@ -1199,9 +1264,9 @@ HTML_TIMESTAMP         = YES
 
 # If the HTML_DYNAMIC_MENUS tag is set to YES then the generated HTML
 # documentation will contain a main index with vertical navigation menus that
-# are dynamically created via Javascript. If disabled, the navigation index will
+# are dynamically created via JavaScript. If disabled, the navigation index will
 # consists of multiple levels of tabs that are statically embedded in every HTML
-# page. Disable this option to support browsers that do not have Javascript,
+# page. Disable this option to support browsers that do not have JavaScript,
 # like the Qt help browser.
 # The default value is: YES.
 # This tag requires that the tag GENERATE_HTML is set to YES.
@@ -1307,7 +1372,7 @@ CHM_FILE               =
 HHC_LOCATION           =
 
 # The GENERATE_CHI flag controls if a separate .chi index file is generated
-# (YES) or that it should be included in the master .chm file (NO).
+# (YES) or that it should be included in the main .chm file (NO).
 # The default value is: NO.
 # This tag requires that the tag GENERATE_HTMLHELP is set to YES.
 
@@ -1352,7 +1417,7 @@ QCH_FILE               =
 
 # The QHP_NAMESPACE tag specifies the namespace to use when generating Qt Help
 # Project output. For more information please see Qt Help Project / Namespace
-# (see: http://doc.qt.io/archives/qt-4.8/qthelpproject.html#namespace).
+# (see: https://doc.qt.io/archives/qt-4.8/qthelpproject.html#namespace).
 # The default value is: org.doxygen.Project.
 # This tag requires that the tag GENERATE_QHP is set to YES.
 
@@ -1360,7 +1425,7 @@ QHP_NAMESPACE          =
 
 # The QHP_VIRTUAL_FOLDER tag specifies the namespace to use when generating Qt
 # Help Project output. For more information please see Qt Help Project / Virtual
-# Folders (see: http://doc.qt.io/archives/qt-4.8/qthelpproject.html#virtual-
+# Folders (see: https://doc.qt.io/archives/qt-4.8/qthelpproject.html#virtual-
 # folders).
 # The default value is: doc.
 # This tag requires that the tag GENERATE_QHP is set to YES.
@@ -1369,7 +1434,7 @@ QHP_VIRTUAL_FOLDER     = doc
 
 # If the QHP_CUST_FILTER_NAME tag is set, it specifies the name of a custom
 # filter to add. For more information please see Qt Help Project / Custom
-# Filters (see: http://doc.qt.io/archives/qt-4.8/qthelpproject.html#custom-
+# Filters (see: https://doc.qt.io/archives/qt-4.8/qthelpproject.html#custom-
 # filters).
 # This tag requires that the tag GENERATE_QHP is set to YES.
 
@@ -1377,7 +1442,7 @@ QHP_CUST_FILTER_NAME   =
 
 # The QHP_CUST_FILTER_ATTRS tag specifies the list of the attributes of the
 # custom filter to add. For more information please see Qt Help Project / Custom
-# Filters (see: http://doc.qt.io/archives/qt-4.8/qthelpproject.html#custom-
+# Filters (see: https://doc.qt.io/archives/qt-4.8/qthelpproject.html#custom-
 # filters).
 # This tag requires that the tag GENERATE_QHP is set to YES.
 
@@ -1385,7 +1450,7 @@ QHP_CUST_FILTER_ATTRS  =
 
 # The QHP_SECT_FILTER_ATTRS tag specifies the list of the attributes this
 # project's filter section matches. Qt Help Project / Filter Attributes (see:
-# http://doc.qt.io/archives/qt-4.8/qthelpproject.html#filter-attributes).
+# https://doc.qt.io/archives/qt-4.8/qthelpproject.html#filter-attributes).
 # This tag requires that the tag GENERATE_QHP is set to YES.
 
 QHP_SECT_FILTER_ATTRS  =
@@ -1469,6 +1534,17 @@ TREEVIEW_WIDTH         = 250
 
 EXT_LINKS_IN_WINDOW    = NO
 
+# If the HTML_FORMULA_FORMAT option is set to svg, doxygen will use the pdf2svg
+# tool (see https://github.com/dawbarton/pdf2svg) or inkscape (see
+# https://inkscape.org) to generate formulas as SVG images instead of PNGs for
+# the HTML output. These images will generally look nicer at scaled resolutions.
+# Possible values are: png (the default) and svg (looks nicer but requires the
+# pdf2svg or inkscape tool).
+# The default value is: png.
+# This tag requires that the tag GENERATE_HTML is set to YES.
+
+HTML_FORMULA_FORMAT    = png
+
 # Use this tag to change the font size of LaTeX formulas included as images in
 # the HTML documentation. When you change the font size after a successful
 # doxygen run you need to manually remove any form_*.png images from the HTML
@@ -1489,8 +1565,14 @@ FORMULA_FONTSIZE       = 10
 
 FORMULA_TRANSPARENT    = YES
 
+# The FORMULA_MACROFILE can contain LaTeX \newcommand and \renewcommand commands
+# to create new LaTeX commands to be used in formulas as building blocks. See
+# the section "Including formulas" for details.
+
+FORMULA_MACROFILE      =
+
 # Enable the USE_MATHJAX option to render LaTeX formulas using MathJax (see
-# https://www.mathjax.org) which uses client side Javascript for the rendering
+# https://www.mathjax.org) which uses client side JavaScript for the rendering
 # instead of using pre-rendered bitmaps. Use this if you do not have LaTeX
 # installed or if you want to formulas look prettier in the HTML output. When
 # enabled you may also need to install MathJax separately and configure the path
@@ -1518,7 +1600,7 @@ MATHJAX_FORMAT         = HTML-CSS
 # Content Delivery Network so you can quickly see the result without installing
 # MathJax. However, it is strongly recommended to install a local copy of
 # MathJax from https://www.mathjax.org before deployment.
-# The default value is: https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/.
+# The default value is: https://cdn.jsdelivr.net/npm/mathjax@2.
 # This tag requires that the tag USE_MATHJAX is set to YES.
 
 MATHJAX_RELPATH        = http://cdn.mathjax.org/mathjax/latest
@@ -1560,7 +1642,7 @@ MATHJAX_CODEFILE       =
 SEARCHENGINE           = NO
 
 # When the SERVER_BASED_SEARCH tag is enabled the search engine will be
-# implemented using a web server instead of a web client using Javascript. There
+# implemented using a web server instead of a web client using JavaScript. There
 # are two flavors of web server based searching depending on the EXTERNAL_SEARCH
 # setting. When disabled, doxygen will generate a PHP script for searching and
 # an index file used by the script. When EXTERNAL_SEARCH is enabled the indexing
@@ -1664,10 +1746,11 @@ LATEX_CMD_NAME         = "@LATEX_COMPILER@"
 MAKEINDEX_CMD_NAME     = "@MAKEINDEX_COMPILER@"
 
 # The LATEX_MAKEINDEX_CMD tag can be used to specify the command name to
-# generate index for LaTeX.
+# generate index for LaTeX. In case there is no backslash (\) as first character
+# it will be automatically added in the LaTeX code.
 # Note: This tag is used in the generated output file (.tex).
 # See also: MAKEINDEX_CMD_NAME for the part in the Makefile / make.bat.
-# The default value is: \makeindex.
+# The default value is: makeindex.
 # This tag requires that the tag GENERATE_LATEX is set to YES.
 
 LATEX_MAKEINDEX_CMD    = \makeindex
@@ -1756,9 +1839,11 @@ LATEX_EXTRA_FILES      =
 
 PDF_HYPERLINKS         = YES
 
-# If the USE_PDFLATEX tag is set to YES, doxygen will use pdflatex to generate
-# the PDF file directly from the LaTeX files. Set this option to YES, to get a
-# higher quality PDF documentation.
+# If the USE_PDFLATEX tag is set to YES, doxygen will use the engine as
+# specified with LATEX_CMD_NAME to generate the PDF file directly from the LaTeX
+# files. Set this option to YES, to get a higher quality PDF documentation.
+#
+# See also section LATEX_CMD_NAME for selecting the engine.
 # The default value is: YES.
 # This tag requires that the tag GENERATE_LATEX is set to YES.
 
@@ -2092,7 +2177,9 @@ INCLUDE_FILE_PATTERNS  = "*.h"
 # recursively expanded use the := operator instead of the = operator.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-PREDEFINED             = USE_BLACKMAGIC USE_IMAGEMAGICK
+PREDEFINED             = USE_BLACKMAGIC \
+                         USE_IMAGEMAGICK \
+                         USE_OPENCV
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The
@@ -2159,12 +2246,6 @@ EXTERNAL_GROUPS        = YES
 
 EXTERNAL_PAGES         = YES
 
-# The PERL_PATH should be the absolute path and name of the perl script
-# interpreter (i.e. the result of 'which perl').
-# The default file (with absolute path) is: /usr/bin/perl.
-
-PERL_PATH              = /usr/bin/perl
-
 #---------------------------------------------------------------------------
 # Configuration options related to the dot tool
 #---------------------------------------------------------------------------
@@ -2177,15 +2258,6 @@ PERL_PATH              = /usr/bin/perl
 # The default value is: YES.
 
 CLASS_DIAGRAMS         = YES
-
-# You can define message sequence charts within doxygen comments using the \msc
-# command. Doxygen will then run the mscgen tool (see:
-# http://www.mcternan.me.uk/mscgen/)) to produce the chart and insert it in the
-# documentation. The MSCGEN_PATH tag allows you to specify the directory where
-# the mscgen tool resides. If left empty the tool is assumed to be found in the
-# default search path.
-
-MSCGEN_PATH            =
 
 # You can include diagrams made with dia in doxygen documentation. Doxygen will
 # then run dia to produce the diagram and insert it in the documentation. The

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -453,9 +453,6 @@ endif()
 if(UNIX AND NOT APPLE)
   set(CPACK_GENERATOR "DEB")
 endif()
-#if(UNIX AND APPLE)
-#  set(CPACK_GENERATOR "DragNDrop")
-#endif()
 set(CPACK_DEBIAN_PACKAGE_MAINTAINER "Jonathan Thomas") #required
 
 include(CPack)

--- a/src/CVObjectDetection.h
+++ b/src/CVObjectDetection.h
@@ -122,7 +122,7 @@ namespace openshot
         // Add frame object detection data into protobuf message.
         void AddFrameDataToProto(pb_objdetect::Frame* pbFrameData, CVDetectionData& dData);
 
-        /// Get and Set JSON methods
+        // Get and Set JSON methods
         void SetJson(const std::string value); ///< Load JSON string into this object
         void SetJsonValue(const Json::Value root); ///< Load Json::Value into this object
 

--- a/src/CVStabilization.h
+++ b/src/CVStabilization.h
@@ -101,13 +101,13 @@ class CVStabilization {
     /// Will handle a Thread safely comutication between ClipProcessingJobs and the processing effect classes
 	ProcessingController *processingController;
 
-    // Track current frame features and find the relative transformation
+    /// Track current frame features and find the relative transformation
     bool TrackFrameFeatures(cv::Mat frame, size_t frameNum);
 
     std::vector<CamTrajectory> ComputeFramesTrajectory();
     std::map<size_t,CamTrajectory> SmoothTrajectory(std::vector <CamTrajectory> &trajectory);
 
-    // Generate new transformations parameters for each frame to follow the smoothed trajectory
+    /// Generate new transformations parameters for each frame to follow the smoothed trajectory
     std::map<size_t,TransformParam> GenNewCamPosition(std::map <size_t,CamTrajectory> &smoothed_trajectory);
 
     public:
@@ -115,23 +115,23 @@ class CVStabilization {
     std::map <size_t,CamTrajectory> trajectoryData; // Save camera trajectory data
     std::map <size_t,TransformParam> transformationData; // Save transormation data
 
-    // Set default smoothing window value to compute stabilization
+    /// Set default smoothing window value to compute stabilization
     CVStabilization(std::string processInfoJson, ProcessingController &processingController);
 
-    // Process clip and store necessary stabilization data
+    /// Process clip and store necessary stabilization data
     void stabilizeClip(openshot::Clip& video, size_t _start=0, size_t _end=0, bool process_interval=false);
 
     /// Protobuf Save and Load methods
-    // Save stabilization data to protobuf file
+    /// Save stabilization data to protobuf file
     bool SaveStabilizedData();
-    // Add frame stabilization data into protobuf message
+    /// Add frame stabilization data into protobuf message
     void AddFrameDataToProto(pb_stabilize::Frame* pbFrameData, CamTrajectory& trajData, TransformParam& transData, size_t frame_number);
 
     // Return requested struct info for a given frame
     TransformParam GetTransformParamData(size_t frameId);
     CamTrajectory GetCamTrajectoryTrackedData(size_t frameId);
 
-    /// Get and Set JSON methods
+    // Get and Set JSON methods
     void SetJson(const std::string value); ///< Load JSON string into this object
     void SetJsonValue(const Json::Value root); ///< Load Json::Value into this object
 

--- a/src/CVTracker.h
+++ b/src/CVTracker.h
@@ -116,23 +116,24 @@ namespace openshot
 			// Constructor
 			CVTracker(std::string processInfoJson, ProcessingController &processingController);
 
-			// Set desirable tracker method
+			/// Set desirable tracker method
 			cv::Ptr<cv::Tracker> selectTracker(std::string trackerType);
 
-			// Track object in the hole clip or in a given interval
-			// If start, end and process_interval are passed as argument, clip will be processed in [start,end)
+			/// Track object in the hole clip or in a given interval
+			///
+			/// If start, end and process_interval are passed as argument, clip will be processed in [start,end)
 			void trackClip(openshot::Clip& video, size_t _start=0, size_t _end=0, bool process_interval=false);
 
-			// Get tracked data for a given frame
+			/// Get tracked data for a given frame
 			FrameData GetTrackedData(size_t frameId);
 
-			/// Protobuf Save and Load methods
-			// Save protobuf file
+			// Protobuf Save and Load methods
+			/// Save protobuf file
 			bool SaveTrackedData();
-			// Add frame tracked data into protobuf message.
+			/// Add frame tracked data into protobuf message.
 			void AddFrameDataToProto(pb_tracker::Frame* pbFrameData, FrameData& fData);
 
-			/// Get and Set JSON methods
+			// Get and Set JSON methods
 			void SetJson(const std::string value); ///< Load JSON string into this object
 			void SetJsonValue(const Json::Value root); ///< Load Json::Value into this object
 

--- a/src/CacheBase.h
+++ b/src/CacheBase.h
@@ -107,7 +107,7 @@ namespace openshot {
 		/// @param channels The number of audio channels in the frame
 		void SetMaxBytesFromInfo(int64_t number_of_frames, int width, int height, int sample_rate, int channels);
 
-		/// Get and Set JSON methods
+		// Get and Set JSON methods
 		virtual std::string Json() = 0; ///< Generate JSON string of this object
 		virtual void SetJson(const std::string value) = 0; ///< Load JSON string into this object
 		virtual Json::Value JsonValue() = 0; ///< Generate Json::Value for this object

--- a/src/CacheDisk.h
+++ b/src/CacheDisk.h
@@ -124,7 +124,7 @@ namespace openshot {
 		/// @param end_frame_number The ending frame number of the cached frame
 		void Remove(int64_t start_frame_number, int64_t end_frame_number);
 
-		/// Get and Set JSON methods
+		// Get and Set JSON methods
 		std::string Json(); ///< Generate JSON string of this object
 		void SetJson(const std::string value); ///< Load JSON string into this object
 		Json::Value JsonValue(); ///< Generate Json::Value for this object

--- a/src/CacheMemory.h
+++ b/src/CacheMemory.h
@@ -108,7 +108,7 @@ namespace openshot {
 		/// @param end_frame_number The ending frame number of the cached frame
 		void Remove(int64_t start_frame_number, int64_t end_frame_number);
 
-		/// Get and Set JSON methods
+		// Get and Set JSON methods
 		std::string Json(); ///< Generate JSON string of this object
 		void SetJson(const std::string value); ///< Load JSON string into this object
 		Json::Value JsonValue(); ///< Generate Json::Value for this object

--- a/src/ChunkReader.h
+++ b/src/ChunkReader.h
@@ -150,7 +150,7 @@ namespace openshot
 		/// Return the type name of the class
 		std::string Name() override { return "ChunkReader"; };
 
-		/// Get and Set JSON methods
+		// Get and Set JSON methods
 		std::string Json() const override; ///< Generate JSON string of this object
 		void SetJson(const std::string value) override; ///< Load JSON string into this object
 		Json::Value JsonValue() const override; ///< Generate Json::Value for this object

--- a/src/Clip.h
+++ b/src/Clip.h
@@ -37,8 +37,8 @@
 	#include <opencv2/opencv.hpp>
 	#include <opencv2/core.hpp>
 	#undef uint64
-	#undef int64	
-	
+	#undef int64
+
 #endif
 
 #include <memory>
@@ -120,8 +120,8 @@ namespace openshot {
 
 	private:
 		bool waveform; ///< Should a waveform be used instead of the clip's image
-		std::list<openshot::EffectBase*> effects; ///<List of clips on this timeline
-		bool is_open;	///> Is Reader opened
+		std::list<openshot::EffectBase*> effects; ///< List of clips on this timeline
+		bool is_open;	///< Is Reader opened
 
 		// Audio resampler (if time mapping)
 		openshot::AudioResampler *resampler;
@@ -243,11 +243,11 @@ namespace openshot {
 		/// Get the current reader
 		openshot::ReaderBase* Reader();
 
-		/// Override End() method
+		// Override End() method
 		float End() const; ///< Get end position (in seconds) of clip (trim end of video), which can be affected by the time curve.
 		void End(float value) { end = value; } ///< Set end position (in seconds) of clip (trim end of video)
 
-		/// Get and Set JSON methods
+		// Get and Set JSON methods
 		std::string Json() const override; ///< Generate JSON string of this object
 		void SetJson(const std::string value) override; ///< Load JSON string into this object
 		Json::Value JsonValue() const override; ///< Generate Json::Value for this object
@@ -261,7 +261,7 @@ namespace openshot {
 		/// @param effect Remove an effect from the clip.
 		void RemoveEffect(openshot::EffectBase* effect);
 
-		/// Waveform property
+		// Waveform property
 		bool Waveform() { return waveform; } ///< Get the waveform property of this clip
 		void Waveform(bool value) { waveform = value; } ///< Set the waveform property of this clip
 
@@ -296,11 +296,11 @@ namespace openshot {
 		openshot::Keyframe perspective_c4_x; ///< Curves representing X for coordinate 4
 		openshot::Keyframe perspective_c4_y; ///< Curves representing Y for coordinate 4
 
-		/// Audio channel filter and mappings
+		// Audio channel filter and mappings
 		openshot::Keyframe channel_filter; ///< A number representing an audio channel to filter (clears all other channels)
 		openshot::Keyframe channel_mapping; ///< A number representing an audio channel to output (only works when filtering a channel)
 
-		/// Override has_video and has_audio properties of clip (and their readers)
+		// Override has_video and has_audio properties of clip (and their readers)
 		openshot::Keyframe has_audio; ///< An optional override to determine if this clip has audio (-1=undefined, 0=no, 1=yes)
 		openshot::Keyframe has_video; ///< An optional override to determine if this clip has video (-1=undefined, 0=no, 1=yes)
 	};

--- a/src/ClipBase.h
+++ b/src/ClipBase.h
@@ -103,7 +103,7 @@ namespace openshot {
 		/// @param frame_number The frame number (starting at 1) of the clip or effect on the timeline.
 		virtual std::shared_ptr<openshot::Frame> GetFrame(std::shared_ptr<openshot::Frame> frame, int64_t frame_number) = 0;
 
-		/// Get basic properties
+		// Get basic properties
 		std::string Id() const { return id; } ///< Get the Id of this clip object
 		float Position() const { return position; } ///< Get position on timeline (in seconds)
 		int Layer() const { return layer; } ///< Get layer of clip on timeline (lower number is covered by higher numbers)
@@ -112,7 +112,7 @@ namespace openshot {
 		float Duration() const { return end - start; } ///< Get the length of this clip (in seconds)
 		openshot::TimelineBase* ParentTimeline() { return timeline; } ///< Get the associated Timeline pointer (if any)
 
-		/// Set basic properties
+		// Set basic properties
 		void Id(std::string value) { id = value; } ///> Set the Id of this clip object
 		void Position(float value) { position = value; } ///< Set position on timeline (in seconds)
 		void Layer(int value) { layer = value; } ///< Set layer of clip on timeline (lower number is covered by higher numbers)
@@ -120,7 +120,7 @@ namespace openshot {
 		void End(float value) { end = value; } ///< Set end position (in seconds) of clip (trim end of video)
 		void ParentTimeline(openshot::TimelineBase* new_timeline) { timeline = new_timeline; } ///< Set associated Timeline pointer
 
-		/// Get and Set JSON methods
+		// Get and Set JSON methods
 		virtual std::string Json() const = 0; ///< Generate JSON string of this object
 		virtual void SetJson(const std::string value) = 0; ///< Load JSON string into this object
 		virtual Json::Value JsonValue() const = 0; ///< Generate Json::Value for this object

--- a/src/Color.h
+++ b/src/Color.h
@@ -68,7 +68,7 @@ namespace openshot {
 		/// Get the distance between 2 RGB pairs. (0=identical colors, 10=very close colors, 760=very different colors)
 		static long GetDistance(long R1, long G1, long B1, long R2, long G2, long B2);
 
-		/// Get and Set JSON methods
+		// Get and Set JSON methods
 		std::string Json() const; ///< Generate JSON string of this object
 		Json::Value JsonValue() const; ///< Generate Json::Value for this object
 		void SetJson(const std::string value); ///< Load JSON string into this object

--- a/src/Coordinate.h
+++ b/src/Coordinate.h
@@ -68,7 +68,7 @@ namespace openshot {
 		/// @param co A std::pair<double, double> tuple containing (X, Y)
 		Coordinate(const std::pair<double, double>& co);
 
-		/// Get and Set JSON methods
+		// Get and Set JSON methods
 		std::string Json() const; ///< Generate JSON string of this object
 		Json::Value JsonValue() const; ///< Generate Json::Value for this object
 		void SetJson(const std::string value); ///< Load JSON string into this object

--- a/src/CrashHandler.h
+++ b/src/CrashHandler.h
@@ -63,7 +63,6 @@ namespace openshot {
 		CrashHandler(CrashHandler const&) = delete;             // Don't allow the user to copy this instance
 
 		/// Default assignment operator
-		//CrashHandler & operator=(CrashHandler const&){};  // Don't allow the user to assign this instance
 		CrashHandler & operator=(CrashHandler const&) = delete;  // Don't allow the user to assign this instance
 
 		/// Private variable to keep track of singleton instance

--- a/src/DecklinkReader.h
+++ b/src/DecklinkReader.h
@@ -116,7 +116,7 @@ namespace openshot
 		/// Return the type name of the class
 		std::string Name() { return "DecklinkReader"; };
 
-		/// Get and Set JSON methods
+		// Get and Set JSON methods
 		std::string Json() const override; ///< Generate JSON string of this object
 		void SetJson(const std::string value); ///< Load JSON string into this object
 		Json::Value JsonValue() const; ///< Generate Json::Value for this object

--- a/src/DummyReader.h
+++ b/src/DummyReader.h
@@ -142,7 +142,7 @@ namespace openshot
 		/// Return the type name of the class
 		std::string Name() override { return "DummyReader"; };
 
-		/// Get and Set JSON methods
+		// Get and Set JSON methods
 		std::string Json() const override; ///< Generate JSON string of this object
 		void SetJson(const std::string value) override; ///< Load JSON string into this object
 		Json::Value JsonValue() const override; ///< Generate Json::Value for this object

--- a/src/EffectBase.h
+++ b/src/EffectBase.h
@@ -92,7 +92,7 @@ namespace openshot
 		/// Set parent clip object of this effect
 		void ParentClip(openshot::ClipBase* new_clip);
 
-		/// Get and Set JSON methods
+		// Get and Set JSON methods
 		virtual std::string Json() const = 0; ///< Generate JSON string of this object
 		virtual void SetJson(const std::string value) = 0; ///< Load JSON string into this object
 		virtual Json::Value JsonValue() const = 0; ///< Generate Json::Value for this object

--- a/src/EffectInfo.h
+++ b/src/EffectInfo.h
@@ -47,10 +47,10 @@ namespace openshot
 	class EffectInfo
 	{
 	public:
-		// Create an instance of an effect (factory style)
+		/// Create an instance of an effect (factory style)
 		EffectBase* CreateEffect(std::string effect_type);
 
-		/// JSON methods
+		// JSON methods
 		static std::string Json(); ///< Generate JSON string of this object
 		static Json::Value JsonValue(); ///< Generate Json::Value for this object
 

--- a/src/Exceptions.h
+++ b/src/Exceptions.h
@@ -41,7 +41,7 @@ namespace openshot {
 	 * A std::exception-derived exception class with custom message.
 	 * All OpenShot exception classes inherit from this class.
 	 */
-	class ExceptionBase : public std::exception //: public exception
+	class ExceptionBase : public std::exception
 	{
 	protected:
 		std::string m_message;

--- a/src/Exceptions.h
+++ b/src/Exceptions.h
@@ -370,7 +370,7 @@ namespace openshot {
 #ifndef SWIG
 	/// Exception when too many seek attempts happen
 	class
-	__attribute__ ((deprecated (TMS_DEP_MSG) ))
+	__attribute__ ((deprecated(TMS_DEP_MSG)))
 	TooManySeeks : public ExceptionBase
 	{
 	public:
@@ -381,11 +381,7 @@ namespace openshot {
 		 * @param message A message to accompany the exception
 		 * @param file_path (optional) The input file being processed
 		 */
-		TooManySeeks(std::string message, std::string file_path="")
-#ifndef SWIG
-		__attribute__ ((deprecated (TMS_DEP_MSG) ))
-#endif
-			: ExceptionBase(message), file_path(file_path) { }
+		TooManySeeks(std::string message, std::string file_path="") __attribute__ ((deprecated(TMS_DEP_MSG)));
 		virtual ~TooManySeeks() noexcept {}
 	};
 #endif

--- a/src/FFmpegReader.h
+++ b/src/FFmpegReader.h
@@ -265,7 +265,7 @@ namespace openshot {
 		/// Return the type name of the class
 		std::string Name() override { return "FFmpegReader"; };
 
-		/// Get and Set JSON methods
+		// Get and Set JSON methods
 		std::string Json() const override; ///< Generate JSON string of this object
 		void SetJson(const std::string value) override; ///< Load JSON string into this object
 		Json::Value JsonValue() const override; ///< Generate Json::Value for this object

--- a/src/FrameMapper.h
+++ b/src/FrameMapper.h
@@ -199,7 +199,7 @@ namespace openshot
 		/// Return the type name of the class
 		std::string Name() override { return "FrameMapper"; };
 
-		/// Get and Set JSON methods
+		// Get and Set JSON methods
 		std::string Json() const override; ///< Generate JSON string of this object
 		void SetJson(const std::string value) override; ///< Load JSON string into this object
 		Json::Value JsonValue() const override; ///< Generate Json::Value for this object

--- a/src/ImageReader.h
+++ b/src/ImageReader.h
@@ -107,7 +107,7 @@ namespace openshot
 		/// Return the type name of the class
 		std::string Name() override { return "ImageReader"; };
 
-		/// Get and Set JSON methods
+		// Get and Set JSON methods
 		std::string Json() const override; ///< Generate JSON string of this object
 		void SetJson(const std::string value) override; ///< Load JSON string into this object
 		Json::Value JsonValue() const override; ///< Generate Json::Value for this object

--- a/src/KeyFrame.h
+++ b/src/KeyFrame.h
@@ -126,7 +126,7 @@ namespace openshot {
 		/// Get the direction of the curve at a specific index (increasing or decreasing)
 		bool IsIncreasing(int index) const;
 
-		/// Get and Set JSON methods
+		// Get and Set JSON methods
 		std::string Json() const; ///< Generate JSON string of this object
 		Json::Value JsonValue() const; ///< Generate Json::Value for this object
 		void SetJson(const std::string value); ///< Load JSON string into this object

--- a/src/Point.h
+++ b/src/Point.h
@@ -118,7 +118,7 @@ namespace openshot
 		/// Set the right handle to a percent of the primary coordinate (0 to 1)
 		void Initialize_RightHandle(float x, float y);
 
-		/// Get and Set JSON methods
+		// Get and Set JSON methods
 		std::string Json() const; ///< Generate JSON string of this object
 		Json::Value JsonValue() const; ///< Generate Json::Value for this object
 		void SetJson(const std::string value); ///< Load JSON string into this object

--- a/src/Profiles.h
+++ b/src/Profiles.h
@@ -88,7 +88,7 @@ namespace openshot
 		/// @param path 	The folder path / location of a profile file
 		Profile(std::string path);
 
-		/// Get and Set JSON methods
+		// Get and Set JSON methods
 		std::string Json() const; ///< Generate JSON string of this object
 		Json::Value JsonValue() const; ///< Generate Json::Value for this object
 		void SetJson(const std::string value); ///< Load JSON string into this object

--- a/src/QtHtmlReader.h
+++ b/src/QtHtmlReader.h
@@ -132,7 +132,7 @@ namespace openshot
 		/// Return the type name of the class
 		std::string Name() override { return "QtHtmlReader"; };
 
-		/// Get and Set JSON methods
+		// Get and Set JSON methods
 		std::string Json() const override; ///< Generate JSON string of this object
 		void SetJson(const std::string value) override; ///< Load JSON string into this object
 		Json::Value JsonValue() const override; ///< Generate Json::Value for this object

--- a/src/QtImageReader.h
+++ b/src/QtImageReader.h
@@ -114,7 +114,7 @@ namespace openshot
 		/// Return the type name of the class
 		std::string Name() override { return "QtImageReader"; };
 
-		/// Get and Set JSON methods
+		// Get and Set JSON methods
 		std::string Json() const override; ///< Generate JSON string of this object
 		void SetJson(const std::string value) override; ///< Load JSON string into this object
 		Json::Value JsonValue() const override; ///< Generate Json::Value for this object

--- a/src/QtTextReader.h
+++ b/src/QtTextReader.h
@@ -143,7 +143,7 @@ namespace openshot
 		/// Return the type name of the class
 		std::string Name() override { return "QtTextReader"; };
 
-		/// Get and Set JSON methods
+		// Get and Set JSON methods
 		std::string Json() const override; ///< Generate JSON string of this object
 		void SetJson(const std::string value) override; ///< Load JSON string into this object
 		Json::Value JsonValue() const override; ///< Generate Json::Value for this object

--- a/src/ReaderBase.h
+++ b/src/ReaderBase.h
@@ -139,7 +139,7 @@ namespace openshot
 		/// Return the type name of the class
 		virtual std::string Name() = 0;
 
-		/// Get and Set JSON methods
+		// Get and Set JSON methods
 		virtual std::string Json() const = 0; ///< Generate JSON string of this object
 		virtual void SetJson(const std::string value) = 0; ///< Load JSON string into this object
 		virtual Json::Value JsonValue() const = 0; ///< Generate Json::Value for this object

--- a/src/TextReader.h
+++ b/src/TextReader.h
@@ -141,7 +141,7 @@ namespace openshot
 		/// Return the type name of the class
 		std::string Name() override { return "TextReader"; };
 
-		/// Get and Set JSON methods
+		// Get and Set JSON methods
 		std::string Json() const override; ///< Generate JSON string of this object
 		void SetJson(const std::string value) override; ///< Load JSON string into this object
 		Json::Value JsonValue() const override; ///< Generate Json::Value for this object

--- a/src/Timeline.h
+++ b/src/Timeline.h
@@ -185,7 +185,7 @@ namespace openshot {
 		/// Apply a FrameMapper to a clip which matches the settings of this timeline
 		void apply_mapper_to_clip(openshot::Clip* clip);
 
-		/// Apply JSON Diffs to various objects contained in this timeline
+		// Apply JSON Diffs to various objects contained in this timeline
 		void apply_json_to_clips(Json::Value change); ///<Apply JSON diff to clips
 		void apply_json_to_effects(Json::Value change); ///< Apply JSON diff to effects
 		void apply_json_to_effects(Json::Value change, openshot::EffectBase* existing_effect); ///<Apply JSON diff to a specific effect
@@ -312,7 +312,7 @@ namespace openshot {
 		/// Return the type name of the class
 		std::string Name() override { return "Timeline"; };
 
-		/// Get and Set JSON methods
+		// Get and Set JSON methods
 		std::string Json() const override; ///< Generate JSON string of this object
 		void SetJson(const std::string value) override; ///< Load JSON string into this object
 		Json::Value JsonValue() const override; ///< Generate Json::Value for this object

--- a/src/WriterBase.h
+++ b/src/WriterBase.h
@@ -106,7 +106,7 @@ namespace openshot
 		/// This method is required for all derived classes of WriterBase.  Write a block of frames from a reader.
 		virtual void WriteFrame(openshot::ReaderBase* reader, int64_t start, int64_t length) = 0;
 
-		/// Get and Set JSON methods
+		// Get and Set JSON methods
 		std::string Json() const; ///< Generate JSON string of this object
 		Json::Value JsonValue() const; ///< Generate Json::Value for this object
 		void SetJson(const std::string value); ///< Load JSON string into this object

--- a/src/effects/Bars.h
+++ b/src/effects/Bars.h
@@ -96,7 +96,7 @@ namespace openshot
 		/// @param frame_number The frame number (starting at 1) of the clip or effect on the timeline.
 		std::shared_ptr<openshot::Frame> GetFrame(std::shared_ptr<openshot::Frame> frame, int64_t frame_number) override;
 
-		/// Get and Set JSON methods
+		// Get and Set JSON methods
 		std::string Json() const override; ///< Generate JSON string of this object
 		void SetJson(const std::string value) override; ///< Load JSON string into this object
 		Json::Value JsonValue() const override; ///< Generate Json::Value for this object

--- a/src/effects/Blur.h
+++ b/src/effects/Blur.h
@@ -57,7 +57,7 @@ namespace openshot
 		/// Init effect settings
 		void init_effect_details();
 
-		/// Internal blur methods (inspired and credited to http://blog.ivank.net/fastest-gaussian-blur.html)
+		// Internal blur methods (inspired and credited to http://blog.ivank.net/fastest-gaussian-blur.html)
 		void boxBlurH(unsigned char *scl, unsigned char *tcl, int w, int h, int r);
 		void boxBlurT(unsigned char *scl, unsigned char *tcl, int w, int h, int r);
 
@@ -99,7 +99,7 @@ namespace openshot
 		/// @param frame_number The frame number (starting at 1) of the clip or effect on the timeline.
 		std::shared_ptr<openshot::Frame> GetFrame(std::shared_ptr<openshot::Frame> frame, int64_t frame_number) override;
 
-		/// Get and Set JSON methods
+		// Get and Set JSON methods
 		std::string Json() const override; ///< Generate JSON string of this object
 		void SetJson(const std::string value) override; ///< Load JSON string into this object
 		Json::Value JsonValue() const override; ///< Generate Json::Value for this object

--- a/src/effects/Brightness.h
+++ b/src/effects/Brightness.h
@@ -88,7 +88,7 @@ namespace openshot
 		/// @param frame_number The frame number (starting at 1) of the clip or effect on the timeline.
 		std::shared_ptr<openshot::Frame> GetFrame(std::shared_ptr<openshot::Frame> frame, int64_t frame_number) override;
 
-		/// Get and Set JSON methods
+		// Get and Set JSON methods
 		std::string Json() const override; ///< Generate JSON string of this object
 		void SetJson(const std::string value) override; ///< Load JSON string into this object
 		Json::Value JsonValue() const override; ///< Generate Json::Value for this object

--- a/src/effects/Caption.h
+++ b/src/effects/Caption.h
@@ -117,7 +117,7 @@ public:
 	std::string CaptionText(); ///< Set the caption string to use (see VTT format)
 	void CaptionText(std::string new_caption_text); ///< Get the caption string
 
-	/// Get and Set JSON methods
+	// Get and Set JSON methods
 	std::string Json() const override; ///< Generate JSON string of this object
 	void SetJson(const std::string value) override; ///< Load JSON string into this object
 	Json::Value JsonValue() const override; ///< Generate Json::Value for this object

--- a/src/effects/ChromaKey.h
+++ b/src/effects/ChromaKey.h
@@ -91,7 +91,7 @@ namespace openshot
 		/// @param frame_number The frame number (starting at 1) of the clip or effect on the timeline.
 		std::shared_ptr<openshot::Frame> GetFrame(std::shared_ptr<openshot::Frame> frame, int64_t frame_number) override;
 
-		/// Get and Set JSON methods
+		// Get and Set JSON methods
 		std::string Json() const override; ///< Generate JSON string of this object
 		void SetJson(const std::string value) override; ///< Load JSON string into this object
 		Json::Value JsonValue() const override; ///< Generate Json::Value for this object

--- a/src/effects/ColorShift.h
+++ b/src/effects/ColorShift.h
@@ -100,7 +100,7 @@ namespace openshot
 		/// @param frame_number The frame number (starting at 1) of the clip or effect on the timeline.
 		std::shared_ptr<openshot::Frame> GetFrame(std::shared_ptr<openshot::Frame> frame, int64_t frame_number) override;
 
-		/// Get and Set JSON methods
+		// Get and Set JSON methods
 		std::string Json() const override; ///< Generate JSON string of this object
 		void SetJson(const std::string value) override; ///< Load JSON string into this object
 		Json::Value JsonValue() const override; ///< Generate Json::Value for this object

--- a/src/effects/Crop.h
+++ b/src/effects/Crop.h
@@ -96,7 +96,7 @@ namespace openshot
 		/// @param frame_number The frame number (starting at 1) of the clip or effect on the timeline.
 		std::shared_ptr<openshot::Frame> GetFrame(std::shared_ptr<openshot::Frame> frame, int64_t frame_number) override;
 
-		/// Get and Set JSON methods
+		// Get and Set JSON methods
 		std::string Json() const override; ///< Generate JSON string of this object
 		void SetJson(const std::string value) override; ///< Load JSON string into this object
 		Json::Value JsonValue() const override; ///< Generate Json::Value for this object

--- a/src/effects/Deinterlace.h
+++ b/src/effects/Deinterlace.h
@@ -59,10 +59,10 @@ namespace openshot
 
 	public:
 
-		/// Blank constructor, useful when using Json to load the effect properties
+		/// Default constructor, useful when using Json to load the effect properties
 		Deinterlace();
 
-		/// Default constructor
+		/// Constructor
 		Deinterlace(bool isOdd);
 
 		/// @brief This method is required for all derived classes of ClipBase, and returns a
@@ -84,7 +84,7 @@ namespace openshot
 		/// @param frame_number The frame number (starting at 1) of the clip or effect on the timeline.
 		std::shared_ptr<openshot::Frame> GetFrame(std::shared_ptr<openshot::Frame> frame, int64_t frame_number) override;
 
-		/// Get and Set JSON methods
+		// Get and Set JSON methods
 		std::string Json() const override; ///< Generate JSON string of this object
 		void SetJson(const std::string value) override; ///< Load JSON string into this object
 		Json::Value JsonValue() const override; ///< Generate Json::Value for this object

--- a/src/effects/Hue.h
+++ b/src/effects/Hue.h
@@ -60,10 +60,10 @@ namespace openshot
 	public:
 		Keyframe hue;	///< Shift the hue coordinates (left or right)
 
-		/// Blank constructor, useful when using Json to load the effect properties
+		/// Default constructor, useful when using Json to load the effect properties
 		Hue();
 
-		/// Default constructor, which takes 1 curve. The curves will shift the hue of the image.
+		/// Constructor which takes 1 curve. The curves will shift the hue of the image.
 		///
 		/// @param hue The curve to adjust the hue shift (between 0 and 1)
 		Hue(Keyframe hue);
@@ -87,7 +87,7 @@ namespace openshot
 		/// @param frame_number The frame number (starting at 1) of the clip or effect on the timeline.
 		std::shared_ptr<openshot::Frame> GetFrame(std::shared_ptr<openshot::Frame> frame, int64_t frame_number) override;
 
-		/// Get and Set JSON methods
+		// Get and Set JSON methods
 		std::string Json() const override; ///< Generate JSON string of this object
 		void SetJson(const std::string value) override; ///< Load JSON string into this object
 		Json::Value JsonValue() const override; ///< Generate Json::Value for this object

--- a/src/effects/Mask.h
+++ b/src/effects/Mask.h
@@ -97,7 +97,7 @@ namespace openshot
 		/// @param frame_number The frame number (starting at 1) of the clip or effect on the timeline.
 		std::shared_ptr<openshot::Frame> GetFrame(std::shared_ptr<openshot::Frame> frame, int64_t frame_number) override;
 
-		/// Get and Set JSON methods
+		// Get and Set JSON methods
 		std::string Json() const override; ///< Generate JSON string of this object
 		void SetJson(const std::string value) override; ///< Load JSON string into this object
 		Json::Value JsonValue() const override; ///< Generate Json::Value for this object

--- a/src/effects/Negate.h
+++ b/src/effects/Negate.h
@@ -75,7 +75,7 @@ namespace openshot
 		/// @param frame_number The frame number (starting at 1) of the clip or effect on the timeline.
 		std::shared_ptr<openshot::Frame> GetFrame(std::shared_ptr<openshot::Frame> frame, int64_t frame_number) override;
 
-		/// Get and Set JSON methods
+		// Get and Set JSON methods
 		std::string Json() const override; ///< Generate JSON string of this object
 		void SetJson(const std::string value) override; ///< Load JSON string into this object
 		Json::Value JsonValue() const override; ///< Generate Json::Value for this object

--- a/src/effects/ObjectDetection.h
+++ b/src/effects/ObjectDetection.h
@@ -78,11 +78,9 @@ namespace openshot
 
 	public:
 
-		/// Blank constructor, useful when using Json to load the effect properties
-		ObjectDetection(std::string clipTrackerDataPath);
+        ObjectDetection();
 
-		/// Default constructor
-		ObjectDetection();
+		ObjectDetection(std::string clipTrackerDataPath);
 
 		/// @brief This method is required for all derived classes of EffectBase, and returns a
 		/// modified openshot::Frame object
@@ -97,12 +95,12 @@ namespace openshot
 
 		std::shared_ptr<openshot::Frame> GetFrame(int64_t frame_number) override { return GetFrame(std::shared_ptr<Frame> (new Frame()), frame_number); }
 
-		// Load protobuf data file
+		/// Load protobuf data file
         bool LoadObjDetectdData(std::string inputFilePath);
 
 		DetectionData GetTrackedData(size_t frameId);
 
-		/// Get and Set JSON methods
+		// Get and Set JSON methods
 		std::string Json() const override; ///< Generate JSON string of this object
 		void SetJson(const std::string value) override; ///< Load JSON string into this object
 		Json::Value JsonValue() const override; ///< Generate Json::Value for this object

--- a/src/effects/ObjectDetection.h
+++ b/src/effects/ObjectDetection.h
@@ -59,57 +59,57 @@ struct DetectionData{
 
 namespace openshot
 {
-	/**
-	 * @brief This effect displays all the detected objects on a clip.
-	 */
-	class ObjectDetection : public EffectBase
-	{
-	private:
-		std::string protobuf_data_path;
-		std::map<size_t, DetectionData> detectionsData;
-		std::vector<std::string> classNames;
+    /**
+     * @brief This effect displays all the detected objects on a clip.
+     */
+    class ObjectDetection : public EffectBase
+    {
+    private:
+        std::string protobuf_data_path;
+        std::map<size_t, DetectionData> detectionsData;
+        std::vector<std::string> classNames;
 
-		std::vector<cv::Scalar> classesColor;
+        std::vector<cv::Scalar> classesColor;
 
-		/// Init effect settings
-		void init_effect_details();
+        /// Init effect settings
+        void init_effect_details();
 
-		void drawPred(int classId, float conf, cv::Rect2d box, cv::Mat& frame);
+        void drawPred(int classId, float conf, cv::Rect2d box, cv::Mat& frame);
 
-	public:
+    public:
 
         ObjectDetection();
 
-		ObjectDetection(std::string clipTrackerDataPath);
+        ObjectDetection(std::string clipTrackerDataPath);
 
-		/// @brief This method is required for all derived classes of EffectBase, and returns a
-		/// modified openshot::Frame object
-		///
-		/// The frame object is passed into this method, and a frame_number is passed in which
-		/// tells the effect which settings to use from its keyframes (starting at 1).
-		///
-		/// @returns The modified openshot::Frame object
-		/// @param frame The frame object that needs the effect applied to it
-		/// @param frame_number The frame number (starting at 1) of the effect on the timeline.
-		std::shared_ptr<Frame> GetFrame(std::shared_ptr<Frame> frame, int64_t frame_number) override;
+        /// @brief This method is required for all derived classes of EffectBase, and returns a
+        /// modified openshot::Frame object
+        ///
+        /// The frame object is passed into this method, and a frame_number is passed in which
+        /// tells the effect which settings to use from its keyframes (starting at 1).
+        ///
+        /// @returns The modified openshot::Frame object
+        /// @param frame The frame object that needs the effect applied to it
+        /// @param frame_number The frame number (starting at 1) of the effect on the timeline.
+        std::shared_ptr<Frame> GetFrame(std::shared_ptr<Frame> frame, int64_t frame_number) override;
 
-		std::shared_ptr<openshot::Frame> GetFrame(int64_t frame_number) override { return GetFrame(std::make_shared<Frame>(), frame_number); }
+        std::shared_ptr<openshot::Frame> GetFrame(int64_t frame_number) override { return GetFrame(std::make_shared<Frame>(), frame_number); }
 
-		/// Load protobuf data file
+        /// Load protobuf data file
         bool LoadObjDetectdData(std::string inputFilePath);
 
-		DetectionData GetTrackedData(size_t frameId);
+        DetectionData GetTrackedData(size_t frameId);
 
-		// Get and Set JSON methods
-		std::string Json() const override; ///< Generate JSON string of this object
-		void SetJson(const std::string value) override; ///< Load JSON string into this object
-		Json::Value JsonValue() const override; ///< Generate Json::Value for this object
-		void SetJsonValue(const Json::Value root) override; ///< Load Json::Value into this object
+        // Get and Set JSON methods
+        std::string Json() const override; ///< Generate JSON string of this object
+        void SetJson(const std::string value) override; ///< Load JSON string into this object
+        Json::Value JsonValue() const override; ///< Generate Json::Value for this object
+        void SetJsonValue(const Json::Value root) override; ///< Load Json::Value into this object
 
-		/// Get all properties for a specific frame (perfect for a UI to display the current state
-		/// of all properties at any time)
-		std::string PropertiesJSON(int64_t requested_frame) const override;
-	};
+        /// Get all properties for a specific frame (perfect for a UI to display the current state
+        /// of all properties at any time)
+        std::string PropertiesJSON(int64_t requested_frame) const override;
+    };
 
 }
 

--- a/src/effects/ObjectDetection.h
+++ b/src/effects/ObjectDetection.h
@@ -93,7 +93,7 @@ namespace openshot
 		/// @param frame_number The frame number (starting at 1) of the effect on the timeline.
 		std::shared_ptr<Frame> GetFrame(std::shared_ptr<Frame> frame, int64_t frame_number) override;
 
-		std::shared_ptr<openshot::Frame> GetFrame(int64_t frame_number) override { return GetFrame(std::shared_ptr<Frame> (new Frame()), frame_number); }
+		std::shared_ptr<openshot::Frame> GetFrame(int64_t frame_number) override { return GetFrame(std::make_shared<Frame>(), frame_number); }
 
 		/// Load protobuf data file
         bool LoadObjDetectdData(std::string inputFilePath);

--- a/src/effects/Pixelate.h
+++ b/src/effects/Pixelate.h
@@ -63,10 +63,10 @@ namespace openshot
 		Keyframe right;			///< Size of right margin
 		Keyframe bottom;		///< Size of bottom margin
 
-		/// Blank constructor, useful when using Json to load the effect properties
+		/// Default constructor, useful when using Json to load the effect properties
 		Pixelate();
 
-		/// Default constructor, which takes 5 curves. These curves animate the pixelization effect over time.
+		/// Cnstructor which takes 5 curves. These curves animate the pixelization effect over time.
 		///
 		/// @param pixelization The curve to adjust the amount of pixelization (0 to 1)
 		/// @param left The curve to adjust the left margin size (between 0 and 1)
@@ -94,7 +94,7 @@ namespace openshot
 		/// @param frame_number The frame number (starting at 1) of the clip or effect on the timeline.
 		std::shared_ptr<openshot::Frame> GetFrame(std::shared_ptr<openshot::Frame> frame, int64_t frame_number) override;
 
-		/// Get and Set JSON methods
+		// Get and Set JSON methods
 		std::string Json() const override; ///< Generate JSON string of this object
 		void SetJson(const std::string value) override; ///< Load JSON string into this object
 		Json::Value JsonValue() const override; ///< Generate Json::Value for this object

--- a/src/effects/Saturation.h
+++ b/src/effects/Saturation.h
@@ -99,7 +99,7 @@ namespace openshot
 		/// @param frame_number The frame number (starting at 1) of the clip or effect on the timeline.
 		std::shared_ptr<openshot::Frame> GetFrame(std::shared_ptr<openshot::Frame> frame, int64_t frame_number) override;
 
-		/// Get and Set JSON methods
+		// Get and Set JSON methods
 		std::string Json() const override; ///< Generate JSON string of this object
 		void SetJson(const std::string value) override; ///< Load JSON string into this object
 		Json::Value JsonValue() const override; ///< Generate Json::Value for this object

--- a/src/effects/Shift.h
+++ b/src/effects/Shift.h
@@ -90,7 +90,7 @@ namespace openshot
 		/// @param frame_number The frame number (starting at 1) of the clip or effect on the timeline.
 		std::shared_ptr<openshot::Frame> GetFrame(std::shared_ptr<openshot::Frame> frame, int64_t frame_number) override;
 
-		/// Get and Set JSON methods
+		// Get and Set JSON methods
 		std::string Json() const override; ///< Generate JSON string of this object
 		void SetJson(const std::string value) override; ///< Load JSON string into this object
 		Json::Value JsonValue() const override; ///< Generate Json::Value for this object

--- a/src/effects/Stabilizer.h
+++ b/src/effects/Stabilizer.h
@@ -94,11 +94,9 @@ namespace openshot
 		std::map <size_t,EffectCamTrajectory> trajectoryData; // Save camera trajectory data
 		std::map <size_t,EffectTransformParam> transformationData; // Save transormation data
 
-		/// Blank constructor, useful when using Json to load the effect properties
-		Stabilizer(std::string clipTrackerDataPath);
+        Stabilizer();
 
-		/// Default constructor
-		Stabilizer();
+		Stabilizer(std::string clipTrackerDataPath);
 
 		/// @brief This method is required for all derived classes of EffectBase, and returns a
 		/// modified openshot::Frame object
@@ -115,10 +113,10 @@ namespace openshot
 			return GetFrame(std::make_shared<openshot::Frame>(), frame_number);
 		};
 
-		// Load protobuf data file
+		/// Load protobuf data file
 		bool LoadStabilizedData(std::string inputFilePath);
 
-		/// Get and Set JSON methods
+		// Get and Set JSON methods
 		std::string Json() const override; ///< Generate JSON string of this object
 		void SetJson(const std::string value) override; ///< Load JSON string into this object
 		Json::Value JsonValue() const override; ///< Generate Json::Value for this object

--- a/src/effects/Stabilizer.h
+++ b/src/effects/Stabilizer.h
@@ -75,57 +75,57 @@ struct EffectCamTrajectory
 namespace openshot
 {
 
-	/**
-	 * @brief This class stabilizes video clip to remove undesired shaking and jitter.
-	 *
-	 * Adding stabilization is useful to increase video quality overall, since it removes
-	 * from subtle to harsh unexpected camera movements.
-	 */
-	class Stabilizer : public EffectBase
-	{
-	private:
-		/// Init effect settings
-		void init_effect_details();
-		std::string protobuf_data_path;
-		Keyframe zoom;
+    /**
+     * @brief This class stabilizes video clip to remove undesired shaking and jitter.
+     *
+     * Adding stabilization is useful to increase video quality overall, since it removes
+     * from subtle to harsh unexpected camera movements.
+     */
+    class Stabilizer : public EffectBase
+    {
+    private:
+        /// Init effect settings
+        void init_effect_details();
+        std::string protobuf_data_path;
+        Keyframe zoom;
 
-	public:
-		std::string teste;
-		std::map <size_t,EffectCamTrajectory> trajectoryData; // Save camera trajectory data
-		std::map <size_t,EffectTransformParam> transformationData; // Save transormation data
+    public:
+        std::string teste;
+        std::map <size_t,EffectCamTrajectory> trajectoryData; // Save camera trajectory data
+        std::map <size_t,EffectTransformParam> transformationData; // Save transormation data
 
         Stabilizer();
 
-		Stabilizer(std::string clipTrackerDataPath);
+        Stabilizer(std::string clipTrackerDataPath);
 
-		/// @brief This method is required for all derived classes of EffectBase, and returns a
-		/// modified openshot::Frame object
-		///
-		/// The frame object is passed into this method, and a frame_number is passed in which
-		/// tells the effect which settings to use from its keyframes (starting at 1).
-		///
-		/// @returns The modified openshot::Frame object
-		/// @param frame The frame object that needs the effect applied to it
-		/// @param frame_number The frame number (starting at 1) of the effect on the timeline.
-		std::shared_ptr<Frame> GetFrame(std::shared_ptr<Frame> frame, int64_t frame_number) override;
+        /// @brief This method is required for all derived classes of EffectBase, and returns a
+        /// modified openshot::Frame object
+        ///
+        /// The frame object is passed into this method, and a frame_number is passed in which
+        /// tells the effect which settings to use from its keyframes (starting at 1).
+        ///
+        /// @returns The modified openshot::Frame object
+        /// @param frame The frame object that needs the effect applied to it
+        /// @param frame_number The frame number (starting at 1) of the effect on the timeline.
+        std::shared_ptr<Frame> GetFrame(std::shared_ptr<Frame> frame, int64_t frame_number) override;
 
-		std::shared_ptr<openshot::Frame> GetFrame(int64_t frame_number) override {
-			return GetFrame(std::make_shared<openshot::Frame>(), frame_number);
-		};
+        std::shared_ptr<openshot::Frame> GetFrame(int64_t frame_number) override {
+            return GetFrame(std::make_shared<openshot::Frame>(), frame_number);
+        };
 
-		/// Load protobuf data file
-		bool LoadStabilizedData(std::string inputFilePath);
+        /// Load protobuf data file
+        bool LoadStabilizedData(std::string inputFilePath);
 
-		// Get and Set JSON methods
-		std::string Json() const override; ///< Generate JSON string of this object
-		void SetJson(const std::string value) override; ///< Load JSON string into this object
-		Json::Value JsonValue() const override; ///< Generate Json::Value for this object
-		void SetJsonValue(const Json::Value root) override; ///< Load Json::Value into this object
+        // Get and Set JSON methods
+        std::string Json() const override; ///< Generate JSON string of this object
+        void SetJson(const std::string value) override; ///< Load JSON string into this object
+        Json::Value JsonValue() const override; ///< Generate Json::Value for this object
+        void SetJsonValue(const Json::Value root) override; ///< Load Json::Value into this object
 
-		/// Get all properties for a specific frame (perfect for a UI to display the current state
-		/// of all properties at any time)
-		std::string PropertiesJSON(int64_t requested_frame) const override;
-	};
+        /// Get all properties for a specific frame (perfect for a UI to display the current state
+        /// of all properties at any time)
+        std::string PropertiesJSON(int64_t requested_frame) const override;
+    };
 
 }
 

--- a/src/effects/Tracker.h
+++ b/src/effects/Tracker.h
@@ -88,11 +88,9 @@ namespace openshot
 
 		std::map<int, EffectFrameData> trackedDataById; // Save object tracking box data
 
-		/// Blank constructor, useful when using Json to load the effect properties
-		Tracker(std::string clipTrackerDataPath);
+        Tracker();
 
-		/// Default constructor
-		Tracker();
+		Tracker(std::string clipTrackerDataPath);
 
 		/// @brief This method is required for all derived classes of EffectBase, and returns a
 		/// modified openshot::Frame object
@@ -106,13 +104,13 @@ namespace openshot
 		std::shared_ptr<Frame> GetFrame(std::shared_ptr<Frame> frame, int64_t frame_number) override;
 		std::shared_ptr<openshot::Frame> GetFrame(int64_t frame_number) override { return GetFrame(std::shared_ptr<Frame> (new Frame()), frame_number); }
 
-		// Load protobuf data file
+		/// Load protobuf data file
 		bool LoadTrackedData(std::string inputFilePath);
 
-		// Get tracker info for the desired frame
+		/// Get tracker info for the desired frame
 		EffectFrameData GetTrackedData(size_t frameId);
 
-		/// Get and Set JSON methods
+		// Get and Set JSON methods
 		std::string Json() const override; ///< Generate JSON string of this object
 		void SetJson(const std::string value) override; ///< Load JSON string into this object
 		Json::Value JsonValue() const override; ///< Generate Json::Value for this object

--- a/src/effects/Tracker.h
+++ b/src/effects/Tracker.h
@@ -72,54 +72,56 @@ struct EffectFrameData{
 
 namespace openshot
 {
-	/**
-	 * @brief This class track a given object through the clip and, when called, draws a box surrounding it.
-	 *
-	 * Tracking is useful to better visualize and follow the movement of an object through video.
-	 */
-	class Tracker : public EffectBase
-	{
-	private:
-		/// Init effect settings
-		void init_effect_details();
-		std::string protobuf_data_path;
+    /**
+     * @brief This class track a given object through the clip and, when called, draws a box surrounding it.
+     *
+     * Tracking is useful to better visualize and follow the movement of an object through video.
+     */
+    class Tracker : public EffectBase
+    {
+    private:
+        /// Init effect settings
+        void init_effect_details();
+        std::string protobuf_data_path;
 
-	public:
+    public:
 
-		std::map<int, EffectFrameData> trackedDataById; // Save object tracking box data
+        std::map<int, EffectFrameData> trackedDataById; // Save object tracking box data
 
+        /// Blank constructor, useful when using Json to load the effect properties
+        Tracker(std::string clipTrackerDataPath);
+
+        /// Default constructor
         Tracker();
 
-		Tracker(std::string clipTrackerDataPath);
+        /// @brief This method is required for all derived classes of EffectBase, and returns a
+        /// modified openshot::Frame object
+        ///
+        /// The frame object is passed into this method, and a frame_number is passed in which
+        /// tells the effect which settings to use from its keyframes (starting at 1).
+        ///
+        /// @returns The modified openshot::Frame object
+        /// @param frame The frame object that needs the effect applied to it
+        /// @param frame_number The frame number (starting at 1) of the effect on the timeline.
+        std::shared_ptr<Frame> GetFrame(std::shared_ptr<Frame> frame, int64_t frame_number) override;
+        std::shared_ptr<openshot::Frame> GetFrame(int64_t frame_number) override { return GetFrame(std::shared_ptr<Frame> (new Frame()), frame_number); }
 
-		/// @brief This method is required for all derived classes of EffectBase, and returns a
-		/// modified openshot::Frame object
-		///
-		/// The frame object is passed into this method, and a frame_number is passed in which
-		/// tells the effect which settings to use from its keyframes (starting at 1).
-		///
-		/// @returns The modified openshot::Frame object
-		/// @param frame The frame object that needs the effect applied to it
-		/// @param frame_number The frame number (starting at 1) of the effect on the timeline.
-		std::shared_ptr<Frame> GetFrame(std::shared_ptr<Frame> frame, int64_t frame_number) override;
-		std::shared_ptr<openshot::Frame> GetFrame(int64_t frame_number) override { return GetFrame(std::shared_ptr<Frame> (new Frame()), frame_number); }
+        // Load protobuf data file
+        bool LoadTrackedData(std::string inputFilePath);
 
-		/// Load protobuf data file
-		bool LoadTrackedData(std::string inputFilePath);
+        // Get tracker info for the desired frame
+        EffectFrameData GetTrackedData(size_t frameId);
 
-		/// Get tracker info for the desired frame
-		EffectFrameData GetTrackedData(size_t frameId);
+        // Get and Set JSON methods
+        std::string Json() const override; ///< Generate JSON string of this object
+        void SetJson(const std::string value) override; ///< Load JSON string into this object
+        Json::Value JsonValue() const override; ///< Generate Json::Value for this object
+        void SetJsonValue(const Json::Value root) override; ///< Load Json::Value into this object
 
-		// Get and Set JSON methods
-		std::string Json() const override; ///< Generate JSON string of this object
-		void SetJson(const std::string value) override; ///< Load JSON string into this object
-		Json::Value JsonValue() const override; ///< Generate Json::Value for this object
-		void SetJsonValue(const Json::Value root) override; ///< Load Json::Value into this object
-
-		/// Get all properties for a specific frame (perfect for a UI to display the current state
-		/// of all properties at any time)
-		std::string PropertiesJSON(int64_t requested_frame) const override;
-	};
+        /// Get all properties for a specific frame (perfect for a UI to display the current state
+        /// of all properties at any time)
+        std::string PropertiesJSON(int64_t requested_frame) const override;
+        };
 
 }
 

--- a/src/effects/Wave.h
+++ b/src/effects/Wave.h
@@ -65,10 +65,10 @@ namespace openshot
 		Keyframe shift_x;		///< Amount to shift X-axis
 		Keyframe speed_y;		///< Speed of the wave on the Y-axis
 
-		/// Blank constructor, useful when using Json to load the effect properties
+		/// Default constructor, useful when using Json to load the effect properties
 		Wave();
 
-		/// Default constructor, which takes 5 curves. The curves will distort the image.
+		/// Constructor which takes 5 curves. The curves will distort the image.
 		///
 		/// @param wavelength The curve to adjust the wavelength (0.0 to 3.0)
 		/// @param amplitude The curve to adjust the amplitude (0.0 to 5.0)
@@ -96,7 +96,7 @@ namespace openshot
 		/// @param frame_number The frame number (starting at 1) of the clip or effect on the timeline.
 		std::shared_ptr<openshot::Frame> GetFrame(std::shared_ptr<openshot::Frame> frame, int64_t frame_number) override;
 
-		/// Get and Set JSON methods
+		// Get and Set JSON methods
 		std::string Json() const override; ///< Generate JSON string of this object
 		void SetJson(const std::string value) override; ///< Load JSON string into this object
 		Json::Value JsonValue() const override; ///< Generate Json::Value for this object

--- a/src/sort_filter/KalmanTracker.h
+++ b/src/sort_filter/KalmanTracker.h
@@ -10,7 +10,7 @@
 
 #define StateType cv::Rect_<float>
 
-// This class represents the internel state of individual tracked objects observed as bounding box.
+/// This class represents the internel state of individual tracked objects observed as bounding box.
 class KalmanTracker
 {
 public:

--- a/tests/Timeline_Tests.cpp
+++ b/tests/Timeline_Tests.cpp
@@ -57,6 +57,7 @@ TEST(Constructor)
 	// Check values
 	CHECK_EQUAL(640, t1.info.width);
 	CHECK_EQUAL(480, t1.info.height);
+	CHECK_EQUAL("Timeline", t1.Name());
 
 	// Create a default fraction (should be 1/1)
 	Timeline t2(300, 240, fps, 44100, 2, LAYOUT_STEREO);


### PR DESCRIPTION
This PR fixes a few widespread issues with the documentation comments in our header files, that affect the Doxygen-generated API docs. The issues fixed are:

#### Using both documentation comment blocks and member comments together

Any given item (function, variable, etc.) can only have one documentation comment associated with it. This (though previously very common in our code) does not work:
```cpp
/// Get and Set JSON methods
void SetJson(const std::string value); ///< Load JSON string into this object
void SetJsonValue(const Json::Value root); ///< Load Json::Value into this object
```
It will result in the documentation for `SetJson` being "Get and Set JSON methods", as the preceding-comment-block documentation will always take priority.

(Technically member documentation — the trailing `///< ...` type — [isn't supposed to be used for functions _at all_](https://www.doxygen.nl/manual/docblocks.html#memberdoc), only for variables and members of structs and enums. I think it only works here because class methods are technically members of a `struct`. But it'll still break if there's a preceding doc comment.)

#### Placing documentation comments over groups of functions

Documentation comments can only be used to document a single feature (class, function, variable, etc.). Placing a documentation comment over multiple functions doesn't make sense:
```cpp
/// Internal blur methods (inspired and credited to http://blog.ivank.net/fastest-gaussian-blur.html)
void boxBlurH(unsigned char *scl, unsigned char *tcl, int w, int h, int r);
void boxBlurT(unsigned char *scl, unsigned char *tcl, int w, int h, int r);
```
This will result in `boxBlurH` having the comment text as its documentation, and `boxBlurT` being undocumented.

#### Constructor terminology

Finally, a terminology note. A default constructor **is one that can be called with no arguments**. Full stop. [That is the definition](https://en.cppreference.com/w/cpp/language/default_constructor). A few of our headers contained documentation comments like this, which are just wrong and confusing:
```cpp
/// Blank constructor, useful when using Json to load the effect properties
Pixelate();

/// Default constructor, which takes 5 curves. These curves animate the pixelization effect over time.
Pixelate(Keyframe pixelization, Keyframe left, Keyframe top, Keyframe right, Keyframe bottom);
```
So, I tried to correct as many of those as I could, to label the correct constructor as the default.
That abuse of terminology so threw poor @BrennoCaldato that the OpenCV effect headers ended up with comments like _these_:
```cpp
/// Blank constructor, useful when using Json to load the effect properties
Tracker(std::string clipTrackerDataPath);

/// Default constructor
Tracker();
```
Which... I mean, the second comment is _correct_ so it's hard to fault it. Still, I  just removed those comments entirely because they didn't provide any API details that required documentation.

Hopefully I fixed all of these, I tried to find them all but I can't promise I didn't miss any.

Beyond those issues I also fixed some nested `#ifdef` nonsense I created in deprecating `TooManySeeks`, and polished up some other minor issues.