### PR TITLE
WIP: Fix Mask/Transitions for Global Timeline Effects

### DIFF
--- a/src/Clip.cpp
+++ b/src/Clip.cpp
@@ -394,9 +394,9 @@ std::shared_ptr<Frame> Clip::GetFrame(std::shared_ptr<openshot::Frame> backgroun
         // Apply global timeline effects (i.e. transitions & masks... if any)
         if (timeline != NULL && options != NULL) {
             if (options->is_top_clip) {
-                // Apply global timeline effects (only to top clip... if overlapping)
+                // Apply global timeline effects (only to top clip... if overlapping, pass in timeline frame number)
                 Timeline* timeline_instance = (Timeline*) timeline;
-                original_frame = timeline_instance->apply_effects(original_frame, options->timeline_frame_number, Layer());
+                original_frame = timeline_instance->apply_effects(original_frame, background_frame->number, Layer());
             }
         }
 

--- a/src/Clip.h
+++ b/src/Clip.h
@@ -214,24 +214,39 @@ namespace openshot {
 		/// Look up an effect by ID
 		openshot::EffectBase* GetEffect(const std::string& id);
 
-		/// @brief Get an openshot::Frame object for a specific frame number of this timeline. The image size and number
+		/// @brief Get an openshot::Frame object for a specific frame number of this clip. The image size and number
 		/// of samples match the source reader.
 		///
 		/// @returns A new openshot::Frame object
-		/// @param frame_number The frame number (starting at 1) of the clip or effect on the timeline.
+		/// @param frame_number The frame number (starting at 1) of the clip
 		std::shared_ptr<openshot::Frame> GetFrame(int64_t frame_number) override;
 
-		/// @brief Get an openshot::Frame object for a specific frame number of this timeline. The image size and number
-		/// of samples can be customized to match the Timeline, or any custom output. Extra samples will be moved to the
-		/// next Frame. Missing samples will be moved from the next Frame.
+		/// @brief Get an openshot::Frame object for a specific frame number of this clip. The image size and number
+        /// of samples match the background_frame passed in and the timeline (if available).
 		///
 		/// A new openshot::Frame objects is returned, based on a copy from the source image, with all keyframes and clip effects
-		/// rendered.
+		/// rendered/rasterized.
 		///
 		/// @returns The modified openshot::Frame object
 		/// @param background_frame The frame object to use as a background canvas (i.e. an existing Timeline openshot::Frame instance)
-		/// @param frame_number The frame number (starting at 1) of the clip or effect on the timeline.
+		/// @param frame_number The frame number (starting at 1) of the clip. The image size and number
+        /// of samples match the background_frame passed in and the timeline (if available)
 		std::shared_ptr<openshot::Frame> GetFrame(std::shared_ptr<openshot::Frame> background_frame, int64_t frame_number);
+
+        /// @brief Get an openshot::Frame object for a specific frame number of this clip. The image size and number
+        /// of samples match the background_frame passed in and the timeline (if available).
+        ///
+        /// A new openshot::Frame objects is returned, based on a copy from the source image, with all keyframes and clip effects
+        /// rendered/rasterized.
+        ///
+        /// @returns The modified openshot::Frame object
+        /// @param background_frame The frame object to use as a background canvas (i.e. an existing Timeline openshot::Frame instance)
+        /// @param frame_number The frame number (starting at 1) of the clip on the timeline. The image size and number
+        /// of samples match the timeline.
+        /// @param options The openshot::TimelineInfoStruct pointer, with more details about this specific timeline clip,
+        /// such as, if it's a top clip, and what the absolute timeline frame number is. This info is used to apply global
+        /// transitions and masks, if needed.
+        std::shared_ptr<openshot::Frame> GetFrame(std::shared_ptr<openshot::Frame> background_frame, int64_t frame_number, openshot::TimelineInfoStruct* options);
 
 		/// Open the internal reader
 		void Open() override;

--- a/src/Clip.h
+++ b/src/Clip.h
@@ -164,7 +164,6 @@ namespace openshot {
 		void reverse_buffer(juce::AudioSampleBuffer* buffer);
 
 
-
 	public:
 		openshot::GravityType gravity;   ///< The gravity of a clip determines where it snaps to its parent
 		openshot::ScaleType scale;		 ///< The scale determines how a clip should be resized to fit its parent
@@ -244,8 +243,7 @@ namespace openshot {
         /// @param frame_number The frame number (starting at 1) of the clip on the timeline. The image size and number
         /// of samples match the timeline.
         /// @param options The openshot::TimelineInfoStruct pointer, with more details about this specific timeline clip,
-        /// such as, if it's a top clip, and what the absolute timeline frame number is. This info is used to apply global
-        /// transitions and masks, if needed.
+        /// such as, if it's a top clip. This info is used to apply global transitions and masks, if needed.
         std::shared_ptr<openshot::Frame> GetFrame(std::shared_ptr<openshot::Frame> background_frame, int64_t frame_number, openshot::TimelineInfoStruct* options);
 
 		/// Open the internal reader

--- a/src/Timeline.cpp
+++ b/src/Timeline.cpp
@@ -475,11 +475,10 @@ std::shared_ptr<Frame> Timeline::GetOrCreateFrame(std::shared_ptr<Frame> backgro
 }
 
 // Process a new layer of video or audio
-void Timeline::add_layer(std::shared_ptr<Frame> new_frame, Clip* source_clip, int64_t clip_frame_number, int64_t timeline_frame_number, bool is_top_clip, float max_volume)
+void Timeline::add_layer(std::shared_ptr<Frame> new_frame, Clip* source_clip, int64_t clip_frame_number, bool is_top_clip, float max_volume)
 {
     // Create timeline options (with details about this current frame request)
     TimelineInfoStruct* options = new TimelineInfoStruct();
-    options->timeline_frame_number = timeline_frame_number;
     options->is_top_clip = is_top_clip;
 
     // Get the clip's frame, composited on top of the current timeline frame
@@ -492,12 +491,12 @@ void Timeline::add_layer(std::shared_ptr<Frame> new_frame, Clip* source_clip, in
 		return;
 
 	// Debug output
-	ZmqLogger::Instance()->AppendDebugMethod("Timeline::add_layer", "new_frame->number", new_frame->number, "clip_frame_number", clip_frame_number, "timeline_frame_number", timeline_frame_number);
+	ZmqLogger::Instance()->AppendDebugMethod("Timeline::add_layer", "new_frame->number", new_frame->number, "clip_frame_number", clip_frame_number);
 
 	/* COPY AUDIO - with correct volume */
 	if (source_clip->Reader()->info.has_audio) {
 		// Debug output
-		ZmqLogger::Instance()->AppendDebugMethod("Timeline::add_layer (Copy Audio)", "source_clip->Reader()->info.has_audio", source_clip->Reader()->info.has_audio, "source_frame->GetAudioChannelsCount()", source_frame->GetAudioChannelsCount(), "info.channels", info.channels, "clip_frame_number", clip_frame_number, "timeline_frame_number", timeline_frame_number);
+		ZmqLogger::Instance()->AppendDebugMethod("Timeline::add_layer (Copy Audio)", "source_clip->Reader()->info.has_audio", source_clip->Reader()->info.has_audio, "source_frame->GetAudioChannelsCount()", source_frame->GetAudioChannelsCount(), "info.channels", info.channels, "clip_frame_number", clip_frame_number);
 
 		if (source_frame->GetAudioChannelsCount() == info.channels && source_clip->has_audio.GetInt(clip_frame_number) != 0)
 			for (int channel = 0; channel < source_frame->GetAudioChannelsCount(); channel++)
@@ -550,7 +549,7 @@ void Timeline::add_layer(std::shared_ptr<Frame> new_frame, Clip* source_clip, in
 			}
 		else
 			// Debug output
-			ZmqLogger::Instance()->AppendDebugMethod("Timeline::add_layer (No Audio Copied - Wrong # of Channels)", "source_clip->Reader()->info.has_audio", source_clip->Reader()->info.has_audio, "source_frame->GetAudioChannelsCount()", source_frame->GetAudioChannelsCount(), "info.channels", info.channels, "clip_frame_number", clip_frame_number, "timeline_frame_number", timeline_frame_number);
+			ZmqLogger::Instance()->AppendDebugMethod("Timeline::add_layer (No Audio Copied - Wrong # of Channels)", "source_clip->Reader()->info.has_audio", source_clip->Reader()->info.has_audio, "source_frame->GetAudioChannelsCount()", source_frame->GetAudioChannelsCount(), "info.channels", info.channels, "clip_frame_number", clip_frame_number);
 	}
 
 	// Debug output
@@ -753,7 +752,7 @@ std::shared_ptr<Frame> Timeline::GetFrame(int64_t requested_frame)
                 ZmqLogger::Instance()->AppendDebugMethod("Timeline::GetFrame (Calculate clip's frame #)", "clip->Position()", clip->Position(), "clip->Start()", clip->Start(), "info.fps.ToFloat()", info.fps.ToFloat(), "clip_frame_number", clip_frame_number);
 
                 // Add clip's frame as layer
-                add_layer(new_frame, clip, clip_frame_number, requested_frame, is_top_clip, max_volume);
+                add_layer(new_frame, clip, clip_frame_number, is_top_clip, max_volume);
 
             } else {
                 // Debug output

--- a/src/Timeline.h
+++ b/src/Timeline.h
@@ -198,10 +198,7 @@ namespace openshot {
 		std::vector<openshot::Clip*> find_intersecting_clips(int64_t requested_frame, int number_of_frames, bool include);
 
 		/// Get a clip's frame or generate a blank frame
-		std::shared_ptr<openshot::Frame> GetOrCreateFrame(std::shared_ptr<Frame> background_frame, openshot::Clip* clip, int64_t number);
-
-		/// Apply effects to the source frame (if any)
-		std::shared_ptr<openshot::Frame> apply_effects(std::shared_ptr<openshot::Frame> frame, int64_t timeline_frame_number, int layer);
+		std::shared_ptr<openshot::Frame> GetOrCreateFrame(std::shared_ptr<Frame> background_frame, openshot::Clip* clip, int64_t number, openshot::TimelineInfoStruct* options);
 
 		/// Compare 2 floating point numbers for equality
 		bool isEqual(double a, double b);
@@ -248,6 +245,9 @@ namespace openshot {
 		/// @brief Add an effect to the timeline
 		/// @param effect Add an effect to the timeline. An effect can modify the audio or video of an openshot::Frame.
 		void AddEffect(openshot::EffectBase* effect);
+
+        /// Apply global/timeline effects to the source frame (if any)
+        std::shared_ptr<openshot::Frame> apply_effects(std::shared_ptr<openshot::Frame> frame, int64_t timeline_frame_number, int layer);
 
 		/// Apply the timeline's framerate and samplerate to all clips
 		void ApplyMapperToClips();

--- a/src/Timeline.h
+++ b/src/Timeline.h
@@ -175,7 +175,7 @@ namespace openshot {
 		int max_concurrent_frames; ///< Max concurrent frames to process at one time
 
 		/// Process a new layer of video or audio
-		void add_layer(std::shared_ptr<openshot::Frame> new_frame, openshot::Clip* source_clip, int64_t clip_frame_number, int64_t timeline_frame_number, bool is_top_clip, float max_volume);
+		void add_layer(std::shared_ptr<openshot::Frame> new_frame, openshot::Clip* source_clip, int64_t clip_frame_number, bool is_top_clip, float max_volume);
 
 		/// Apply a FrameMapper to a clip which matches the settings of this timeline
 		void apply_mapper_to_clip(openshot::Clip* clip);

--- a/src/TimelineBase.h
+++ b/src/TimelineBase.h
@@ -39,14 +39,12 @@ namespace openshot {
      * @brief This struct contains info about the current Timeline clip instance
      *
      * When the Timeline requests an openshot::Frame instance from a Clip, it passes
-     * this struct along, with some additional details from the Timeline, such as the absolute
-     * timeline frame number requested, and if this clip is above or below overlapping clips, etc...
-     * This info can help determine if a Clip should apply global effects from the Timeline, such
-     * as a global Transition/Mask effect.
+     * this struct along, with some additional details from the Timeline, such as if this clip is
+     * above or below overlapping clips, etc... This info can help determine if a Clip should apply
+     * global effects from the Timeline, such as a global Transition/Mask effect.
      */
     struct TimelineInfoStruct
     {
-        int64_t timeline_frame_number;    ///< The absolute frame number from the timeline we are requesting
         bool is_top_clip;                 ///< Is clip on top (if overlapping another clip)
     };
 

--- a/src/TimelineBase.h
+++ b/src/TimelineBase.h
@@ -31,8 +31,25 @@
 #ifndef OPENSHOT_TIMELINE_BASE_H
 #define OPENSHOT_TIMELINE_BASE_H
 
+#include <cstdint>
+
 
 namespace openshot {
+    /**
+     * @brief This struct contains info about the current Timeline clip instance
+     *
+     * When the Timeline requests an openshot::Frame instance from a Clip, it passes
+     * this struct along, with some additional details from the Timeline, such as the absolute
+     * timeline frame number requested, and if this clip is above or below overlapping clips, etc...
+     * This info can help determine if a Clip should apply global effects from the Timeline, such
+     * as a global Transition/Mask effect.
+     */
+    struct TimelineInfoStruct
+    {
+        int64_t timeline_frame_number;    ///< The absolute frame number from the timeline we are requesting
+        bool is_top_clip;                 ///< Is clip on top (if overlapping another clip)
+    };
+
 	/**
 	 * @brief This class represents a timeline (used for building generic timeline implementations)
 	 */


### PR DESCRIPTION
Refactor of global timeline effects, to address a regression with global/timeline Mask/Transitions no longer working correctly. This was caused by an optimization that broke the general behavior of the global transitions.