### PR TITLE
Markdown fixes, INSTALL-LINUX partial update

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -24,6 +24,7 @@ Instructions on how to install these dependencies vary for each operating system
 Libraries and executables have been labeled in the list below to help distinguish between them.
 
 #### FFmpeg (libavformat, libavcodec, libavutil, libavdevice, libavresample, libswscale)
+
 *   <http://www.ffmpeg.org/> **(Library)**
 
 *   This library is used to decode and encode video, audio, and image files.
@@ -31,10 +32,12 @@ Libraries and executables have been labeled in the list below to help distinguis
     such as frame rate, sample rate, aspect ratio, and other common attributes.
 
 #### ImageMagick++ (libMagick++, libMagickWand, libMagickCore)
+
 *   <http://www.imagemagick.org/script/magick++.php> **(Library)**
 *   This library is **optional**, and used to decode and encode images.
 
 #### OpenShot Audio Library (libopenshot-audio)
+
 *   <https://github.com/OpenShot/libopenshot-audio/> **(Library)**
 
 *   This library is used to mix, resample, host plug-ins, and play audio.
@@ -42,6 +45,7 @@ Libraries and executables have been labeled in the list below to help distinguis
     an outstanding audio library used by many different applications.
 
 #### Qt 5 (libqt5)
+
 *   <http://www.qt.io/qt5/> **(Library)**
 
 *   Qt5 is used to display video, store image data, composite images,
@@ -49,12 +53,14 @@ Libraries and executables have been labeled in the list below to help distinguis
     such as file system manipulation, high resolution timers, etc.
 
 #### ZeroMQ (libzmq)
+
 *   <http://zeromq.org/> **(Library)**
 
 *   This library is used to communicate between libopenshot and other applications (publisher / subscriber).
     Primarily used to send debug data from libopenshot.
 
 #### OpenMP (`-fopenmp`)
+
 *   <http://openmp.org/wp/> **(Compiler Flag)**
 
 *   If your compiler supports this flag (GCC, Clang, and most other compilers),
@@ -62,28 +68,33 @@ Libraries and executables have been labeled in the list below to help distinguis
     used to improve performance and take advantage of multi-core processors.
 
 #### CMake (`cmake`)
+
 *   <http://www.cmake.org/> **(Executable)**
 
 *   This executable is used to automate the generation of Makefiles,
     check for dependencies, and is the backbone of libopenshot’s cross-platform build process.
 
 #### SWIG (`swig`)
+
 *   <http://www.swig.org/> **(Executable)**
 
 *   This executable is used to generate the Python and Ruby bindings for libopenshot.
     It is a powerful wrapper for C++ libraries, and supports many languages.
 
 #### Python 3 (libpython)
+
 *   <http://www.python.org/> **(Executable and Library)**
 
 *   This library is used by swig to create the Python (version 3+) bindings for libopenshot.
     This is also the official language used by OpenShot Video Editor (a graphical interface to libopenshot).
 
 #### Doxygen (doxygen)
+
 *   <http://www.stack.nl/~dimitri/doxygen/> **(Executable)**
 *   This executable is used to auto-generate the documentation used by libopenshot.
 
 #### UnitTest++ (libunittest++)
+
 *   <https://github.com/unittest-cpp/> **(Library)**
 
 *   This library is used to execute unit tests for libopenshot.
@@ -105,38 +116,46 @@ git clone https://github.com/OpenShot/libopenshot-audio.git
 The source code is divided up into the following folders.
 
 #### `build/`
+
 This folder needs to be manually created,
 and is used by cmake to store the build system control files and generated output
 (such as compiled object files and the result of template-file processing)
 as well as the final results of the build (library, tool, and test program binaries).
 
 #### `cmake/`
+
 This folder contains custom modules not included by default in cmake.
 CMake find modules are used to discover dependency libraries on the system,
 and to incorporate their headers and object files.
 CMake code modules are used to implement build features such as test coverage scanning.
 
 #### `doc/`
+
 This folder contains documentation and related files.
 This includes logos and images required by the doxygen-generated API documentation.
 
 #### `src/`
+
 This folder contains all source code (`*.cpp`) and headers (`*.h`) for libopenshot.
 
 #### `bindings/`
+
 This folder contains language bindings for the libopenshot API.
 Current supported languages are Python and Ruby.
 
 #### `examples/`
+
 This folder contains various pieces of example code written in C++, Ruby, or Python.
 It also holds the media files (data files) used in examples and unit tests.
 
 #### `tests/`
+
 This folder contains all unit test code.
 Each test file (`<class>_Tests.cpp`) contains the tests for the named class.
 We use UnitTest++ macros to keep the test code uncomplicated and manageable.
 
 #### `thirdparty/`
+
 This folder contains code not written by the OpenShot team.
 For example, `jsoncpp`, an open-source JSON parser.
 
@@ -158,6 +177,7 @@ While it is possible to build in-tree,
 we highly recommend you use a `/build/` sub-folder to compile each library.
 
 These instructions have only been tested with the following compiler stacks:
+
 *   The GNU compiler suite (including MSYS2/MinGW for Windows)
 *   The Clang compiler (including AppleClang on MacOS)
 
@@ -166,6 +186,7 @@ It may be possible to build libopenshot using other compiler stacks,
 but most likely not without modifications to the build system which you would have to make yourself.
 
 ### CMake Flags (Optional)
+
 There are many different build flags that can be passed to cmake to adjust how libopenshot is compiled.
 Some of these flags might be required when compiling on certain OSes,
 depending on how your build environment is setup.
@@ -179,6 +200,7 @@ cmake -B build -S . -DMAGICKCORE_HDRI_ENABLE=1 -DENABLE_TESTS=1 ...
 Following are some of the flags you might need to set when generating your build system.
 
 #### Optional behaviors of the build system
+
 *   `-DENABLE_TESTS=0` (default: `ON`)
 *   `-DENABLE_COVERAGE=1` (default: `OFF`)
 *   `-DENABLE_DOCS=0` (default: `ON` if doxygen found)
@@ -186,26 +208,31 @@ Following are some of the flags you might need to set when generating your build
 *   `-DENABLE_PYTHON=0` (default: `ON` if SWIG and Python detected)
 
 #### Options to configure the compiler
+
 *   `-DCMAKE_BUILD_TYPE=Release`, `-DCMAKE_BUILD_TYPE=Debug` (default: `Release` if unset)
 *   `-DCMAKE_CXX_FLAGS="-Wall -Wextra"` (default: CMake builtin defaults for build type)
 *   `-DCMAKE_CXX_COMPILER=/path/to/g++`, `-DCMAKE_CXX_COMPILER=/path/to/clang++`
 *   `-DCMAKE_C_COMPILER=/path/to/gcc`, `-DCMAKE_CXX_COMPILER=/path/to/clang` (used by CMake for OS probes)
 
 #### Options to configure dependencies
+
 *   `-DCMAKE_PREFIX_PATH=/extra/path/to/search/for/libraries/`
 *   `-DUSE_SYSTEM_JSONCPP=0` (default: auto if discovered)
 *   `-DENABLE_MAGICK=0` (default: auto if discovered)
 
 #### Options to compile bindings for a specific Python installation
+
 *   `-DPYTHON_INCLUDE_DIR=/location/of/python/includes/`
 *   `-DPYTHON_LIBRARY=/location/of/libpython*.so`
 *   `-DPYTHON_FRAMEWORKS=/usr/local/Cellar/python3/3.3.2/Frameworks/Python.framework/` (MacOS only)
 
 #### Options only relevant when building with ImageMagick
+
 *   `-DMAGICKCORE_HDRI_ENABLE=1` (default `0`)
 *   `-DMAGICKCORE_QUANTUM_DEPTH=8` (default `16`)
 
 ## Linux Build Instructions (libopenshot-audio)
+
 To compile libopenshot-audio, we need to build it from source code and install the results.
 Launch a terminal and enter:
 
@@ -218,6 +245,7 @@ cmake --install build
 ```
 
 ## Linux Build Instructions (libopenshot)
+
 Run the following commands to compile libopenshot:
 
 ```sh
@@ -235,5 +263,7 @@ For more detailed instructions, please see:
 *   [doc/INSTALL-WINDOWS.md][INSTALL-WINDOWS]
 
 [INSTALL-LINUX]: https://github.com/OpenShot/libopenshot/blob/develop/doc/INSTALL-LINUX.md
+
 [INSTALL-MAC]: https://github.com/OpenShot/libopenshot/blob/develop/doc/INSTALL-MAC.md
+
 [INSTALL-WINDOWS]: https://github.com/OpenShot/libopenshot/blob/develop/doc/INSTALL-WINDOWS.md

--- a/README.md
+++ b/README.md
@@ -8,32 +8,32 @@ solutions to the world.
 
 ## Features
 
-* Cross-Platform (Linux, Mac, and Windows)
-* Multi-Layer Compositing
-* Video and Audio Effects (Chroma Key, Color Adjustment, Grayscale, etc…)
-* Animation Curves (Bézier, Linear, Constant)
-* Time Mapping (Curve-based Slow Down, Speed Up, Reverse)
-* Audio Mixing & Resampling (Curve-based)
-* Audio Plug-ins (VST & AU)
-* Audio Drivers (ASIO, WASAPI, DirectSound, CoreAudio, iPhone Audio,
-  ALSA, JACK, and Android)
-* Telecine and Inverse Telecine (Film to TV, TV to Film)
-* Frame Rate Conversions
-* Multi-Processor Support (Performance)
-* Python and Ruby Bindings (All Features Supported)
-* Qt Video Player Included (Ability to display video on any QWidget)
-* Unit Tests (Stability)
-* All FFmpeg Formats and Codecs Supported (Images, Videos, and Audio files)
-* Full Documentation with Examples (Doxygen Generated)
+*   Cross-Platform (Linux, Mac, and Windows)
+*   Multi-Layer Compositing
+*   Video and Audio Effects (Chroma Key, Color Adjustment, Grayscale, etc…)
+*   Animation Curves (Bézier, Linear, Constant)
+*   Time Mapping (Curve-based Slow Down, Speed Up, Reverse)
+*   Audio Mixing & Resampling (Curve-based)
+*   Audio Plug-ins (VST & AU)
+*   Audio Drivers (ASIO, WASAPI, DirectSound, CoreAudio, iPhone Audio,
+    ALSA, JACK, and Android)
+*   Telecine and Inverse Telecine (Film to TV, TV to Film)
+*   Frame Rate Conversions
+*   Multi-Processor Support (Performance)
+*   Python and Ruby Bindings (All Features Supported)
+*   Qt Video Player Included (Ability to display video on any QWidget)
+*   Unit Tests (Stability)
+*   All FFmpeg Formats and Codecs Supported (Images, Videos, and Audio files)
+*   Full Documentation with Examples (Doxygen Generated)
 
 ## Install
 
 Detailed instructions for building libopenshot and libopenshot-audio for
 each OS. These instructions are also available in the `/docs/` source folder.
 
-   * [Linux](https://github.com/OpenShot/libopenshot/wiki/Linux-Build-Instructions)
-   * [Mac](https://github.com/OpenShot/libopenshot/wiki/Mac-Build-Instructions)
-   * [Windows](https://github.com/OpenShot/libopenshot/wiki/Windows-Build-Instructions)
+*   [Linux](https://github.com/OpenShot/libopenshot/wiki/Linux-Build-Instructions)
+*   [Mac](https://github.com/OpenShot/libopenshot/wiki/Mac-Build-Instructions)
+*   [Windows](https://github.com/OpenShot/libopenshot/wiki/Windows-Build-Instructions)
 
 ## Hardware Acceleration
 
@@ -47,9 +47,11 @@ Please see [`doc/HW-ACCEL.md`](doc/HW-ACCEL.md) for more information.
 ## Documentation
 
 Beautiful HTML documentation can be generated using Doxygen.
+
+```sh
+cmake --build <builddir> --target doc
 ```
-make doc
-```
+
 (Also available online: http://openshot.org/files/libopenshot/)
 
 ## Developers
@@ -68,11 +70,11 @@ https://github.com/OpenShot/libopenshot/issues
 
 ## Websites
 
-- https://www.openshot.org/  (Official website and blog)
-- https://github.com/OpenShot/libopenshot/ (source code and issue tracker)
-- https://github.com/OpenShot/libopenshot-audio/ (source code for audio library)
-- https://github.com/OpenShot/openshot-qt/ (source code for Qt client)
-- https://launchpad.net/openshot/
+*   https://www.openshot.org/  (Official website and blog)
+*   https://github.com/OpenShot/libopenshot/ (source code and issue tracker)
+*   https://github.com/OpenShot/libopenshot-audio/ (source code for audio library)
+*   https://github.com/OpenShot/openshot-qt/ (source code for Qt client)
+*   https://launchpad.net/openshot/
 
 ### License
 

--- a/doc/HW-ACCEL.md
+++ b/doc/HW-ACCEL.md
@@ -7,15 +7,15 @@ our support for this in the future!
 
 The following table summarizes our current level of support:
 
-|                    |  Linux Decode   | Linux Encode   | Mac Decode |    Mac Encode  | Windows Decode | Windows Encode | Notes            |
-|--------------------|:---------------:|:--------------:|:----------:|:--------------:|:--------------:|:--------------:|------------------|
-| VA-API             |   ✔️ &nbsp;      |    ✔️ &nbsp;    |      -     |        -       |       -        |        -       | *Linux Only*     |
-| VDPAU              | ✔️ <sup>1</sup>  | ✅ <sup>2</sup> |      -    |        -       |       -        |        -       | *Linux Only*     |
-| CUDA (NVDEC/NVENC) | ❌ <sup>3</sup> |   ✔️ &nbsp;     |      -     |        -       |       -        |    ✔️ &nbsp;    | *Cross Platform* |
-| VideoToolBox       |           -     |         -      |  ✔️ &nbsp;  | ❌ <sup>4</sup> |      -        |       -         | *Mac Only*       |
-| DXVA2              |           -     |         -      |      -     |        -       | ❌ <sup>3</sup> |      -         | *Windows Only*   |
-| D3D11VA            |           -     |         -      |      -     |        -       | ❌ <sup>3</sup> |      -         | *Windows Only*   |
-| QSV                | ❌ <sup>3</sup> |   ❌ &nbsp;   |  ❌ &nbsp; |   ❌ &nbsp;    |   ❌ &nbsp;     |    ❌ &nbsp;   | *Cross Platform* |
+|                    |  Linux Decode   |  Linux Encode   |    Mac Decode   |    Mac Encode   |  Windows Decode | Windows Encode  | Notes            |
+|--------------------|:---------------:|:---------------:|:---------------:|:---------------:|:---------------:|:---------------:|------------------|
+| VA-API             | ✔️ <sup> </sup> | ✔️ <sup> </sup> |      -          |        -        |        -        |        -        | *Linux Only*     |
+| VDPAU              | ✔️ <sup>1</sup> | ✅ <sup>2</sup> |      -          |        -        |        -        |        -        | *Linux Only*     |
+| CUDA (NVDEC/NVENC) | ❌ <sup>3</sup> | ✔️ <sup> </sup> |      -          |        -        |        -        | ✔️ <sup> </sup> | *Cross Platform* |
+| VideoToolBox       |           -     |         -       | ✔️ <sup> </sup> | ❌ <sup>4</sup> |        -        |       -         | *Mac Only*       |
+| DXVA2              |           -     |         -       |      -          |        -        | ❌ <sup>3</sup> |       -         | *Windows Only*   |
+| D3D11VA            |           -     |         -       |      -          |        -        | ❌ <sup>3</sup> |       -         | *Windows Only*   |
+| QSV                | ❌ <sup>3</sup> | ❌ <sup> </sup> | ❌ <sup> </sup> | ❌ <sup> </sup> | ❌ <sup> </sup> | ❌ <sup> </sup> | *Cross Platform* |
 
 #### Notes
 
@@ -26,8 +26,8 @@ The following table summarizes our current level of support:
 
 ## Supported FFmpeg Versions
 
-* HW accel is supported from FFmpeg version 3.4
-* HW accel was removed for nVidia drivers in Ubuntu for FFmpeg 4+
+*   HW accel is supported from FFmpeg version 3.4
+*   HW accel was removed for nVidia drivers in Ubuntu for FFmpeg 4+
 
 **Notice:** The FFmpeg versions of Ubuntu and PPAs for Ubuntu show the
 same behaviour. FFmpeg 3 has working nVidia hardware acceleration while
@@ -78,9 +78,9 @@ in Ubuntu 18.04) for the AppImage to work with hardware acceleration.
 An AppImage that works on both systems (supporting libva and libva2),
 might be possible when no libva is included in the AppImage.
 
-*  vaapi is working for intel and AMD
-*  vaapi is working for decode only for nouveau
-*  nVidia driver is working for export only
+*   vaapi is working for intel and AMD
+*   vaapi is working for decode only for nouveau
+*   nVidia driver is working for export only
 
 ## AMD Graphics Cards (RadeonOpenCompute/ROCm)
 
@@ -116,11 +116,12 @@ fallback (you either get green frames or an "invalid file" error in OpenShot).
 This needs to be improved to successfully fall-back to software decoding.
 
 **Needed:**
-  * A way to get options and limits of the GPU, such as
- supported dimensions (width and height).
-  *  A way to list the actual Graphic Cards available to FFmpeg (for the
-  user to choose which card for decoding and encoding, as opposed
-  to "Graphics Card X")
+
+*   A way to get options and limits of the GPU, such as
+    supported dimensions (width and height).
+*   A way to list the actual Graphic Cards available to FFmpeg (for the
+    user to choose which card for decoding and encoding, as opposed
+    to "Graphics Card X")
 
 **Further improvement:** Right now the frame can be decoded on the GPU, but the
 frame is then copied to CPU memory for modifications. It is then copied back to

--- a/doc/INSTALL-LINUX.md
+++ b/doc/INSTALL-LINUX.md
@@ -2,228 +2,323 @@
 
 ## Getting Started
 
-The best way to get started with libopenshot, is to learn about our build system, obtain all the source code,
-install a development IDE and tools, and better understand our dependencies. So, please read through the
-following sections, and follow the instructions. And keep in mind, that your computer is likely different
-than the one used when writing these instructions. Your file paths and versions of applications might be
-slightly different, so keep an eye out for subtle file path differences in the commands you type.
+The best way to get started with libopenshot is by trying it yourself.
+Obtain the source code and learn about our build system,
+to better understand our dependencies.
+Then, install a development IDE and tools to build and work with the code.
+Thhe instructions in this document will guide you through that process.
+But keep in mind,
+your computer will be different from the one used to write these instructions.
+File paths, software versions, and other details will differ slightly.
+You should keep an eye out for any changes you need to make,
+before copy-pasting the commands listed here.
 
 ## Build Tools
 
-CMake is the backbone of our build system.  It is a cross-platform build system, which checks for
-dependencies, locates header files and libraries, generates makefiles, and supports the cross-platform
-compiling of libopenshot and libopenshot-audio.  CMake uses an out-of-source build concept, where
-all temporary build files, such as makefiles, object files, and even the final binaries, are created
-outside of the source code folder, inside a /build/ sub-folder.  This prevents the build process
-from cluttering up the source code.  These instructions have only been tested with the GNU compiler
-(including MSYS2/MinGW for Windows).
+CMake is the backbone of our build system.
+It is a cross-platform build system, used on all supported operating systems.
+CMake checks for dependencies,
+locates header files and libraries,
+generates build scripting and configuration,
+and drives cross-platform compiling of libopenshot and libopenshot-audio.
+
+CMake uses an out-of-source build concept.
+All generated files, whether build tooling or compiled binaries,
+are placed in a location separate from the source code they were built from.
+Typically, we use a sub-folder named `build/` at the root of the tree.
+This separation prevents the build process from cluttering up the source code.
+
+These instructions have only been tested with the GNU C++ compiler `g++`
+(including under MSYS2/MinGW for Windows),
+and the Clang C++ compiler `clang++`
+(including AppleClang on macOS systems).
 
 ## Dependencies
 
-The following libraries are required to build libopenshot.  Instructions on how to install these
-dependencies vary for each operating system.  Libraries and Executables have been labeled in the
-list below to help distinguish between them.
+The following libraries are required to build libopenshot.
+Installation instructions vary for each operating system.
+Each item in the list has been labeled as a Library or Executable,
+to help distinguish between the two major types of dependency.
 
 ### FFmpeg (libavformat, libavcodec, libavutil, libavdevice, libavresample, libswscale)
 
-*   http://www.ffmpeg.org/ `(Library)`
-*   This library is used to decode and encode video, audio, and image files.  It is also used to obtain information about media files, such as frame rate, sample rate, aspect ratio, and other common attributes.
+*   http://www.ffmpeg.org/ **(Library)**
+*   Used to decode and encode video, audio, and image files.
+    It is also used to obtain information about media files,
+    such as frame rate, sample rate, aspect ratio, and other common attributes.
 
 ### ImageMagick++ (libMagick++, libMagickWand, libMagickCore)
 
-*   http://www.imagemagick.org/script/magick++.php `(Library)`
-*   This library is **optional**, and used to decode and encode images.
+*   http://www.imagemagick.org/script/magick++.php **(*Optional* Library)**
+*   Can be used to decode and encode images. (Largely replaced by Qt5's QImage.)
 
 ### OpenShot Audio Library (libopenshot-audio)
 
-*   https://github.com/OpenShot/libopenshot-audio/ `(Library)`
-*   This library is used to mix, resample, host plug-ins, and play audio. It is based on the JUCE project, which is an outstanding audio library used by many different applications
+*   https://github.com/OpenShot/libopenshot-audio/ **(Library)**
+*   The companion library to libopenshot,
+    it's used to mix, resample, and play audio.
+    libopenshot-audio is based on the JUCE project,
+    an outstanding audio library used by many different applications.
 
-### Qt 5 (libqt5)
+### Qt 5 (libQt5Core, libQt5Gui, libQt5Widgets)
 
-*   http://www.qt.io/qt5/ `(Library)`
-*   Qt5 is used to display video, store image data, composite images, apply image effects, and many other utility functions, such as file system manipulation, high resolution timers, etc...
+*   http://www.qt.io/qt5/ **(Library)**
+*   Used for a wealth of internal data processing and utility functions.
+    These include: displaying video; storing and processing image data;
+    applying visual effects; and data, string, and file manipulation.
 
 ### CMake (cmake)
 
-*   http://www.cmake.org/ `(Executable)`
-*   This executable is used to automate the generation of Makefiles, check for dependencies, and is the backbone of libopenshot’s cross-platform build process.
+*   http://www.cmake.org/ **(Executable)**
+*   Used to generate the build system that compiles libopenshot.
+    CMake detects and configures all of the other build dependencies,
+    scripts the compiler and linker commands to produce executable code,
+    and generates libopenshot's final configuration and install tree.
 
 ### SWIG (swig)
 
-*   http://www.swig.org/ `(Executable)`
-*   This executable is used to generate the Python and Ruby bindings for libopenshot. It is a simple and powerful wrapper for C++ libraries, and supports many languages.
+*   http://www.swig.org/ **(Executable)**
+*   Used during the build process to generate language binding wrappers,
+    allowing us to produce Python and Ruby interfaces to libopenshot.
+    SWIG supports many more languages,
+    and libopenshot could be extended to any of them if necessary.
 
 ### Python 3 (libpython)
 
-*   http://www.python.org/ `(Executable and Library)`
-*   This library is used by swig to create the Python (version 3+) bindings for libopenshot. This is also the official language used by OpenShot Video Editor (a graphical interface to libopenshot).
+*   http://www.python.org/ **(Executable and Library)**
+*   SWIG compiles libopenshot's Python bindings as extensions to libpython,
+    making them accessible from any Python code running in the interpreter.
+    Python is also the language used by the primary consumer of our APIs,
+    OpenShot Video Editor (a PyQt5 graphical interface to libopenshot).
 
 ### Doxygen (doxygen)
 
-*   http://www.stack.nl/~dimitri/doxygen/ `(Executable)`
-*   This executable is used to auto-generate the documentation used by libopenshot.
+*   http://www.stack.nl/~dimitri/doxygen/ **(Executable)**
+*   Used to auto-generate the API documentation for libopenshot.
 
-### UnitTest++ (libunittest++)
+### Catch2 (catch2.hpp) & CTest (ctest)
 
-*   https://github.com/unittest-cpp/ `(Library)`
-*   This library is used to execute unit tests for libopenshot.  It contains many macros used to keep our unit testing code very clean and simple.
+*   Catch2: https://github.com/catchorg/catch2/ **(Header-only Library)**
+*   CTest: Part of the CMake build system
+*   Used together to ensure correctness of our code through unit testing.
+    Catch2 provides macros used to write clean and simple tests.
+    CTest unit-tests each code submission and reports on the results,
+    which help us to catch many bugs before they make it into the library.
 
 ### ZeroMQ (libzmq)
 
-*   http://zeromq.org/ `(Library)`
-*   This library is used to communicate between libopenshot and other applications (publisher / subscriber). Primarily used to send debug data from libopenshot.
+*   http://zeromq.org/ **(Library)**
+*   Used to communicate between libopenshot and other applications,
+    using a publisher / subscriber local-networking model.
+    Primarily used to stream libopenshot's debug logs to library users.
 
 ### OpenMP (-fopenmp)
 
-*   http://openmp.org/wp/ `(Compiler Flag)`
-*   If your compiler supports this flag (GCC, Clang, and most other compilers), it provides libopenshot with easy methods of using parallel programming techniques to improve performance and take advantage of multi-core processors.
+*   http://openmp.org/wp/ **(Compiler Flag)**
+*   Compilers that support this flag (including GCC, Clang, and most others)
+    allow libopenshot to easily activate parallel coding techniques,
+    permitting our code to take best advantage of multi-core processors.
+    These algorithms are primarily used to accelerate effects processing.
 
 ## CMake Flags (Optional)
 
-There are many different build flags that can be passed to cmake to adjust how libopenshot is
-compiled. Some of these flags might be required when compiling on certain OSes, just depending
-on how your build environment is setup. To add a build flag, follow this general syntax:
-`cmake -DMAGICKCORE_HDRI_ENABLE=1 -DENABLE_TESTS=1 ../`
+The libopenshot build system offers many customization options,
+which can be used to adjust for specific scenarios or environments.
+Some may be required when compiling on certain OSes,
+or depending how your build environment is setup.
+What follows is an incomplete list,
+many additional options are currently undocumented.
+For full details read the `CMakeLists.txt` files in the source tree.
 
-*   MAGICKCORE_HDRI_ENABLE (default 0)
-*   MAGICKCORE_QUANTUM_DEPTH (default 0)
-*   OPENSHOT_IMAGEMAGICK_COMPATIBILITY (default 0)
-*   DISABLE_TESTS (default 0)
-*   CMAKE_PREFIX_PATH (`/location/to/missing/library/`)
-*   PYTHON_INCLUDE_DIR (`/location/to/python/include/`)
-*   PYTHON_LIBRARY (`/location/to/python/lib.a`)
-*   PYTHON_FRAMEWORKS (`/usr/local/Cellar/python3/3.3.2/Frameworks/Python.framework/`)
-*   CMAKE_CXX_COMPILER (`/location/to/mingw/g++`)
-*   CMAKE_C_COMPILER (`/location/to/mingw/gcc`)
+CMake options are set using either the `ccmake` graphical tool
+(which is not covered here),
+or on the `cmake` command line using this general syntax:
+
+```sh
+cmake -DENABLE_SOME_OPTION=1 -DSOME_DIRECTORY=/path/to/files
+```
+
+### Build configuration
+
+*   `BUILD_TESTING` (default: `1`/`TRUE`)
+*   `CMAKE_INSTALL_PREFIX` (default: `/usr/local`)
+*   `CMAKE_PREFIX_PATH` (e.g. `/location/to/missing/library/`)
+*   `CMAKE_CXX_COMPILER` (e.g. `/location/of/g++`, or `g++` or `clang++`)
+*   `CMAKE_C_COMPILER` (e.g. `/location/of/gcc` or `gcc` or `clang`)
+
+### Dependencies
+
+*   `OpenShotAudio_ROOT` (e.g. `/install/prefix/of/libopenshot-audio`)
+*   `QT_DIR` (e.g. `/location/of/Qt/5.15.0/gcc_x86_64/bin`, path to `qmake`)
+*   `PYTHON_INCLUDE_DIR` (e.g. `/location/to/python/include/`)
+*   `PYTHON_LIBRARY` (e.g. `/location/of/libpython.so`, or `.dll` or `.dylib`)
+*   `PYTHON_FRAMEWORKS` (e.g. `/usr/local/Cellar/python3/3.8.9/Frameworks/Python.framework`)
+
+#### Only applicable if ImageMagick is used
+
+*   `MAGICKCORE_HDRI_ENABLE` (default: `0`)
+*   `MAGICKCORE_QUANTUM_DEPTH` (default: `16`)
 
 ## Obtaining Source Code
 
-The first step in installing libopenshot is to obtain the most recent source code. The source code is
-available on [GitHub](https://github.com/OpenShot/libopenshot). Use the following command
-to obtain the latest libopenshot source code.
+The first step in installing libopenshot is to obtain the most recent code.
+The source code is maintained in the official GitHub project
+[OpenShot/libopenshot](https://github.com/OpenShot/libopenshot).
+Use the following commands to obtain a local copy of the current code.
 
-    git clone https://github.com/OpenShot/libopenshot.git
-    git clone https://github.com/OpenShot/libopenshot-audio.git
+```sh
+git clone https://github.com/OpenShot/libopenshot.git
+git clone https://github.com/OpenShot/libopenshot-audio.git
+```
 
 ## Folder Structure (libopenshot)
 
 The source code is divided up into the following folders.
 
-### build/
+### `build/`
 
-*   This folder needs to be manually created, and is used by cmake to store the temporary build files, such as makefiles, as well as the final binaries (library and test executables).
+*   This folder needs to be manually created,
+    and is used by cmake to store the temporary build files,
+    as well as the final binaries (library and test executables).
 
-### cmake/
+### `cmake/`
 
-*   This folder contains custom modules not included by default in cmake, used to find dependency libraries and headers and determine if these libraries are installed.
+*   This folder contains custom modules not included by default in cmake.
+    These are used to find dependency libraries and headers,
+    and to configure the build based on how they're installed.
 
-### doc/
+### `doc/`
 
-*   This folder contains documentation and related files, such as logos and images required by the doxygen auto-generated documentation.
+*   This folder contains documentation and related files,
+    such as logos and images used in the auto-generated documentation.
 
-### include/
+### `src/`
 
-*   This folder contains all headers (\*.h) used by libopenshot.
+*   This folder contains the C++ source (`*.cpp`) and headers (`*.h`)
+    that make up the libopenshot code.
 
-### src/
+### `tests/`
 
-*   This folder contains all source code (\*.cpp) used by libopenshot.
+*   This folder contains the unit test code.
+    Each file (`ClassName.cpp`) contains the tests for that class.
+    This helps keep the test code simple and manageable.
 
-### tests/
+### `thirdparty/`
 
-*   This folder contains all unit test code.  Each class has it’s own test file (\*.cpp), and uses UnitTest++ macros to keep the test code simple and manageable.
-
-### thirdparty/
-
-*   This folder contains code not written by the OpenShot team. For example, jsoncpp, an open-source JSON parser.
+*   This folder contains code not written by the OpenShot team.
+    Currently only a vendored copy of jsoncpp, an open-source JSON parser.
+    CMake will automatically use that copy, by default,
+    when jsoncpp is not installed on the operating system.
 
 ## Install Dependencies
 
-In order to actually compile libopenshot, we need to install some dependencies on your system. The easiest
-way to accomplish this is with our Daily PPA. A PPA is an unofficial Ubuntu repository, which has our
-software packages available to download and install.
+In order to actually compile libopenshot,
+we need to install some dependencies on your system.
+The easiest way to accomplish this is with our Daily PPA.
+A PPA is an unofficial Ubuntu repository,
+which has our software packages available to download and install.
 
-       sudo add-apt-repository ppa:openshot.developers/libopenshot-daily
-       sudo apt-get update
-       sudo apt-get install openshot-qt \
-                            cmake \
-                            libx11-dev \
-                            libasound2-dev \
-                            libavcodec-dev \
-                            libavdevice-dev \
-                            libavfilter-dev \
-                            libavformat-dev \
-                            libavresample-dev \
-                            libavutil-dev \
-                            libfdk-aac-dev \
-                            libfreetype6-dev \
-                            libjsoncpp-dev \
-                            libmagick++-dev \
-                            libopenshot-audio-dev \
-                            libswscale-dev \
-                            libunittest++-dev \
-                            libxcursor-dev \
-                            libxinerama-dev \
-                            libxrandr-dev \
-                            libzmq3-dev \
-                            pkg-config \
-                            python3-dev \
-                            qtbase5-dev \
-                            qtmultimedia5-dev \
-                            swig
+```sh
+sudo add-apt-repository ppa:openshot.developers/libopenshot-daily
+sudo apt update
+sudo apt install    cmake \
+                    libasound2-dev \
+                    libopenshot-audio-dev \
+                    libavcodec-dev \
+                    libavformat-dev \
+                    libavutil-dev \
+                    libswresample-dev \
+                    libswscale-dev \
+                    libpostproc-dev \
+                    qtbase5-dev \
+                    qtbase5-dev-tools \
+                    libjsoncpp-dev \
+                    libzmq3-dev \
+                    libopencv-dev \
+                    libprotobuf-dev \
+                    protobuf-compiler \
+                    python3-dev \
+                    swig
+```
+
+On Ubuntu 20.10+, Catch2 can be installed with `sudo apt install catch`.
+Earlier systems only have Catch 1.x available,
+so install Catch2 using these commands:
+
+```sh
+wget https://launchpad.net/ubuntu/+archive/primary/+files/catch2_2.13.0-1_all.deb
+sudo dpkg -i catch2_2.13.0-1_all.deb
+```
 
 ## Linux Build Instructions (libopenshot-audio)
 
-To compile libopenshot-audio, we need to go through a few additional steps to manually build and
-install it. Launch a terminal and enter:
+To compile libopenshot-audio, in a terminal window type these commands:
 
-    cd [libopenshot-audio repo folder]
-    mkdir build
-    cd build
-    cmake ../
-    make
-    make install
-    ./src/openshot-audio-test-sound  (This should play a test sound)
+```sh
+cd /location/of/libopenshot-audio
+cmake -B build -S .
+cmake --build build
+./build/src/openshot-audio-demo  # (This should play 5 test tones)
+cmake --install build
+```
 
 ## Linux Build Instructions (libopenshot)
 
 Run the following commands to compile libopenshot:
 
-    cd [libopenshot repo directory]
-    mkdir -p build
-    cd build
-    cmake ../
-    make
+```sh
+cd /location/of/libopenshot
+cmake -B build -S .
+cmake --build build
+cmake --build build --target test  # To run the unit tests
+```
 
-If you are missing any dependencies for libopenshot, you might receive error messages at this point.
-Just install the missing packages (usually with a -dev suffix), and run the above commands again.
-Repeat until no error messages are displayed, and the build process completes. Also, if you manually
-install Qt 5, you might need to specify the location for cmake:
+If you are missing any dependencies for libopenshot,
+you might receive error messages at one of these points.
+Just `apt install` the missing packages (usually with a -dev suffix),
+and run the command again.
+Repeat until no error messages are displayed and the build process completes.
+Also, if you manually install Qt 5,
+you might need to specify the location for cmake:
 
-    cmake -DCMAKE_PREFIX_PATH=/qt5_path/qt5/5.2.0/ ../
+```sh
+cmake -B build -S . -DCMAKE_PREFIX_PATH=/qt5_path/qt5/5.2.0/
+```
 
-To run all unit tests (and verify everything is working correctly), launch a terminal, and enter:
+To auto-generate documentation for libopenshot, after building the library run:
 
-    make test
+```sh
+cmake --build build --target doc
+```
 
-To auto-generate documentation for libopenshot, launch a terminal, and enter:
+This will use doxygen to generate a folder of HTML files,
+with all classes and methods documented.
+The folder is located at **`build/doc/html/`**.
 
-    make doc
+Once libopenshot has been successfully built, we need to install it.
 
-This will use doxygen to generate a folder of HTML files, with all classes and methods documented. The
-folder is located at **build/doc/html/**. Once libopenshot has been successfully built, we need to
-install it (i.e. copy it to the correct folder, so other libraries can find it).
+```sh
+cmake --install build
+```
 
-    make install
+This will copy the binary files to `/usr/local/lib/`,
+and the header files to `/usr/local/include/libopenshot/`.
+(Unless you customized the paths with `-DCMAKE_INSTALL_PREFIX=`.)
 
-This will copy the binary files to /usr/local/lib/, and the header files to /usr/local/include/openshot/...
-This is where other projects will look for the libopenshot files when building. Python 3 bindings are
-also installed at this point. let's verify the python bindings work:
+Python 3 bindings are also installed at this point.
+Let's verify the python bindings work:
 
-    python3
-    >>> import openshot
+```python
+python3
+>>> import openshot
+>>> openshot.Version
+OpenShotVersion('0.2.5')
+>>>
+```
 
-If no errors are displayed, you have successfully compiled and installed libopenshot on your system.
-Congratulations and be sure to read our wiki on [Becoming an OpenShot Developer](https://github.com/OpenShot/openshot-qt/wiki/Become-a-Developer)!
-Welcome to the OpenShot developer community! We look forward to meeting you!
+If the library's current version number is displayed,
+you have successfully compiled and installed libopenshot on your system.
+Congratulations, and welcome to the OpenShot developer community!
+
+Be sure to read our wiki on [Becoming an OpenShot Developer](https://github.com/OpenShot/openshot-qt/wiki/Become-a-Developer).
+We look forward to meeting you!

--- a/doc/INSTALL-LINUX.md
+++ b/doc/INSTALL-LINUX.md
@@ -2,226 +2,228 @@
 
 ## Getting Started
 
-The best way to get started with libopenshot, is to learn about our build system, obtain all the source code, 
-install a development IDE and tools, and better understand our dependencies. So, please read through the 
-following sections, and follow the instructions. And keep in mind, that your computer is likely different 
-than the one used when writing these instructions. Your file paths and versions of applications might be 
+The best way to get started with libopenshot, is to learn about our build system, obtain all the source code,
+install a development IDE and tools, and better understand our dependencies. So, please read through the
+following sections, and follow the instructions. And keep in mind, that your computer is likely different
+than the one used when writing these instructions. Your file paths and versions of applications might be
 slightly different, so keep an eye out for subtle file path differences in the commands you type.
 
 ## Build Tools
 
-CMake is the backbone of our build system.  It is a cross-platform build system, which checks for 
-dependencies, locates header files and libraries, generates makefiles, and supports the cross-platform 
-compiling of libopenshot and libopenshot-audio.  CMake uses an out-of-source build concept, where 
-all temporary build files, such as makefiles, object files, and even the final binaries, are created 
-outside of the source code folder, inside a /build/ sub-folder.  This prevents the build process 
-from cluttering up the source code.  These instructions have only been tested with the GNU compiler 
+CMake is the backbone of our build system.  It is a cross-platform build system, which checks for
+dependencies, locates header files and libraries, generates makefiles, and supports the cross-platform
+compiling of libopenshot and libopenshot-audio.  CMake uses an out-of-source build concept, where
+all temporary build files, such as makefiles, object files, and even the final binaries, are created
+outside of the source code folder, inside a /build/ sub-folder.  This prevents the build process
+from cluttering up the source code.  These instructions have only been tested with the GNU compiler
 (including MSYS2/MinGW for Windows).
 
 ## Dependencies
 
-The following libraries are required to build libopenshot.  Instructions on how to install these 
-dependencies vary for each operating system.  Libraries and Executables have been labeled in the 
+The following libraries are required to build libopenshot.  Instructions on how to install these
+dependencies vary for each operating system.  Libraries and Executables have been labeled in the
 list below to help distinguish between them.
 
 ### FFmpeg (libavformat, libavcodec, libavutil, libavdevice, libavresample, libswscale)
-  * http://www.ffmpeg.org/ `(Library)`
-  * This library is used to decode and encode video, audio, and image files.  It is also used to obtain information about media files, such as frame rate, sample rate, aspect ratio, and other common attributes.
+
+*   http://www.ffmpeg.org/ `(Library)`
+*   This library is used to decode and encode video, audio, and image files.  It is also used to obtain information about media files, such as frame rate, sample rate, aspect ratio, and other common attributes.
 
 ### ImageMagick++ (libMagick++, libMagickWand, libMagickCore)
-  * http://www.imagemagick.org/script/magick++.php `(Library)`
-  * This library is **optional**, and used to decode and encode images.
+
+*   http://www.imagemagick.org/script/magick++.php `(Library)`
+*   This library is **optional**, and used to decode and encode images.
 
 ### OpenShot Audio Library (libopenshot-audio)
-  * https://github.com/OpenShot/libopenshot-audio/ `(Library)`
-  * This library is used to mix, resample, host plug-ins, and play audio. It is based on the JUCE project, which is an outstanding audio library used by many different applications
+
+*   https://github.com/OpenShot/libopenshot-audio/ `(Library)`
+*   This library is used to mix, resample, host plug-ins, and play audio. It is based on the JUCE project, which is an outstanding audio library used by many different applications
 
 ### Qt 5 (libqt5)
-  * http://www.qt.io/qt5/ `(Library)`
-  * Qt5 is used to display video, store image data, composite images, apply image effects, and many other utility functions, such as file system manipulation, high resolution timers, etc...
+
+*   http://www.qt.io/qt5/ `(Library)`
+*   Qt5 is used to display video, store image data, composite images, apply image effects, and many other utility functions, such as file system manipulation, high resolution timers, etc...
 
 ### CMake (cmake)
-  * http://www.cmake.org/ `(Executable)`
-  * This executable is used to automate the generation of Makefiles, check for dependencies, and is the backbone of libopenshot’s cross-platform build process.
+
+*   http://www.cmake.org/ `(Executable)`
+*   This executable is used to automate the generation of Makefiles, check for dependencies, and is the backbone of libopenshot’s cross-platform build process.
 
 ### SWIG (swig)
-  * http://www.swig.org/ `(Executable)`
-  * This executable is used to generate the Python and Ruby bindings for libopenshot. It is a simple and powerful wrapper for C++ libraries, and supports many languages.
+
+*   http://www.swig.org/ `(Executable)`
+*   This executable is used to generate the Python and Ruby bindings for libopenshot. It is a simple and powerful wrapper for C++ libraries, and supports many languages.
 
 ### Python 3 (libpython)
-  * http://www.python.org/ `(Executable and Library)`
-  * This library is used by swig to create the Python (version 3+) bindings for libopenshot. This is also the official language used by OpenShot Video Editor (a graphical interface to libopenshot).
+
+*   http://www.python.org/ `(Executable and Library)`
+*   This library is used by swig to create the Python (version 3+) bindings for libopenshot. This is also the official language used by OpenShot Video Editor (a graphical interface to libopenshot).
 
 ### Doxygen (doxygen)
-  * http://www.stack.nl/~dimitri/doxygen/ `(Executable)`
-  * This executable is used to auto-generate the documentation used by libopenshot.
+
+*   http://www.stack.nl/~dimitri/doxygen/ `(Executable)`
+*   This executable is used to auto-generate the documentation used by libopenshot.
 
 ### UnitTest++ (libunittest++)
-  * https://github.com/unittest-cpp/ `(Library)`
-  * This library is used to execute unit tests for libopenshot.  It contains many macros used to keep our unit testing code very clean and simple.
+
+*   https://github.com/unittest-cpp/ `(Library)`
+*   This library is used to execute unit tests for libopenshot.  It contains many macros used to keep our unit testing code very clean and simple.
 
 ### ZeroMQ (libzmq)
-  * http://zeromq.org/ `(Library)`
-  * This library is used to communicate between libopenshot and other applications (publisher / subscriber). Primarily used to send debug data from libopenshot.
+
+*   http://zeromq.org/ `(Library)`
+*   This library is used to communicate between libopenshot and other applications (publisher / subscriber). Primarily used to send debug data from libopenshot.
 
 ### OpenMP (-fopenmp)
-  * http://openmp.org/wp/ `(Compiler Flag)`
-  * If your compiler supports this flag (GCC, Clang, and most other compilers), it provides libopenshot with easy methods of using parallel programming techniques to improve performance and take advantage of multi-core processors.
 
+*   http://openmp.org/wp/ `(Compiler Flag)`
+*   If your compiler supports this flag (GCC, Clang, and most other compilers), it provides libopenshot with easy methods of using parallel programming techniques to improve performance and take advantage of multi-core processors.
 
 ## CMake Flags (Optional)
-There are many different build flags that can be passed to cmake to adjust how libopenshot is 
-compiled. Some of these flags might be required when compiling on certain OSes, just depending 
-on how your build environment is setup. To add a build flag, follow this general syntax: 
+
+There are many different build flags that can be passed to cmake to adjust how libopenshot is
+compiled. Some of these flags might be required when compiling on certain OSes, just depending
+on how your build environment is setup. To add a build flag, follow this general syntax:
 `cmake -DMAGICKCORE_HDRI_ENABLE=1 -DENABLE_TESTS=1 ../`
 
-* MAGICKCORE_HDRI_ENABLE (default 0)
-* MAGICKCORE_QUANTUM_DEPTH (default 0)
-* OPENSHOT_IMAGEMAGICK_COMPATIBILITY (default 0)
-* DISABLE_TESTS (default 0)
-* CMAKE_PREFIX_PATH (`/location/to/missing/library/`)
-* PYTHON_INCLUDE_DIR (`/location/to/python/include/`)
-* PYTHON_LIBRARY (`/location/to/python/lib.a`)
-* PYTHON_FRAMEWORKS (`/usr/local/Cellar/python3/3.3.2/Frameworks/Python.framework/`)
-* CMAKE_CXX_COMPILER (`/location/to/mingw/g++`)
-* CMAKE_C_COMPILER (`/location/to/mingw/gcc`)
+*   MAGICKCORE_HDRI_ENABLE (default 0)
+*   MAGICKCORE_QUANTUM_DEPTH (default 0)
+*   OPENSHOT_IMAGEMAGICK_COMPATIBILITY (default 0)
+*   DISABLE_TESTS (default 0)
+*   CMAKE_PREFIX_PATH (`/location/to/missing/library/`)
+*   PYTHON_INCLUDE_DIR (`/location/to/python/include/`)
+*   PYTHON_LIBRARY (`/location/to/python/lib.a`)
+*   PYTHON_FRAMEWORKS (`/usr/local/Cellar/python3/3.3.2/Frameworks/Python.framework/`)
+*   CMAKE_CXX_COMPILER (`/location/to/mingw/g++`)
+*   CMAKE_C_COMPILER (`/location/to/mingw/gcc`)
 
 ## Obtaining Source Code
 
-The first step in installing libopenshot is to obtain the most recent source code. The source code is 
-available on [GitHub](https://github.com/OpenShot/libopenshot). Use the following command 
+The first step in installing libopenshot is to obtain the most recent source code. The source code is
+available on [GitHub](https://github.com/OpenShot/libopenshot). Use the following command
 to obtain the latest libopenshot source code.
 
-```
-git clone https://github.com/OpenShot/libopenshot.git
-git clone https://github.com/OpenShot/libopenshot-audio.git
-```
+    git clone https://github.com/OpenShot/libopenshot.git
+    git clone https://github.com/OpenShot/libopenshot-audio.git
 
 ## Folder Structure (libopenshot)
 
 The source code is divided up into the following folders.
 
 ### build/
-   * This folder needs to be manually created, and is used by cmake to store the temporary build files, such as makefiles, as well as the final binaries (library and test executables).
+
+*   This folder needs to be manually created, and is used by cmake to store the temporary build files, such as makefiles, as well as the final binaries (library and test executables).
 
 ### cmake/
-   * This folder contains custom modules not included by default in cmake, used to find dependency libraries and headers and determine if these libraries are installed.
+
+*   This folder contains custom modules not included by default in cmake, used to find dependency libraries and headers and determine if these libraries are installed.
 
 ### doc/
-   * This folder contains documentation and related files, such as logos and images required by the doxygen auto-generated documentation.
+
+*   This folder contains documentation and related files, such as logos and images required by the doxygen auto-generated documentation.
 
 ### include/
-   * This folder contains all headers (*.h) used by libopenshot.
+
+*   This folder contains all headers (\*.h) used by libopenshot.
 
 ### src/
-   * This folder contains all source code (*.cpp) used by libopenshot.
+
+*   This folder contains all source code (\*.cpp) used by libopenshot.
 
 ### tests/
-   * This folder contains all unit test code.  Each class has it’s own test file (*.cpp), and uses UnitTest++ macros to keep the test code simple and manageable.
+
+*   This folder contains all unit test code.  Each class has it’s own test file (\*.cpp), and uses UnitTest++ macros to keep the test code simple and manageable.
 
 ### thirdparty/
-   * This folder contains code not written by the OpenShot team. For example, jsoncpp, an open-source JSON parser.
+
+*   This folder contains code not written by the OpenShot team. For example, jsoncpp, an open-source JSON parser.
 
 ## Install Dependencies
 
-In order to actually compile libopenshot, we need to install some dependencies on your system. The easiest 
-way to accomplish this is with our Daily PPA. A PPA is an unofficial Ubuntu repository, which has our 
+In order to actually compile libopenshot, we need to install some dependencies on your system. The easiest
+way to accomplish this is with our Daily PPA. A PPA is an unofficial Ubuntu repository, which has our
 software packages available to download and install.
 
-```
-   sudo add-apt-repository ppa:openshot.developers/libopenshot-daily
-   sudo apt-get update
-   sudo apt-get install openshot-qt \
-                        cmake \
-                        libx11-dev \
-                        libasound2-dev \
-                        libavcodec-dev \
-                        libavdevice-dev \
-                        libavfilter-dev \
-                        libavformat-dev \
-                        libavresample-dev \
-                        libavutil-dev \
-                        libfdk-aac-dev \
-                        libfreetype6-dev \
-                        libjsoncpp-dev \
-                        libmagick++-dev \
-                        libopenshot-audio-dev \
-                        libswscale-dev \
-                        libunittest++-dev \
-                        libxcursor-dev \
-                        libxinerama-dev \
-                        libxrandr-dev \
-                        libzmq3-dev \
-                        pkg-config \
-                        python3-dev \
-                        qtbase5-dev \
-                        qtmultimedia5-dev \
-                        swig
-```
+       sudo add-apt-repository ppa:openshot.developers/libopenshot-daily
+       sudo apt-get update
+       sudo apt-get install openshot-qt \
+                            cmake \
+                            libx11-dev \
+                            libasound2-dev \
+                            libavcodec-dev \
+                            libavdevice-dev \
+                            libavfilter-dev \
+                            libavformat-dev \
+                            libavresample-dev \
+                            libavutil-dev \
+                            libfdk-aac-dev \
+                            libfreetype6-dev \
+                            libjsoncpp-dev \
+                            libmagick++-dev \
+                            libopenshot-audio-dev \
+                            libswscale-dev \
+                            libunittest++-dev \
+                            libxcursor-dev \
+                            libxinerama-dev \
+                            libxrandr-dev \
+                            libzmq3-dev \
+                            pkg-config \
+                            python3-dev \
+                            qtbase5-dev \
+                            qtmultimedia5-dev \
+                            swig
 
 ## Linux Build Instructions (libopenshot-audio)
-To compile libopenshot-audio, we need to go through a few additional steps to manually build and 
+
+To compile libopenshot-audio, we need to go through a few additional steps to manually build and
 install it. Launch a terminal and enter:
 
-```
-cd [libopenshot-audio repo folder]
-mkdir build
-cd build
-cmake ../
-make
-make install
-./src/openshot-audio-test-sound  (This should play a test sound)
-```
+    cd [libopenshot-audio repo folder]
+    mkdir build
+    cd build
+    cmake ../
+    make
+    make install
+    ./src/openshot-audio-test-sound  (This should play a test sound)
 
 ## Linux Build Instructions (libopenshot)
+
 Run the following commands to compile libopenshot:
 
-```
-cd [libopenshot repo directory]
-mkdir -p build
-cd build
-cmake ../
-make
-```
+    cd [libopenshot repo directory]
+    mkdir -p build
+    cd build
+    cmake ../
+    make
 
-If you are missing any dependencies for libopenshot, you might receive error messages at this point. 
-Just install the missing packages (usually with a -dev suffix), and run the above commands again. 
+If you are missing any dependencies for libopenshot, you might receive error messages at this point.
+Just install the missing packages (usually with a -dev suffix), and run the above commands again.
 Repeat until no error messages are displayed, and the build process completes. Also, if you manually
 install Qt 5, you might need to specify the location for cmake:
 
-```
-cmake -DCMAKE_PREFIX_PATH=/qt5_path/qt5/5.2.0/ ../
-```
+    cmake -DCMAKE_PREFIX_PATH=/qt5_path/qt5/5.2.0/ ../
 
 To run all unit tests (and verify everything is working correctly), launch a terminal, and enter:
 
-```
-make test
-```
+    make test
 
 To auto-generate documentation for libopenshot, launch a terminal, and enter:
 
-```
-make doc
-```
+    make doc
 
-This will use doxygen to generate a folder of HTML files, with all classes and methods documented. The 
-folder is located at **build/doc/html/**. Once libopenshot has been successfully built, we need to 
+This will use doxygen to generate a folder of HTML files, with all classes and methods documented. The
+folder is located at **build/doc/html/**. Once libopenshot has been successfully built, we need to
 install it (i.e. copy it to the correct folder, so other libraries can find it).
 
-```
-make install
-```
+    make install
 
-This will copy the binary files to /usr/local/lib/, and the header files to /usr/local/include/openshot/... 
-This is where other projects will look for the libopenshot files when building. Python 3 bindings are 
+This will copy the binary files to /usr/local/lib/, and the header files to /usr/local/include/openshot/...
+This is where other projects will look for the libopenshot files when building. Python 3 bindings are
 also installed at this point. let's verify the python bindings work:
 
-```
-python3
->>> import openshot
-```
+    python3
+    >>> import openshot
 
-If no errors are displayed, you have successfully compiled and installed libopenshot on your system. 
-Congratulations and be sure to read our wiki on [Becoming an OpenShot Developer](https://github.com/OpenShot/openshot-qt/wiki/Become-a-Developer)! 
+If no errors are displayed, you have successfully compiled and installed libopenshot on your system.
+Congratulations and be sure to read our wiki on [Becoming an OpenShot Developer](https://github.com/OpenShot/openshot-qt/wiki/Become-a-Developer)!
 Welcome to the OpenShot developer community! We look forward to meeting you!

--- a/doc/INSTALL-MAC.md
+++ b/doc/INSTALL-MAC.md
@@ -2,219 +2,222 @@
 
 ## Getting Started
 
-The best way to get started with libopenshot, is to learn about our build system, obtain all the source code, 
-install a development IDE and tools, and better understand our dependencies. So, please read through the 
-following sections, and follow the instructions. And keep in mind, that your computer is likely different 
-than the one used when writing these instructions. Your file paths and versions of applications might be 
+The best way to get started with libopenshot, is to learn about our build system, obtain all the source code,
+install a development IDE and tools, and better understand our dependencies. So, please read through the
+following sections, and follow the instructions. And keep in mind, that your computer is likely different
+than the one used when writing these instructions. Your file paths and versions of applications might be
 slightly different, so keep an eye out for subtle file path differences in the commands you type.
 
 ## Build Tools
 
-CMake is the backbone of our build system.  It is a cross-platform build system, which checks for 
-dependencies, locates header files and libraries, generates makefiles, and supports the cross-platform 
-compiling of libopenshot and libopenshot-audio.  CMake uses an out-of-source build concept, where 
-all temporary build files, such as makefiles, object files, and even the final binaries, are created 
-outside of the source code folder, inside a /build/ sub-folder.  This prevents the build process 
-from cluttering up the source code.  These instructions have only been tested with the GNU compiler 
+CMake is the backbone of our build system.  It is a cross-platform build system, which checks for
+dependencies, locates header files and libraries, generates makefiles, and supports the cross-platform
+compiling of libopenshot and libopenshot-audio.  CMake uses an out-of-source build concept, where
+all temporary build files, such as makefiles, object files, and even the final binaries, are created
+outside of the source code folder, inside a /build/ sub-folder.  This prevents the build process
+from cluttering up the source code.  These instructions have only been tested with the GNU compiler
 (including MSYS2/MinGW for Windows).
 
 ## Dependencies
 
-The following libraries are required to build libopenshot.  Instructions on how to install these 
-dependencies vary for each operating system.  Libraries and Executables have been labeled in the 
+The following libraries are required to build libopenshot.  Instructions on how to install these
+dependencies vary for each operating system.  Libraries and Executables have been labeled in the
 list below to help distinguish between them.
 
 ### FFmpeg (libavformat, libavcodec, libavutil, libavdevice, libavresample, libswscale)
-  * http://www.ffmpeg.org/ `(Library)`
-  * This library is used to decode and encode video, audio, and image files.  It is also used to obtain information about media files, such as frame rate, sample rate, aspect ratio, and other common attributes.
+
+*   http://www.ffmpeg.org/ `(Library)`
+*   This library is used to decode and encode video, audio, and image files.  It is also used to obtain information about media files, such as frame rate, sample rate, aspect ratio, and other common attributes.
 
 ### ImageMagick++ (libMagick++, libMagickWand, libMagickCore)
-  * http://www.imagemagick.org/script/magick++.php `(Library)`
-  * This library is **optional**, and used to decode and encode images.
+
+*   http://www.imagemagick.org/script/magick++.php `(Library)`
+*   This library is **optional**, and used to decode and encode images.
 
 ### OpenShot Audio Library (libopenshot-audio)
-  * https://github.com/OpenShot/libopenshot-audio/ `(Library)`
-  * This library is used to mix, resample, host plug-ins, and play audio. It is based on the JUCE project, which is an outstanding audio library used by many different applications
+
+*   https://github.com/OpenShot/libopenshot-audio/ `(Library)`
+*   This library is used to mix, resample, host plug-ins, and play audio. It is based on the JUCE project, which is an outstanding audio library used by many different applications
 
 ### Qt 5 (libqt5)
-  * http://www.qt.io/qt5/ `(Library)`
-  * Qt5 is used to display video, store image data, composite images, apply image effects, and many other utility functions, such as file system manipulation, high resolution timers, etc...
+
+*   http://www.qt.io/qt5/ `(Library)`
+*   Qt5 is used to display video, store image data, composite images, apply image effects, and many other utility functions, such as file system manipulation, high resolution timers, etc...
 
 ### CMake (cmake)
-  * http://www.cmake.org/ `(Executable)`
-  * This executable is used to automate the generation of Makefiles, check for dependencies, and is the backbone of libopenshot’s cross-platform build process.
+
+*   http://www.cmake.org/ `(Executable)`
+*   This executable is used to automate the generation of Makefiles, check for dependencies, and is the backbone of libopenshot’s cross-platform build process.
 
 ### SWIG (swig)
-  * http://www.swig.org/ `(Executable)`
-  * This executable is used to generate the Python and Ruby bindings for libopenshot. It is a simple and powerful wrapper for C++ libraries, and supports many languages.
+
+*   http://www.swig.org/ `(Executable)`
+*   This executable is used to generate the Python and Ruby bindings for libopenshot. It is a simple and powerful wrapper for C++ libraries, and supports many languages.
 
 ### Python 3 (libpython)
-  * http://www.python.org/ `(Executable and Library)`
-  * This library is used by swig to create the Python (version 3+) bindings for libopenshot. This is also the official language used by OpenShot Video Editor (a graphical interface to libopenshot).
+
+*   http://www.python.org/ `(Executable and Library)`
+*   This library is used by swig to create the Python (version 3+) bindings for libopenshot. This is also the official language used by OpenShot Video Editor (a graphical interface to libopenshot).
 
 ### Doxygen (doxygen)
-  * http://www.stack.nl/~dimitri/doxygen/ `(Executable)`
-  * This executable is used to auto-generate the documentation used by libopenshot.
+
+*   http://www.stack.nl/~dimitri/doxygen/ `(Executable)`
+*   This executable is used to auto-generate the documentation used by libopenshot.
 
 ### UnitTest++ (libunittest++)
-  * https://github.com/unittest-cpp/ `(Library)`
-  * This library is used to execute unit tests for libopenshot.  It contains many macros used to keep our unit testing code very clean and simple.
+
+*   https://github.com/unittest-cpp/ `(Library)`
+*   This library is used to execute unit tests for libopenshot.  It contains many macros used to keep our unit testing code very clean and simple.
 
 ### ZeroMQ (libzmq)
-  * http://zeromq.org/ `(Library)`
-  * This library is used to communicate between libopenshot and other applications (publisher / subscriber). Primarily used to send debug data from libopenshot.
+
+*   http://zeromq.org/ `(Library)`
+*   This library is used to communicate between libopenshot and other applications (publisher / subscriber). Primarily used to send debug data from libopenshot.
 
 ### OpenMP (-fopenmp)
-  * http://openmp.org/wp/ `(Compiler Flag)`
-  * If your compiler supports this flag (GCC, Clang, and most other compilers), it provides libopenshot with easy methods of using parallel programming techniques to improve performance and take advantage of multi-core processors.
+
+*   http://openmp.org/wp/ `(Compiler Flag)`
+*   If your compiler supports this flag (GCC, Clang, and most other compilers), it provides libopenshot with easy methods of using parallel programming techniques to improve performance and take advantage of multi-core processors.
 
 ## CMake Flags (Optional)
-There are many different build flags that can be passed to cmake to adjust how libopenshot is compiled. 
-Some of these flags might be required when compiling on certain OSes, just depending on how your build 
-environment is setup. To add a build flag, follow this general syntax: 
+
+There are many different build flags that can be passed to cmake to adjust how libopenshot is compiled.
+Some of these flags might be required when compiling on certain OSes, just depending on how your build
+environment is setup. To add a build flag, follow this general syntax:
 `cmake -DMAGICKCORE_HDRI_ENABLE=1 -DENABLE_TESTS=1 ../`
 
-* MAGICKCORE_HDRI_ENABLE (default 0)
-* MAGICKCORE_QUANTUM_DEPTH (default 0)
-* OPENSHOT_IMAGEMAGICK_COMPATIBILITY (default 0)
-* DISABLE_TESTS (default 0)
-* CMAKE_PREFIX_PATH (`/location/to/missing/library/`)
-* PYTHON_INCLUDE_DIR (`/location/to/python/include/`)
-* PYTHON_LIBRARY (`/location/to/python/lib.a`)
-* PYTHON_FRAMEWORKS (`/usr/local/Cellar/python3/3.3.2/Frameworks/Python.framework/`)
-* CMAKE_CXX_COMPILER (`/location/to/mingw/g++`)
-* CMAKE_C_COMPILER (`/location/to/mingw/gcc`)
+*   MAGICKCORE_HDRI_ENABLE (default 0)
+*   MAGICKCORE_QUANTUM_DEPTH (default 0)
+*   OPENSHOT_IMAGEMAGICK_COMPATIBILITY (default 0)
+*   DISABLE_TESTS (default 0)
+*   CMAKE_PREFIX_PATH (`/location/to/missing/library/`)
+*   PYTHON_INCLUDE_DIR (`/location/to/python/include/`)
+*   PYTHON_LIBRARY (`/location/to/python/lib.a`)
+*   PYTHON_FRAMEWORKS (`/usr/local/Cellar/python3/3.3.2/Frameworks/Python.framework/`)
+*   CMAKE_CXX_COMPILER (`/location/to/mingw/g++`)
+*   CMAKE_C_COMPILER (`/location/to/mingw/gcc`)
 
 ## Obtaining Source Code
 
-The first step in installing libopenshot is to obtain the most recent source code. The source code 
-is available on [GitHub](https://github.com/OpenShot/libopenshot). Use the following command to 
+The first step in installing libopenshot is to obtain the most recent source code. The source code
+is available on [GitHub](https://github.com/OpenShot/libopenshot). Use the following command to
 obtain the latest libopenshot source code.
 
-```
-git clone https://github.com/OpenShot/libopenshot.git
-git clone https://github.com/OpenShot/libopenshot-audio.git
-```
+    git clone https://github.com/OpenShot/libopenshot.git
+    git clone https://github.com/OpenShot/libopenshot-audio.git
 
 ## Folder Structure (libopenshot)
 
 The source code is divided up into the following folders.
 
 ### build/
-   * This folder needs to be manually created, and is used by cmake to store the temporary build files, such as makefiles, as well as the final binaries (library and test executables).
+
+*   This folder needs to be manually created, and is used by cmake to store the temporary build files, such as makefiles, as well as the final binaries (library and test executables).
 
 ### cmake/
-   * This folder contains custom modules not included by default in cmake, used to find dependency libraries and headers and determine if these libraries are installed.
+
+*   This folder contains custom modules not included by default in cmake, used to find dependency libraries and headers and determine if these libraries are installed.
 
 ### doc/
-   * This folder contains documentation and related files, such as logos and images required by the doxygen auto-generated documentation.
+
+*   This folder contains documentation and related files, such as logos and images required by the doxygen auto-generated documentation.
 
 ### include/
-   * This folder contains all headers (*.h) used by libopenshot.
+
+*   This folder contains all headers (\*.h) used by libopenshot.
 
 ### src/
-   * This folder contains all source code (*.cpp) used by libopenshot.
+
+*   This folder contains all source code (\*.cpp) used by libopenshot.
 
 ### tests/
-   * This folder contains all unit test code.  Each class has it’s own test file (*.cpp), and uses UnitTest++ macros to keep the test code simple and manageable.
+
+*   This folder contains all unit test code.  Each class has it’s own test file (\*.cpp), and uses UnitTest++ macros to keep the test code simple and manageable.
 
 ### thirdparty/
-   * This folder contains code not written by the OpenShot team. For example, jsoncpp, an open-source JSON parser.
+
+*   This folder contains code not written by the OpenShot team. For example, jsoncpp, an open-source JSON parser.
 
 ## Install Dependencies
 
-In order to actually compile libopenshot and libopenshot-audio, we need to install some dependencies on 
-your system. Most packages needed by libopenshot can be installed easily with Homebrew. However, first 
-install Xcode with the following options ("UNIX Development", "System Tools", "Command Line Tools", or 
+In order to actually compile libopenshot and libopenshot-audio, we need to install some dependencies on
+your system. Most packages needed by libopenshot can be installed easily with Homebrew. However, first
+install Xcode with the following options ("UNIX Development", "System Tools", "Command Line Tools", or
 "Command Line Support"). Be sure to refresh your list of Homebrew packages with the “brew update” command.
 
-**NOTE:** Homebrew seems to work much better for most users (compared to MacPorts), so I am going to 
+**NOTE:** Homebrew seems to work much better for most users (compared to MacPorts), so I am going to
 focus on brew for this guide.
 
-Install the following packages using the Homebrew package installer (http://brew.sh/). Pay close attention 
-to any warnings or errors during these brew installs. NOTE: You might have some conflicting libraries in 
+Install the following packages using the Homebrew package installer (http://brew.sh/). Pay close attention
+to any warnings or errors during these brew installs. NOTE: You might have some conflicting libraries in
 your /usr/local/ folders, so follow the directions from brew if these are detected.
 
-```
-brew install gcc48 --enable-all-languages
-brew install ffmpeg
-brew install librsvg
-brew install swig
-brew install doxygen
-brew install unittest-cpp --cc=gcc-4.8. You must specify the c++ compiler with the --cc flag to be 4.7 or 4.8.
-brew install qt5
-brew install cmake
-brew install zeromq
-```
+    brew install gcc48 --enable-all-languages
+    brew install ffmpeg
+    brew install librsvg
+    brew install swig
+    brew install doxygen
+    brew install unittest-cpp --cc=gcc-4.8. You must specify the c++ compiler with the --cc flag to be 4.7 or 4.8.
+    brew install qt5
+    brew install cmake
+    brew install zeromq
 
 ## Mac Build Instructions (libopenshot-audio)
-Since libopenshot-audio is not available in a Homebrew or MacPorts package, we need to go through a 
+
+Since libopenshot-audio is not available in a Homebrew or MacPorts package, we need to go through a
 few additional steps to manually build and install it. Launch a terminal and enter:
 
-```
-cd [libopenshot-audio repo folder]
-mkdir build
-cd build
-cmake -d -G "Unix Makefiles" -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang ../   (CLang must be used due to GNU incompatible Objective-C code in some of the Apple frameworks)
-make
-make install
-./src/openshot-audio-test-sound  (This should play a test sound)
-```
+    cd [libopenshot-audio repo folder]
+    mkdir build
+    cd build
+    cmake -d -G "Unix Makefiles" -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang ../   (CLang must be used due to GNU incompatible Objective-C code in some of the Apple frameworks)
+    make
+    make install
+    ./src/openshot-audio-test-sound  (This should play a test sound)
 
 ## Mac Build Instructions (libopenshot)
+
 Run the following commands to build libopenshot:
 
-```
-$ cd [libopenshot repo folder]
-$ mkdir build
-$ cd build
-$ cmake -G "Unix Makefiles"  -DCMAKE_CXX_COMPILER=/usr/local/opt/gcc48/bin/g++-4.8 -DCMAKE_C_COMPILER=/usr/local/opt/gcc48/bin/gcc-4.8 -DCMAKE_PREFIX_PATH=/usr/local/Cellar/qt5/5.4.2/ -DPYTHON_INCLUDE_DIR=/usr/local/Cellar/python3/3.3.2/Frameworks/Python.framework/Versions/3.3/include/python3.3m/ -DPYTHON_LIBRARY=/usr/local/Cellar/python3/3.3.2/Frameworks/Python.framework/Versions/3.3/lib/libpython3.3.dylib -DPython_FRAMEWORKS=/usr/local/Cellar/python3/3.3.2/Frameworks/Python.framework/ ../ -D"CMAKE_BUILD_TYPE:STRING=Debug"
-```
+    $ cd [libopenshot repo folder]
+    $ mkdir build
+    $ cd build
+    $ cmake -G "Unix Makefiles"  -DCMAKE_CXX_COMPILER=/usr/local/opt/gcc48/bin/g++-4.8 -DCMAKE_C_COMPILER=/usr/local/opt/gcc48/bin/gcc-4.8 -DCMAKE_PREFIX_PATH=/usr/local/Cellar/qt5/5.4.2/ -DPYTHON_INCLUDE_DIR=/usr/local/Cellar/python3/3.3.2/Frameworks/Python.framework/Versions/3.3/include/python3.3m/ -DPYTHON_LIBRARY=/usr/local/Cellar/python3/3.3.2/Frameworks/Python.framework/Versions/3.3/lib/libpython3.3.dylib -DPython_FRAMEWORKS=/usr/local/Cellar/python3/3.3.2/Frameworks/Python.framework/ ../ -D"CMAKE_BUILD_TYPE:STRING=Debug"
 
-The extra arguments on the cmake command make sure the compiler will be gcc4.8 and that cmake 
-knows where to look for the Qt header files and Python library. Double check these file paths, 
+The extra arguments on the cmake command make sure the compiler will be gcc4.8 and that cmake
+knows where to look for the Qt header files and Python library. Double check these file paths,
 as yours will likely be different.
 
-```
-make
-```
+    make
 
-If you are missing any dependencies for libopenshot, you will receive error messages at this point. 
-Just install the missing dependencies, and run the above commands again. Repeat until no error 
+If you are missing any dependencies for libopenshot, you will receive error messages at this point.
+Just install the missing dependencies, and run the above commands again. Repeat until no error
 messages are displayed and the build process completes.
 
-Also, if you are having trouble building, please see the CMake Flags section above, as it might 
+Also, if you are having trouble building, please see the CMake Flags section above, as it might
 provide a solution for finding a missing folder path, missing Python 3 library, etc...
 
 To run all unit tests (and verify everything is working correctly), launch a terminal, and enter:
 
-```
-make test
-```
+    make test
 
 To auto-generate the documentation for libopenshot, launch a terminal, and enter:
 
-```
-make doc
-```
+    make doc
 
-This will use doxygen to generate a folder of HTML files, with all classes and methods documented. 
-The folder is located at build/doc/html/. Once libopenshot has been successfully built, we need 
+This will use doxygen to generate a folder of HTML files, with all classes and methods documented.
+The folder is located at build/doc/html/. Once libopenshot has been successfully built, we need
 to install it (i.e. copy it to the correct folder, so other libraries can find it).
 
-```
-make install
-```
+    make install
 
-This should copy the binary files to /usr/local/lib/, and the header files to /usr/local/include/openshot/... 
-This is where other projects will look for the libopenshot files when building. Python 3 bindings are 
+This should copy the binary files to /usr/local/lib/, and the header files to /usr/local/include/openshot/...
+This is where other projects will look for the libopenshot files when building. Python 3 bindings are
 also installed at this point. let's verify the python bindings work:
 
-```
-python3 (or python)
->>> import openshot
-```
+    python3 (or python)
+    >>> import openshot
 
-If no errors are displayed, you have successfully compiled and installed libopenshot on your 
-system. Congratulations and be sure to read our wiki on [Becoming an OpenShot Developer](https://github.com/OpenShot/openshot-qt/wiki/Become-a-Developer)! 
+If no errors are displayed, you have successfully compiled and installed libopenshot on your
+system. Congratulations and be sure to read our wiki on [Becoming an OpenShot Developer](https://github.com/OpenShot/openshot-qt/wiki/Become-a-Developer)!
 Welcome to the OpenShot developer community! We look forward to meeting you!

--- a/doc/INSTALL-WINDOWS.md
+++ b/doc/INSTALL-WINDOWS.md
@@ -2,161 +2,174 @@
 
 ## Getting Started
 
-The best way to get started with libopenshot, is to learn about our build system, obtain all the 
-source code, install a development IDE and tools, and better understand our dependencies. So, 
-please read through the following sections, and follow the instructions. And keep in mind, 
-that your computer is likely different than the one used when writing these instructions. 
-Your file paths and versions of applications might be slightly different, so keep an eye out 
+The best way to get started with libopenshot, is to learn about our build system, obtain all the
+source code, install a development IDE and tools, and better understand our dependencies. So,
+please read through the following sections, and follow the instructions. And keep in mind,
+that your computer is likely different than the one used when writing these instructions.
+Your file paths and versions of applications might be slightly different, so keep an eye out
 for subtle file path differences in the commands you type.
 
 ## Build Tools
 
-CMake is the backbone of our build system.  It is a cross-platform build system, which 
-checks for dependencies, locates header files and libraries, generates makefiles, and 
-supports the cross-platform compiling of libopenshot and libopenshot-audio.  CMake uses 
-an out-of-source build concept, where all temporary build files, such as makefiles, 
-object files, and even the final binaries, are created outside of the source code 
-folder, inside a /build/ sub-folder.  This prevents the build process from cluttering 
-up the source code.  These instructions have only been tested with the GNU compiler 
+CMake is the backbone of our build system.  It is a cross-platform build system, which
+checks for dependencies, locates header files and libraries, generates makefiles, and
+supports the cross-platform compiling of libopenshot and libopenshot-audio.  CMake uses
+an out-of-source build concept, where all temporary build files, such as makefiles,
+object files, and even the final binaries, are created outside of the source code
+folder, inside a /build/ sub-folder.  This prevents the build process from cluttering
+up the source code.  These instructions have only been tested with the GNU compiler
 (including MSYS2/MinGW for Windows).
 
 ## Dependencies
 
-The following libraries are required to build libopenshot.  Instructions on how to 
-install these dependencies vary for each operating system.  Libraries and Executables 
+The following libraries are required to build libopenshot.  Instructions on how to
+install these dependencies vary for each operating system.  Libraries and Executables
 have been labeled in the list below to help distinguish between them.
 
 ### FFmpeg (libavformat, libavcodec, libavutil, libavdevice, libavresample, libswscale)
-  * http://www.ffmpeg.org/ `(Library)`
-  * This library is used to decode and encode video, audio, and image files.  It is also used to obtain information about media files, such as frame rate, sample rate, aspect ratio, and other common attributes.
+
+*   http://www.ffmpeg.org/ `(Library)`
+*   This library is used to decode and encode video, audio, and image files.  It is also used to obtain information about media files, such as frame rate, sample rate, aspect ratio, and other common attributes.
 
 ### ImageMagick++ (libMagick++, libMagickWand, libMagickCore)
-  * http://www.imagemagick.org/script/magick++.php `(Library)`
-  * This library is **optional**, and used to decode and encode images.
+
+*   http://www.imagemagick.org/script/magick++.php `(Library)`
+*   This library is **optional**, and used to decode and encode images.
 
 ### OpenShot Audio Library (libopenshot-audio)
-  * https://github.com/OpenShot/libopenshot-audio/ `(Library)`
-  * This library is used to mix, resample, host plug-ins, and play audio. It is based on the JUCE project, which is an outstanding audio library used by many different applications
+
+*   https://github.com/OpenShot/libopenshot-audio/ `(Library)`
+*   This library is used to mix, resample, host plug-ins, and play audio. It is based on the JUCE project, which is an outstanding audio library used by many different applications
 
 ### Qt 5 (libqt5)
-  * http://www.qt.io/qt5/ `(Library)`
-  * Qt5 is used to display video, store image data, composite images, apply image effects, and many other utility functions, such as file system manipulation, high resolution timers, etc...
+
+*   http://www.qt.io/qt5/ `(Library)`
+*   Qt5 is used to display video, store image data, composite images, apply image effects, and many other utility functions, such as file system manipulation, high resolution timers, etc...
 
 ### CMake (cmake)
-  * http://www.cmake.org/ `(Executable)`
-  * This executable is used to automate the generation of Makefiles, check for dependencies, and is the backbone of libopenshot’s cross-platform build process.
+
+*   http://www.cmake.org/ `(Executable)`
+*   This executable is used to automate the generation of Makefiles, check for dependencies, and is the backbone of libopenshot’s cross-platform build process.
 
 ### SWIG (swig)
-  * http://www.swig.org/ `(Executable)`
-  * This executable is used to generate the Python and Ruby bindings for libopenshot. It is a simple and powerful wrapper for C++ libraries, and supports many languages.
+
+*   http://www.swig.org/ `(Executable)`
+*   This executable is used to generate the Python and Ruby bindings for libopenshot. It is a simple and powerful wrapper for C++ libraries, and supports many languages.
 
 ### Python 3 (libpython)
-  * http://www.python.org/ `(Executable and Library)`
-  * This library is used by swig to create the Python (version 3+) bindings for libopenshot. This is also the official language used by OpenShot Video Editor (a graphical interface to libopenshot).
+
+*   http://www.python.org/ `(Executable and Library)`
+*   This library is used by swig to create the Python (version 3+) bindings for libopenshot. This is also the official language used by OpenShot Video Editor (a graphical interface to libopenshot).
 
 ### Doxygen (doxygen)
-  * http://www.stack.nl/~dimitri/doxygen/ `(Executable)`
-  * This executable is used to auto-generate the documentation used by libopenshot.
+
+*   http://www.stack.nl/~dimitri/doxygen/ `(Executable)`
+*   This executable is used to auto-generate the documentation used by libopenshot.
 
 ### UnitTest++ (libunittest++)
-  * https://github.com/unittest-cpp/ `(Library)`
-  * This library is used to execute unit tests for libopenshot.  It contains many macros used to keep our unit testing code very clean and simple.
+
+*   https://github.com/unittest-cpp/ `(Library)`
+*   This library is used to execute unit tests for libopenshot.  It contains many macros used to keep our unit testing code very clean and simple.
 
 ### ZeroMQ (libzmq)
-  * http://zeromq.org/ `(Library)`
-  * This library is used to communicate between libopenshot and other applications (publisher / subscriber). Primarily used to send debug data from libopenshot.
+
+*   http://zeromq.org/ `(Library)`
+*   This library is used to communicate between libopenshot and other applications (publisher / subscriber). Primarily used to send debug data from libopenshot.
 
 ### OpenMP (-fopenmp)
-  * http://openmp.org/wp/ `(Compiler Flag)`
-  * If your compiler supports this flag (GCC, Clang, and most other compilers), it provides libopenshot with easy methods of using parallel programming techniques to improve performance and take advantage of multi-core processors.
+
+*   http://openmp.org/wp/ `(Compiler Flag)`
+*   If your compiler supports this flag (GCC, Clang, and most other compilers), it provides libopenshot with easy methods of using parallel programming techniques to improve performance and take advantage of multi-core processors.
 
 ## CMake Flags (Optional)
-There are many different build flags that can be passed to cmake to adjust how libopenshot 
-is compiled. Some of these flags might be required when compiling on certain OSes, just 
-depending on how your build environment is setup. To add a build flag, follow this general 
+
+There are many different build flags that can be passed to cmake to adjust how libopenshot
+is compiled. Some of these flags might be required when compiling on certain OSes, just
+depending on how your build environment is setup. To add a build flag, follow this general
 syntax: `cmake -DMAGICKCORE_HDRI_ENABLE=1 -DENABLE_TESTS=1 ../`
 
-* MAGICKCORE_HDRI_ENABLE (default 0)
-* MAGICKCORE_QUANTUM_DEPTH (default 0)
-* OPENSHOT_IMAGEMAGICK_COMPATIBILITY (default 0)
-* DISABLE_TESTS (default 0)
-* CMAKE_PREFIX_PATH (`/location/to/missing/library/`)
-* PYTHON_INCLUDE_DIR (`/location/to/python/include/`)
-* PYTHON_LIBRARY (`/location/to/python/lib.a`)
-* PYTHON_FRAMEWORKS (`/usr/local/Cellar/python3/3.3.2/Frameworks/Python.framework/`)
-* CMAKE_CXX_COMPILER (`/location/to/mingw/g++`)
-* CMAKE_C_COMPILER (`/location/to/mingw/gcc`)
+*   MAGICKCORE_HDRI_ENABLE (default 0)
+*   MAGICKCORE_QUANTUM_DEPTH (default 0)
+*   OPENSHOT_IMAGEMAGICK_COMPATIBILITY (default 0)
+*   DISABLE_TESTS (default 0)
+*   CMAKE_PREFIX_PATH (`/location/to/missing/library/`)
+*   PYTHON_INCLUDE_DIR (`/location/to/python/include/`)
+*   PYTHON_LIBRARY (`/location/to/python/lib.a`)
+*   PYTHON_FRAMEWORKS (`/usr/local/Cellar/python3/3.3.2/Frameworks/Python.framework/`)
+*   CMAKE_CXX_COMPILER (`/location/to/mingw/g++`)
+*   CMAKE_C_COMPILER (`/location/to/mingw/gcc`)
 
 ## Environment Variables
 
-Many environment variables will need to be set during this Windows installation guide. 
-The command line will need to be closed and re-launched after any changes to your environment 
-variables. Also, dependency libraries will not be found during linking or execution without 
-being found in the PATH environment variable. So, if you get errors related to missing 
+Many environment variables will need to be set during this Windows installation guide.
+The command line will need to be closed and re-launched after any changes to your environment
+variables. Also, dependency libraries will not be found during linking or execution without
+being found in the PATH environment variable. So, if you get errors related to missing
 commands or libraries, double check the PATH variable.
 
-The following environment variables need to be added to your “System Variables”.  Be sure to 
+The following environment variables need to be added to your “System Variables”.  Be sure to
 check each folder path for accuracy, as your paths will likely be different than this list.
 
 ### Example Variables
 
-* DL_DIR (`C:\libdl`)
-* DXSDK_DIR (`C:\Program Files\Microsoft DirectX SDK (June 2010)\`)
-* FFMPEGDIR (`C:\ffmpeg-git-95f163b-win32-dev`)
-* FREETYPE_DIR (`C:\Program Files\GnuWin32`)
-* HOME (`C:\msys\1.0\home`)
-* LIBOPENSHOT_AUDIO_DIR (`C:\Program Files\libopenshot-audio`)
-* QTDIR (`C:\qt5`)
-* SNDFILE_DIR (`C:\Program Files\libsndfile`)
-* UNITTEST_DIR (`C:\UnitTest++`)
-* ZMQDIR (`C:\msys2\usr\local\`)
-* PATH (`The following paths are an example`)
-   * `C:\Qt5\bin; C:\Qt5\MinGW\bin\; C:\msys\1.0\local\lib; C:\Program Files\CMake 2.8\bin; C:\UnitTest++\build; C:\libopenshot\build\src; C:\Program Files\doxygen\bin; C:\ffmpeg-git-95f163b-win32-dev\lib; C:\swigwin-2.0.4; C:\Python33; C:\Program Files\Project\lib; C:\msys2\usr\local\`
-
-
-
-
+*   DL_DIR (`C:\libdl`)
+*   DXSDK_DIR (`C:\Program Files\Microsoft DirectX SDK (June 2010)\`)
+*   FFMPEGDIR (`C:\ffmpeg-git-95f163b-win32-dev`)
+*   FREETYPE_DIR (`C:\Program Files\GnuWin32`)
+*   HOME (`C:\msys\1.0\home`)
+*   LIBOPENSHOT_AUDIO_DIR (`C:\Program Files\libopenshot-audio`)
+*   QTDIR (`C:\qt5`)
+*   SNDFILE_DIR (`C:\Program Files\libsndfile`)
+*   UNITTEST_DIR (`C:\UnitTest++`)
+*   ZMQDIR (`C:\msys2\usr\local\`)
+*   PATH (`The following paths are an example`)
+    *   `C:\Qt5\bin; C:\Qt5\MinGW\bin\; C:\msys\1.0\local\lib; C:\Program Files\CMake 2.8\bin; C:\UnitTest++\build; C:\libopenshot\build\src; C:\Program Files\doxygen\bin; C:\ffmpeg-git-95f163b-win32-dev\lib; C:\swigwin-2.0.4; C:\Python33; C:\Program Files\Project\lib; C:\msys2\usr\local\`
 
 ## Obtaining Source Code
 
-The first step in installing libopenshot is to obtain the most recent source code. The source code 
-is available on [GitHub](https://github.com/OpenShot/libopenshot). Use the following command to 
+The first step in installing libopenshot is to obtain the most recent source code. The source code
+is available on [GitHub](https://github.com/OpenShot/libopenshot). Use the following command to
 obtain the latest libopenshot source code.
 
-```
-git clone https://github.com/OpenShot/libopenshot.git
-git clone https://github.com/OpenShot/libopenshot-audio.git
-```
+    git clone https://github.com/OpenShot/libopenshot.git
+    git clone https://github.com/OpenShot/libopenshot-audio.git
 
 ## Folder Structure (libopenshot)
 
 The source code is divided up into the following folders.
 
 ### build/
-   * This folder needs to be manually created, and is used by cmake to store the temporary 
-   build files, such as makefiles, as well as the final binaries (library and test executables).
+
+*   This folder needs to be manually created, and is used by cmake to store the temporary
+    build files, such as makefiles, as well as the final binaries (library and test executables).
 
 ### cmake/
-   * This folder contains custom modules not included by default in cmake, used to find 
-   dependency libraries and headers and determine if these libraries are installed.
+
+*   This folder contains custom modules not included by default in cmake, used to find
+    dependency libraries and headers and determine if these libraries are installed.
 
 ### doc/
-   * This folder contains documentation and related files, such as logos and images 
-   required by the doxygen auto-generated documentation.
+
+*   This folder contains documentation and related files, such as logos and images
+    required by the doxygen auto-generated documentation.
 
 ### include/
-   * This folder contains all headers (*.h) used by libopenshot.
+
+*   This folder contains all headers (\*.h) used by libopenshot.
 
 ### src/
-   * This folder contains all source code (*.cpp) used by libopenshot.
+
+*   This folder contains all source code (\*.cpp) used by libopenshot.
 
 ### tests/
-   * This folder contains all unit test code.  Each class has it’s own test file (*.cpp), and 
-   uses UnitTest++ macros to keep the test code simple and manageable.
+
+*   This folder contains all unit test code.  Each class has it’s own test file (\*.cpp), and
+    uses UnitTest++ macros to keep the test code simple and manageable.
 
 ### thirdparty/
-   * This folder contains code not written by the OpenShot team. For example, jsoncpp, an 
-   open-source JSON parser.
+
+*   This folder contains code not written by the OpenShot team. For example, jsoncpp, an
+    open-source JSON parser.
 
 ## Install MSYS2 Dependencies
 
@@ -164,168 +177,158 @@ Most Windows dependencies needed for libopenshot-audio, libopenshot, and opensho
 can be installed easily with MSYS2 and the pacman package manager. Follow these
 directions to setup a Windows build environment for OpenShot.
 
-1) Install MSYS2: http://www.msys2.org/
+1.  Install MSYS2: http://www.msys2.org/
 
-2) Run MSYS2 command prompt (for example: `C:\msys64\msys2_shell.cmd`)
+2.  Run MSYS2 command prompt (for example: `C:\msys64\msys2_shell.cmd`)
 
-3) Append PATH (so MSYS2 can find executables and libraries):
+3.  Append PATH (so MSYS2 can find executables and libraries):
 
-```
-PATH=$PATH:/c/msys64/mingw64/bin:/c/msys64/mingw64/lib     (64-bit PATH)
-  or 
-PATH=$PATH:/c/msys32/mingw32/bin:/c/msys32/mingw32/lib     (32-bit PATH)
-```
+<!---->
 
-4) Update and upgrade all packages
+    PATH=$PATH:/c/msys64/mingw64/bin:/c/msys64/mingw64/lib     (64-bit PATH)
+      or 
+    PATH=$PATH:/c/msys32/mingw32/bin:/c/msys32/mingw32/lib     (32-bit PATH)
 
-```
-pacman -Syu
-```
+4.  Update and upgrade all packages
+
+<!---->
+
+    pacman -Syu
 
 5a) Install the following packages (**64-Bit**)
 
-```
-pacman -S --needed base-devel mingw-w64-x86_64-toolchain
-pacman -S mingw64/mingw-w64-x86_64-ffmpeg
-pacman -S mingw64/mingw-w64-x86_64-python3-pyqt5
-pacman -S mingw64/mingw-w64-x86_64-swig
-pacman -S mingw64/mingw-w64-x86_64-cmake
-pacman -S mingw64/mingw-w64-x86_64-doxygen
-pacman -S mingw64/mingw-w64-x86_64-python3-pip
-pacman -S mingw32/mingw-w64-i686-zeromq
-pacman -S mingw64/mingw-w64-x86_64-python3-pyzmq
-pacman -S mingw64/mingw-w64-x86_64-python3-cx_Freeze
-pacman -S git
+    pacman -S --needed base-devel mingw-w64-x86_64-toolchain
+    pacman -S mingw64/mingw-w64-x86_64-ffmpeg
+    pacman -S mingw64/mingw-w64-x86_64-python3-pyqt5
+    pacman -S mingw64/mingw-w64-x86_64-swig
+    pacman -S mingw64/mingw-w64-x86_64-cmake
+    pacman -S mingw64/mingw-w64-x86_64-doxygen
+    pacman -S mingw64/mingw-w64-x86_64-python3-pip
+    pacman -S mingw32/mingw-w64-i686-zeromq
+    pacman -S mingw64/mingw-w64-x86_64-python3-pyzmq
+    pacman -S mingw64/mingw-w64-x86_64-python3-cx_Freeze
+    pacman -S git
 
-# Install ImageMagick if needed (OPTIONAL and NOT NEEDED)
-pacman -S mingw64/mingw-w64-x86_64-imagemagick
-```
-  
+    # Install ImageMagick if needed (OPTIONAL and NOT NEEDED)
+    pacman -S mingw64/mingw-w64-x86_64-imagemagick
+
 5b) **Or** Install the following packages (**32-Bit**)
 
-```
-pacman -S --needed base-devel mingw32/mingw-w64-i686-toolchain
-pacman -S mingw32/mingw-w64-i686-ffmpeg
-pacman -S mingw32/mingw-w64-i686-python3-pyqt5
-pacman -S mingw32/mingw-w64-i686-swig
-pacman -S mingw32/mingw-w64-i686-cmake
-pacman -S mingw32/mingw-w64-i686-doxygen
-pacman -S mingw32/mingw-w64-i686-python3-pip
-pacman -S mingw32/mingw-w64-i686-zeromq
-pacman -S mingw32/mingw-w64-i686-python3-pyzmq
-pacman -S mingw32/mingw-w64-i686-python3-cx_Freeze
-pacman -S git
+    pacman -S --needed base-devel mingw32/mingw-w64-i686-toolchain
+    pacman -S mingw32/mingw-w64-i686-ffmpeg
+    pacman -S mingw32/mingw-w64-i686-python3-pyqt5
+    pacman -S mingw32/mingw-w64-i686-swig
+    pacman -S mingw32/mingw-w64-i686-cmake
+    pacman -S mingw32/mingw-w64-i686-doxygen
+    pacman -S mingw32/mingw-w64-i686-python3-pip
+    pacman -S mingw32/mingw-w64-i686-zeromq
+    pacman -S mingw32/mingw-w64-i686-python3-pyzmq
+    pacman -S mingw32/mingw-w64-i686-python3-cx_Freeze
+    pacman -S git
 
-# Install ImageMagick if needed (OPTIONAL and NOT NEEDED)
-pacman -S mingw32/mingw-w32-x86_32-imagemagick
-```
+    # Install ImageMagick if needed (OPTIONAL and NOT NEEDED)
+    pacman -S mingw32/mingw-w32-x86_32-imagemagick
 
-6) Install Python PIP Dependencies
- 
-```
-pip3 install httplib2
-pip3 install slacker
-pip3 install tinys3
-pip3 install github3.py
-pip3 install requests
-```  
+6.  Install Python PIP Dependencies
 
-7) Download Unittest++ (https://github.com/unittest-cpp/unittest-cpp) into /MSYS2/[USER]/unittest-cpp-master/
+<!---->
 
-``` 
-cmake -G "MSYS Makefiles" ../ -DCMAKE_MAKE_PROGRAM=mingw32-make -DCMAKE_INSTALL_PREFIX:PATH=/usr
-mingw32-make install
-```
+    pip3 install httplib2
+    pip3 install slacker
+    pip3 install tinys3
+    pip3 install github3.py
+    pip3 install requests
 
-8) ZMQ++ Header (This might not be needed anymore)
-  NOTE: Download and copy zmq.hpp into the /c/msys64/mingw64/include/ folder
+7.  Download Unittest++ (https://github.com/unittest-cpp/unittest-cpp) into /MSYS2/\[USER]/unittest-cpp-master/
+
+<!---->
+
+    cmake -G "MSYS Makefiles" ../ -DCMAKE_MAKE_PROGRAM=mingw32-make -DCMAKE_INSTALL_PREFIX:PATH=/usr
+    mingw32-make install
+
+8.  ZMQ++ Header (This might not be needed anymore)
+    NOTE: Download and copy zmq.hpp into the /c/msys64/mingw64/include/ folder
 
 ## Manual Dependencies
 
 ### DLfcn
-   * https://github.com/dlfcn-win32/dlfcn-win32
-   * Download and Extract the Win32 Static (.tar.bz2) archive to a local folder: `C:\libdl\`
-   * Create an environment variable called DL_DIR and set the value to `C:\libdl\`. This environment variable will be used by CMake to find the binary and header file.
+
+*   https://github.com/dlfcn-win32/dlfcn-win32
+*   Download and Extract the Win32 Static (.tar.bz2) archive to a local folder: `C:\libdl\`
+*   Create an environment variable called DL_DIR and set the value to `C:\libdl\`. This environment variable will be used by CMake to find the binary and header file.
 
 ### DirectX SDK / Windows SDK
-   * Windows 7: (DirectX SDK) http://www.microsoft.com/download/en/details.aspx?displaylang=en&id=6812
-   * Windows 8: (Windows SDK)
-   * https://msdn.microsoft.com/en-us/windows/desktop/aa904949
-   * Download and Install the SDK Setup program.  This is needed for the JUCE library to play audio on Windows.
-Create an environment variable called DXSDK_DIR and set the value to `C:\Program Files\Microsoft DirectX SDK (June 2010)\` (your path might be different). This environment variable will be used by CMake to find the binaries and header files.
+
+*   Windows 7: (DirectX SDK) http://www.microsoft.com/download/en/details.aspx?displaylang=en\&id=6812
+*   Windows 8: (Windows SDK)
+*   https://msdn.microsoft.com/en-us/windows/desktop/aa904949
+*   Download and Install the SDK Setup program.  This is needed for the JUCE library to play audio on Windows.
+    Create an environment variable called DXSDK_DIR and set the value to `C:\Program Files\Microsoft DirectX SDK (June 2010)\` (your path might be different). This environment variable will be used by CMake to find the binaries and header files.
 
 ### libSndFile
-   * http://www.mega-nerd.com/libsndfile/#Download
-   * Download and Install the Win32 Setup program.
-   * Create an environment variable called SNDFILE_DIR and set the value to `C:\Program Files\libsndfile`. This environment variable will be used by CMake to find the binary and header files.
+
+*   http://www.mega-nerd.com/libsndfile/#Download
+*   Download and Install the Win32 Setup program.
+*   Create an environment variable called SNDFILE_DIR and set the value to `C:\Program Files\libsndfile`. This environment variable will be used by CMake to find the binary and header files.
 
 ### libzmq
-   * http://zeromq.org/intro:get-the-software
-   * Download source code (zip)
-   * Follow their instructions, and build with mingw
-   * Create an environment variable called ZMQDIR and set the value to `C:\libzmq\build\` (the location of the compiled version). This environment variable will be used by CMake to find the binary and header files.
+
+*   http://zeromq.org/intro:get-the-software
+*   Download source code (zip)
+*   Follow their instructions, and build with mingw
+*   Create an environment variable called ZMQDIR and set the value to `C:\libzmq\build\` (the location of the compiled version). This environment variable will be used by CMake to find the binary and header files.
 
 ## Windows Build Instructions (libopenshot-audio)
+
 In order to compile libopenshot-audio, launch a command prompt and enter the following commands. This does not require the MSYS2 prompt, but it should work in both the Windows command prompt and the MSYS2 prompt.
 
-```
-cd [libopenshot-audio repo folder]
-mkdir build
-cd build
-cmake -G “MinGW Makefiles” ../
-mingw32-make
-mingw32-make install
-openshot-audio-test-sound  (This should play a test sound)
-```
+    cd [libopenshot-audio repo folder]
+    mkdir build
+    cd build
+    cmake -G “MinGW Makefiles” ../
+    mingw32-make
+    mingw32-make install
+    openshot-audio-test-sound  (This should play a test sound)
 
 ## Windows Build Instructions (libopenshot)
+
 Run the following commands to build libopenshot:
 
-```
-cd [libopenshot repo folder]
-mkdir build
-cd build
-cmake -G "MinGW Makefiles" -DPYTHON_INCLUDE_DIR="C:/Python34/include/" -DPYTHON_LIBRARY="C:/Python34/libs/libpython34.a" ../
-mingw32-make
-```
+    cd [libopenshot repo folder]
+    mkdir build
+    cd build
+    cmake -G "MinGW Makefiles" -DPYTHON_INCLUDE_DIR="C:/Python34/include/" -DPYTHON_LIBRARY="C:/Python34/libs/libpython34.a" ../
+    mingw32-make
 
-If you are missing any dependencies for libopenshot, you will receive error messages at this point. 
-Just install the missing dependencies, and run the above commands again. Repeat until no error 
+If you are missing any dependencies for libopenshot, you will receive error messages at this point.
+Just install the missing dependencies, and run the above commands again. Repeat until no error
 messages are displayed and the build process completes.
 
-Also, if you are having trouble building, please see the CMake Flags section above, as 
+Also, if you are having trouble building, please see the CMake Flags section above, as
 it might provide a solution for finding a missing folder path, missing Python 3 library, etc...
 
 To run all unit tests (and verify everything is working correctly), launch a terminal, and enter:
 
-```
-mingw32-make test
-```
+    mingw32-make test
 
 To auto-generate the documentation for libopenshot, launch a terminal, and enter:
 
-```
-mingw32-make doc
-```
+    mingw32-make doc
 
-This will use doxygen to generate a folder of HTML files, with all classes and methods 
-documented. The folder is located at build/doc/html/. Once libopenshot has been successfully 
+This will use doxygen to generate a folder of HTML files, with all classes and methods
+documented. The folder is located at build/doc/html/. Once libopenshot has been successfully
 built, we need to install it (i.e. copy it to the correct folder, so other libraries can find it).
 
-```
-mingw32-make install
-```
+    mingw32-make install
 
-This should copy the binary files to `C:\Program Files\openshot\lib\`, and the header 
-files to `C:\Program Files\openshot\include\...`  This is where other projects will 
-look for the libopenshot files when building.. Python 3 bindings are also installed 
+This should copy the binary files to `C:\Program Files\openshot\lib\`, and the header
+files to `C:\Program Files\openshot\include\...`  This is where other projects will
+look for the libopenshot files when building.. Python 3 bindings are also installed
 at this point. let's verify the python bindings work:
 
-```
-python3
->>> import openshot
-```
+    python3
+    >>> import openshot
 
-If no errors are displayed, you have successfully compiled and installed libopenshot on 
-your system. Congratulations and be sure to read our wiki on [Becoming an OpenShot Developer](https://github.com/OpenShot/openshot-qt/wiki/Become-a-Developer)! 
+If no errors are displayed, you have successfully compiled and installed libopenshot on
+your system. Congratulations and be sure to read our wiki on [Becoming an OpenShot Developer](https://github.com/OpenShot/openshot-qt/wiki/Become-a-Developer)!
 Welcome to the OpenShot developer community! We look forward to meeting you!


### PR DESCRIPTION
I got sick of Codacy complaining about the Markdown syntax, so I ran all of the `*.md` files through the `remark` formatter to ensure they're compliant.

Then I noticed how out of date `docs/INSTALL-LINUX.md` had gotten, so I at least partially updated it. It still doesn't mention OpenCV or Protobuf (though it does include them in the dependency install commands provided), but at least it covers Catch2/CTest now, and no longer mentions UnitTest++. 

CMake/apt/etc. command lines and some of the configurables mentioned have also been freshened up.
