### PR TITLE
CI,bionic: Work around broken libzmq5 dep

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
       run: |
         sudo add-apt-repository ppa:openshot.developers/libopenshot-daily
         sudo apt update
+        sudo apt remove libzmq5  # See actions/virtual-environments#3317
         sudo apt install \
           cmake swig doxygen graphviz curl lcov \
           libopenshot-audio-dev libasound2-dev \


### PR DESCRIPTION
Seems Github Actions broke their Ubuntu bionic build image recently, making the libzmq3-dev apt install fail. Adding a workaround. See actions/virtual-environments#3317.