### PR TITLE
Timeline: Add a new constructor that takes a ReaderInfo struct and copies parameters

### DIFF
--- a/examples/Example.cpp
+++ b/examples/Example.cpp
@@ -31,8 +31,10 @@
 #include <fstream>
 #include <iostream>
 #include <memory>
-#include "OpenShot.h"
-#include "CrashHandler.h"
+#include "Clip.h"
+#include "Frame.h"
+#include "FFmpegReader.h"
+#include "Timeline.h"
 
 using namespace openshot;
 
@@ -53,16 +55,17 @@ int main(int argc, char* argv[]) {
         const auto time1 = std::chrono::high_resolution_clock::now();
         std::shared_ptr<Frame> f = r9.GetFrame(frame);
         const auto time2 = std::chrono::high_resolution_clock::now();
-        std::cout << "FFmpegReader: " << frame << " (" << double_ms(time2 - time1).count() << " ms)" << std::endl;
+        std::cout << "FFmpegReader: " << frame
+                  << " (" << double_ms(time2 - time1).count() << " ms)\n";
     }
     const auto total_2 = std::chrono::high_resolution_clock::now();
     auto total_sec = std::chrono::duration_cast<ms>(total_2 - total_1);
-    std::cout << "FFmpegReader TOTAL: " << total_sec.count() << " ms" << std::endl;
+    std::cout << "FFmpegReader TOTAL: " << total_sec.count() << " ms\n";
     r9.Close();
 
 
     // Timeline Reader performance test
-    Timeline tm(r9.info.width, r9.info.height, r9.info.fps, r9.info.sample_rate, r9.info.channels, r9.info.channel_layout);
+    Timeline tm(r9.info);
     Clip *c = new Clip(&r9);
     tm.AddClip(c);
     tm.Open();
@@ -73,14 +76,15 @@ int main(int argc, char* argv[]) {
         const auto time1 = std::chrono::high_resolution_clock::now();
         std::shared_ptr<Frame> f = tm.GetFrame(frame);
         const auto time2 = std::chrono::high_resolution_clock::now();
-        std::cout << "Timeline: " << frame << " (" << double_ms(time2 - time1).count() << " ms)" << std::endl;
+        std::cout << "Timeline: " << frame
+                  << " (" << double_ms(time2 - time1).count() << " ms)\n";
     }
     const auto total_4 = std::chrono::high_resolution_clock::now();
     total_sec = std::chrono::duration_cast<ms>(total_4 - total_3);
-    std::cout << "Timeline TOTAL: " << total_sec.count() << " ms" << std::endl;
+    std::cout << "Timeline TOTAL: " << total_sec.count() << " ms\n";
     tm.Close();
 
-    std::cout << "Completed successfully!" << std::endl;
+    std::cout << "Completed successfully!\n";
 
     return 0;
 }

--- a/src/Timeline.cpp
+++ b/src/Timeline.cpp
@@ -29,7 +29,16 @@
  */
 
 #include "Timeline.h"
+
+#include "CacheBase.h"
+#include "CacheDisk.h"
+#include "CacheMemory.h"
+#include "CrashHandler.h"
+#include "FrameMapper.h"
 #include "Exceptions.h"
+
+#include <QDir>
+#include <QFileInfo>
 
 using namespace openshot;
 
@@ -77,6 +86,11 @@ Timeline::Timeline(int width, int height, Fraction fps, int sample_rate, int cha
 	// Init max image size
 	SetMaxSize(info.width, info.height);
 }
+
+// Delegating constructor that copies parameters from a provided ReaderInfo
+Timeline::Timeline(const ReaderInfo info) :
+	Timeline::Timeline(info.width, info.height, info.fps, info.sample_rate,
+	                   info.channels, info.channel_layout) {};
 
 // Constructor for the timeline (which loads a JSON structure from a file path, and initializes a timeline)
 Timeline::Timeline(const std::string& projectPath, bool convert_absolute_paths) :

--- a/src/Timeline.h
+++ b/src/Timeline.h
@@ -38,27 +38,22 @@
 #include <QtGui/QImage>
 #include <QtGui/QPainter>
 #include <QtCore/QRegularExpression>
-#include "CacheBase.h"
-#include "CacheDisk.h"
-#include "CacheMemory.h"
+#include "TimelineBase.h"
+#include "ReaderBase.h"
+
 #include "Color.h"
 #include "Clip.h"
-#include "CrashHandler.h"
-#include "Point.h"
 #include "EffectBase.h"
-#include "Effects.h"
-#include "EffectInfo.h"
 #include "Fraction.h"
 #include "Frame.h"
-#include "FrameMapper.h"
 #include "KeyFrame.h"
-#include "OpenMPUtilities.h"
-#include "ReaderBase.h"
-#include "Settings.h"
-#include "TimelineBase.h"
 
 
 namespace openshot {
+
+	// Forward decls
+	class FrameMapper;
+	class CacheBase;
 
 	/// Comparison method for sorting clip pointers (by Layer and then Position). Clips are sorted
 	/// from lowest layer to top layer (since that is the sequence they need to be combined), and then
@@ -222,7 +217,7 @@ namespace openshot {
 
 	public:
 
-		/// @brief Default Constructor for the timeline (which configures the default frame properties)
+		/// @brief Constructor for the timeline (which configures the default frame properties)
 		/// @param width The image width of generated openshot::Frame objects
 		/// @param height The image height of generated openshot::Frame objects
 		/// @param fps The frame rate of the generated video
@@ -230,6 +225,10 @@ namespace openshot {
 		/// @param channels The number of audio channels
 		/// @param channel_layout The channel layout (i.e. mono, stereo, 3 point surround, etc...)
 		Timeline(int width, int height, openshot::Fraction fps, int sample_rate, int channels, openshot::ChannelLayout channel_layout);
+
+		/// @brief Constructor which takes a ReaderInfo struct to configure parameters
+		/// @param info The reader parameters to configure the new timeline with
+		Timeline(ReaderInfo info);
 
 		/// @brief Project-file constructor for the timeline
 		///

--- a/tests/Timeline_Tests.cpp
+++ b/tests/Timeline_Tests.cpp
@@ -50,7 +50,6 @@ SUITE(Timeline)
 
 TEST(Constructor)
 {
-	// Create a default fraction (should be 1/1)
 	Fraction fps(30000,1000);
 	Timeline t1(640, 480, fps, 44100, 2, LAYOUT_STEREO);
 
@@ -58,7 +57,6 @@ TEST(Constructor)
 	CHECK_EQUAL(640, t1.info.width);
 	CHECK_EQUAL(480, t1.info.height);
 
-	// Create a default fraction (should be 1/1)
 	Timeline t2(300, 240, fps, 44100, 2, LAYOUT_STEREO);
 
 	// Check values
@@ -66,9 +64,29 @@ TEST(Constructor)
 	CHECK_EQUAL(240, t2.info.height);
 }
 
+TEST(ReaderInfo_Constructor)
+{
+	// Create a reader
+	stringstream path;
+	path << TEST_MEDIA_PATH << "test.mp4";
+	Clip clip_video(path.str());
+	clip_video.Open();
+	const auto r1 = clip_video.Reader();
+
+	// Configure a Timeline with the same parameters
+	Timeline t1(r1->info);
+
+	CHECK_EQUAL(r1->info.width, t1.info.width);
+	CHECK_EQUAL(r1->info.height, t1.info.height);
+	CHECK_EQUAL(r1->info.fps.num, t1.info.fps.num);
+	CHECK_EQUAL(r1->info.fps.den, t1.info.fps.den);
+	CHECK_EQUAL(r1->info.sample_rate, t1.info.sample_rate);
+	CHECK_EQUAL(r1->info.channels, t1.info.channels);
+	CHECK_EQUAL(r1->info.channel_layout, t1.info.channel_layout);
+}
+
 TEST(Width_and_Height_Functions)
 {
-	// Create a default fraction (should be 1/1)
 	Fraction fps(30000,1000);
 	Timeline t1(640, 480, fps, 44100, 2, LAYOUT_STEREO);
 
@@ -93,7 +111,6 @@ TEST(Width_and_Height_Functions)
 
 TEST(Framerate)
 {
-	// Create a default fraction (should be 1/1)
 	Fraction fps(24,1);
 	Timeline t1(640, 480, fps, 44100, 2, LAYOUT_STEREO);
 


### PR DESCRIPTION
This PR was inspired when I read this line in the latest `Example.cpp`:
```cpp
Timeline tm(r9.info.width, r9.info.height, r9.info.fps, r9.info.sample_rate, r9.info.channels, r9.info.channel_layout);
```

"Well, that's not using the compiler very efficiently.", I thought to myself. "Nobody should ever have to type that line more than once."

So, I typed that line once, as a new delegating constructor for the `Timeline` class. Its entire code:

```cpp
Timeline::Timeline(const ReaderInfo info) :
	Timeline::Timeline(info.width, info.height, info.fps, info.sample_rate,
	                   info.channels, info.channel_layout) {};
```

As a result, that line in `Example.cpp` becomes:
```cpp
Timeline tm(r9.info);
```

And effectively, the compiler transforms it into the code that used to be there. Easy-peasy. A new unit test is also added for the constructor.