### PR TITLE
Set checkout fetch depth for codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      # Work around a codecov issue detecting commit SHAs
+      # see: https://community.codecov.io/t/issue-detecting-commit-sha-please-run-actions-checkout-with-fetch-depth-1-or-set-to-0/2571
+      with:
+        fetch-depth: 0
 
     - uses: haya14busa/action-cond@v1
       id: coverage


### PR DESCRIPTION
Honestly thought I'd already committed this, but I guess I was thinking of #636.

When used with Github Actions and its predefined `actions/checkout` step, Codecov needs the depth overridden in the default `git checkout --depth=1` command, which can be done by explicitly setting a `fetch-depth` option for `actions/checkout`. This PR changes that step to:

```yml
    steps:
    - uses: actions/checkout@v2
      with:
        fetch-depth: 0
```

See https://community.codecov.io/t/issue-detecting-commit-sha-please-run-actions-checkout-with-fetch-depth-1-or-set-to-0/2571