### PR TITLE
tests: Make ImageWriter tests dependent on ImageMagick being enabled

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -48,8 +48,6 @@ set(OPENSHOT_TESTS
   Color
   Coordinate
   DummyReader
-  ReaderBase
-  ImageWriter
   FFmpegReader
   FFmpegWriter
   Fraction
@@ -58,14 +56,20 @@ set(OPENSHOT_TESTS
   KeyFrame
   Point
   QtImageReader
+  ReaderBase
   Settings
   Timeline
 )
 
-###
-### OPENCV RELATED TEST FILES
-###
-if(ENABLE_OPENCV)
+# ImageMagick related test files
+if(DEFINED CACHE{HAVE_IMAGEMAGICK})
+  list(APPEND OPENSHOT_TESTS
+    ImageWriter
+  )
+endif()
+
+# OPENCV RELATED TEST FILES
+if(DEFINED CACHE{HAVE_OPENCV})
   list(APPEND OPENSHOT_TESTS
     CVTracker
     CVStabilizer


### PR DESCRIPTION
Just like the OpenCV tests require OpenCV, the ImageWriter tests require that ImageMagick be enabled in the build. If it isn't, skip those tests entirely. Silences a CTest message correctly complaining that the unit test executable "has no tests!", when not linked with ImageMagick.