### PR TITLE
Downgrade OpenCV 4.5.1 msg to WARNING

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -396,7 +396,7 @@ if(ENABLE_OPENCV)
       "Build with OpenCV algorithms (requires Protobuf 3)" FORCE)
     # If we have version 4.5.1, all hope is lost
   elseif(OpenCV_VERSION VERSION_EQUAL 4.5.1)
-    message(SEND_ERROR [[Incompatible OpenCV version detected
+    message(WARNING [[Incompatible OpenCV version detected
 OpenCV version 4.5.1 contains header errors which make it unable to be used with OpenShot. OpenCV support wil be disabled. Upgrade to OpenCV 4.5.2+ or downgrade to 4.5.0 or earlier, to enable OpenCV.
 See https://github.com/opencv/opencv/issues/19260]])
     set(ENABLE_OPENCV FALSE CACHE BOOL


### PR DESCRIPTION
I misread the CMake docs, and didn't realize that `SEND_ERROR` message severity would still register as a failed config at the end of the run. So, OpenCV 4.5.1 is still killing our Ubuntu Impish PPA builds.

Downgrade to `WARNING` to let them succeed.