### PR TITLE
Changed JSON communication for detected objects

### DIFF
--- a/src/CVObjectDetection.cpp
+++ b/src/CVObjectDetection.cpp
@@ -81,8 +81,8 @@ void CVObjectDetection::detectObjectsClip(openshot::Clip &video, size_t _start, 
     size_t frame_number;
     if(!process_interval || end <= 1 || end-start == 0){
         // Get total number of frames in video
-        start = (int)(video.Start() * video.Reader()->info.fps.ToFloat()) + 1;
-        end = (int)(video.End() * video.Reader()->info.fps.ToFloat()) + 1;
+        start = (int)(video.Start() * video.Reader()->info.fps.ToFloat());
+        end = (int)(video.End() * video.Reader()->info.fps.ToFloat());
     }
 
     for (frame_number = start; frame_number <= end; frame_number++)

--- a/src/TrackedObjectBBox.cpp
+++ b/src/TrackedObjectBBox.cpp
@@ -382,25 +382,19 @@ void TrackedObjectBBox::SetJsonValue(const Json::Value root)
 		if (!root["BaseFPS"]["den"].isNull())
 			BaseFps.den = (int)root["BaseFPS"]["den"].asInt();
 	}
-
 	// Set the TimeScale by the given JSON object
 	if (!root["TimeScale"].isNull())
 	{
 		double scale = (double)root["TimeScale"].asDouble();
 		this->ScalePoints(scale);
 	}
-
 	// Set the protobuf data path by the given JSON object
 	if (!root["protobuf_data_path"].isNull())
 		protobufDataPath = root["protobuf_data_path"].asString();
-
 	// Set the id of the child clip
 	if (!root["child_clip_id"].isNull() && root["child_clip_id"].asString() != ""){
 		Clip* parentClip = (Clip *) ParentClip();
-
-		if(parentClip && (root["child_clip_id"].asString() != parentClip->Id())){
-			ChildClipId(root["child_clip_id"].asString());
-		}
+		ChildClipId(root["child_clip_id"].asString());
 	}
 	
 	// Set the Keyframes by the given JSON object

--- a/src/effects/ObjectDetection.cpp
+++ b/src/effects/ObjectDetection.cpp
@@ -498,7 +498,7 @@ void ObjectDetection::SetJsonValue(const Json::Value root) {
         protobuf_data_path = root["protobuf_data_path"].asString();
 
         if(!LoadObjDetectdData(protobuf_data_path)){
-            throw InvalidFile("Invalid protobuf data path");
+            throw InvalidFile("Invalid protobuf data path", "");
             protobuf_data_path = "";
         }
     }

--- a/src/effects/ObjectDetection.cpp
+++ b/src/effects/ObjectDetection.cpp
@@ -369,6 +369,9 @@ bool ObjectDetection::LoadObjDetectdData(std::string inputFilePath){
                 ClipBase* parentClip = this->ParentClip();
 	            trackedObjPtr->ParentClip(parentClip);
                 
+                // Create a temp ID. This ID is necessary to initialize the object_id Json list
+                // this Id will be replaced by the one created in the UI
+                trackedObjPtr->Id(std::to_string(objectId));
                 trackedObjects.insert({objectId, trackedObjPtr});
             }
 
@@ -456,11 +459,13 @@ Json::Value ObjectDetection::JsonValue() const {
     root["display_box_text"] = display_box_text.JsonValue();
 
     // Add tracked object's IDs to root
-    root["objects_id"] = Json::Value(Json::arrayValue);
+    Json::Value objects;
     for (auto const& trackedObject : trackedObjects){
         Json::Value trackedObjectJSON = trackedObject.second->JsonValue();
-        root["objects_id"].append(trackedObject.second->Id());
+        // add object json 
+        objects[trackedObject.second->Id()] = trackedObjectJSON;
     }
+    root["objects"] = objects;
 
     // Add the selected object Json to root
     if(trackedObjects.count(selectedObjectIndex) != 0){
@@ -482,7 +487,6 @@ void ObjectDetection::SetJson(const std::string value) {
     // Parse JSON string into JSON objects
     try
     {
-        std::cout<<"entrou no objectDetection SetJson \n"<<value<<"\n\n";
         const Json::Value root = openshot::stringToJson(value);
         // Set all values that match
         SetJsonValue(root);
@@ -490,14 +494,12 @@ void ObjectDetection::SetJson(const std::string value) {
     catch (const std::exception& e)
     {
         // Error parsing JSON (or missing keys)
-        std::cout<< "\n\n"<<e.what()<<"\n\n";
         throw InvalidJSON("JSON is invalid (missing keys or invalid data types)");
     }
 }
 
 // Load Json::Value into this object
 void ObjectDetection::SetJsonValue(const Json::Value root) {
-    std::cout<<"entrou no objectDetection SetJasonValue \n"<<root<<"\n\n";
     // Set parent data
     EffectBase::SetJsonValue(root);
 
@@ -506,7 +508,7 @@ void ObjectDetection::SetJsonValue(const Json::Value root) {
         protobuf_data_path = root["protobuf_data_path"].asString();
 
         if(!LoadObjDetectdData(protobuf_data_path)){
-            std::cout<<"Invalid protobuf data path";
+            throw InvalidFile("Invalid protobuf data path");
             protobuf_data_path = "";
         }
     }
@@ -534,6 +536,15 @@ void ObjectDetection::SetJsonValue(const Json::Value root) {
         }
     }
 
+    if (!root["objects"].isNull()){
+        for (auto const& trackedObject : trackedObjects){
+            std::string obj_id = std::to_string(trackedObject.first);
+            if(!root["objects"][obj_id].isNull()){
+                trackedObject.second->SetJsonValue(root["objects"][obj_id]);
+            }
+        }
+    }
+
     // Set the tracked object's ids
     if (!root["objects_id"].isNull()){
         for (auto const& trackedObject : trackedObjects){
@@ -541,13 +552,6 @@ void ObjectDetection::SetJsonValue(const Json::Value root) {
             trackedObjectJSON["box_id"] = root["objects_id"][trackedObject.first].asString();
             trackedObject.second->SetJsonValue(trackedObjectJSON);
         }
-    }
-
-    // Set the selected object's properties
-    if(trackedObjects.count(selectedObjectIndex) != 0){
-        auto selectedObject = trackedObjects.at(selectedObjectIndex);
-        if (selectedObject)
-            selectedObject->SetJsonValue(root);
     }
 }
 
@@ -557,12 +561,16 @@ std::string ObjectDetection::PropertiesJSON(int64_t requested_frame) const {
     // Generate JSON properties list
     Json::Value root;
 
-    // Add the selected object Json to root
+    Json::Value objects;
     if(trackedObjects.count(selectedObjectIndex) != 0){
         auto selectedObject = trackedObjects.at(selectedObjectIndex);
-        if (selectedObject)
-            root = selectedObject->PropertiesJSON(requested_frame);
+        if (selectedObject){
+            Json::Value trackedObjectJSON = selectedObject->PropertiesJSON(requested_frame);
+            // add object json 
+            objects[selectedObject->Id()] = trackedObjectJSON;
+        }
     }
+    root["objects"] = objects;
 
     root["selected_object_index"] = add_property_json("Selected Object", selectedObjectIndex, "int", "", NULL, 0, 200, false, requested_frame);
     root["id"] = add_property_json("ID", 0.0, "string", Id(), NULL, -1, -1, true, requested_frame);

--- a/src/effects/ObjectDetection.cpp
+++ b/src/effects/ObjectDetection.cpp
@@ -467,16 +467,6 @@ Json::Value ObjectDetection::JsonValue() const {
     }
     root["objects"] = objects;
 
-    // Add the selected object Json to root
-    if(trackedObjects.count(selectedObjectIndex) != 0){
-        auto selectedObject = trackedObjects.at(selectedObjectIndex);
-        if (selectedObject){
-            Json::Value selectedObjectJSON = selectedObject->JsonValue();
-            for (auto const& key : selectedObjectJSON.getMemberNames())
-                root[key] = selectedObjectJSON[key];
-        }
-    }
-
     // return JsonValue
     return root;
 }


### PR DESCRIPTION
Changed JSON communication for detected objects

- The OBjectDetection and Tracker effects have a key "objects" in the Json that contains a dictionary of TrackedObjectBBox indexed by the object ID
- self.data now keep track of all changes in detected objects

Example of the JSON for ObjectDetection:
```
{ // effect parameters
        "id": 7QCETIYKEJ
        "selected_object_index": "2"
        "confidence_threshold": "0.5"
        "class_filter": "truck"
        "objects":{
                //these are the detected objects dicts
                "9FDETJYKEJ":{
                        "box_id" : "9FDETJYKEJ"
                        "x1": "50"
                        "y1": "50"
                        "x2": "100"
                        "y2": "100"
                        "delta_x": {...}
                        ...
                }
                "56BR38F17U":{
                        "box_id" : "56BR38F17U"
                        "x1": "50"
                        "y1": "50"
                        "x2": "100"
                        "y2": "100"
                        "delta_x": {...}
                        ...
                }
        }
}
```