### PR TITLE
Fix inheritance of TimelineBase::Clips(), and add unit test

### DIFF
--- a/src/Timeline.cpp
+++ b/src/Timeline.cpp
@@ -88,9 +88,9 @@ Timeline::Timeline(int width, int height, Fraction fps, int sample_rate, int cha
 }
 
 // Delegating constructor that copies parameters from a provided ReaderInfo
-Timeline::Timeline(const ReaderInfo info) :
-	Timeline::Timeline(info.width, info.height, info.fps, info.sample_rate,
-	                   info.channels, info.channel_layout) {};
+Timeline::Timeline(const ReaderInfo info) : Timeline::Timeline(
+	info.width, info.height, info.fps, info.sample_rate,
+	info.channels, info.channel_layout) {}
 
 // Constructor for the timeline (which loads a JSON structure from a file path, and initializes a timeline)
 Timeline::Timeline(const std::string& projectPath, bool convert_absolute_paths) :
@@ -243,7 +243,7 @@ Timeline::~Timeline() {
 	}
 }
 
-// Add to the tracked_objects map a pointer to a tracked object (TrackedObjectBBox) 
+// Add to the tracked_objects map a pointer to a tracked object (TrackedObjectBBox)
 void Timeline::AddTrackedObject(std::shared_ptr<openshot::TrackedObjectBase> trackedObject){
 
 	// Search for the tracked object on the map
@@ -252,7 +252,7 @@ void Timeline::AddTrackedObject(std::shared_ptr<openshot::TrackedObjectBase> tra
 	if (iterator != tracked_objects.end()){
 		// Tracked object's id already present on the map, overwrite it
 		iterator->second = trackedObject;
-	} 
+	}
 	else{
 		// Tracked object's id not present -> insert it on the map
 		tracked_objects[trackedObject->Id()] = trackedObject;
@@ -275,7 +275,7 @@ std::shared_ptr<openshot::TrackedObjectBase> Timeline::GetTrackedObject(std::str
 	else {
 		// Id not found, return a null pointer
 		return nullptr;
-	}	
+	}
 }
 
 // Return the ID's of the tracked objects as a list of strings
@@ -322,7 +322,7 @@ std::string Timeline::GetTrackedObjectValues(std::string id, int64_t frame_numbe
 			trackedObjectJson["x2"] = x2;
 			trackedObjectJson["y2"] = y2;
 			trackedObjectJson["rotation"] = rotation;
-		
+
 		} else {
 			BBox box = trackedObject->BoxVec.begin()->second;
 			float x1 = box.cx - (box.width/2);
@@ -346,7 +346,7 @@ std::string Timeline::GetTrackedObjectValues(std::string id, int64_t frame_numbe
 		trackedObjectJson["x2"] = 0;
 		trackedObjectJson["y2"] = 0;
 		trackedObjectJson["rotation"] = 0;
-	}	
+	}
 
 	return trackedObjectJson.toStyledString();
 }
@@ -444,7 +444,7 @@ std::list<openshot::EffectBase*> Timeline::ClipEffects() const {
 
 	// Loop through all clips
 	for (const auto& clip : clips) {
-		
+
 		// Get the clip's list of effects
 		std::list<EffectBase*> clipEffectsList = clip->Effects();
 
@@ -1063,7 +1063,7 @@ void Timeline::SetJsonValue(const Json::Value root) {
 			// When a clip is attached to an object, it searches for the object
 			// on it's parent timeline. Setting the parent timeline of the clip here
 			// allows attaching it to an object when exporting the project (because)
-			// the exporter script initializes the clip and it's effects 
+			// the exporter script initializes the clip and it's effects
 			// before setting it's parent timeline.
 			c->ParentTimeline(this);
 

--- a/src/Timeline.h
+++ b/src/Timeline.h
@@ -181,7 +181,7 @@ namespace openshot {
 		int max_concurrent_frames; ///< Max concurrent frames to process at one time
 
 		std::map<std::string, std::shared_ptr<openshot::TrackedObjectBase>> tracked_objects; ///< map of TrackedObjectBBoxes and their IDs
-		
+
 		/// Process a new layer of video or audio
 		void add_layer(std::shared_ptr<openshot::Frame> new_frame, openshot::Clip* source_clip, int64_t clip_frame_number, bool is_top_clip, float max_volume);
 
@@ -246,7 +246,7 @@ namespace openshot {
 
         virtual ~Timeline();
 
-		/// Add to the tracked_objects map a pointer to a tracked object (TrackedObjectBBox) 
+		/// Add to the tracked_objects map a pointer to a tracked object (TrackedObjectBBox)
 		void AddTrackedObject(std::shared_ptr<openshot::TrackedObjectBase> trackedObject);
 		/// Return tracked object pointer by it's id
 		std::shared_ptr<openshot::TrackedObjectBase> GetTrackedObject(std::string id) const;
@@ -281,7 +281,7 @@ namespace openshot {
         void ClearAllCache();
 
 		/// Return a list of clips on the timeline
-		std::list<openshot::Clip*> Clips() { return clips; };
+		std::list<openshot::Clip*> Clips() override { return clips; };
 
 		/// Look up a single clip by ID
 		openshot::Clip* GetClip(const std::string& id);

--- a/src/TimelineBase.cpp
+++ b/src/TimelineBase.cpp
@@ -34,16 +34,6 @@ using namespace openshot;
 
 /// Constructor for the base timeline
 TimelineBase::TimelineBase()
-{
-	// Init preview size (default)
-	preview_width = 1920;
-	preview_height = 1080;
-}
+    : preview_width(1920),
+      preview_height(1080) { }
 
-/* This function will be overloaded in the Timeline class passing no arguments
-* so we'll be able to access the Timeline::Clips() function from a pointer object of
-* the TimelineBase class
-*/
-void TimelineBase::Clips(int test){
-	return;
-}

--- a/src/TimelineBase.h
+++ b/src/TimelineBase.h
@@ -32,9 +32,13 @@
 #define OPENSHOT_TIMELINE_BASE_H
 
 #include <cstdint>
+#include <list>
 
 
 namespace openshot {
+    // Forward decl
+    class Clip;
+
     /**
      * @brief This struct contains info about the current Timeline clip instance
      *
@@ -63,7 +67,7 @@ namespace openshot {
 		/// This function will be overloaded in the Timeline class passing no arguments
 		/// so we'll be able to access the Timeline::Clips() function from a pointer object of
 		/// the TimelineBase class
-		virtual void Clips(int test);
+		virtual std::list<openshot::Clip*> Clips() = 0;
 	};
 }
 

--- a/tests/Timeline.cpp
+++ b/tests/Timeline.cpp
@@ -271,6 +271,33 @@ TEST_CASE( "Clip order", "[libopenshot][timeline]" )
 	t.Close();
 }
 
+TEST_CASE( "TimelineBase", "[libopenshot][timeline]" )
+{
+    // Create a timeline
+    Timeline t(640, 480, Fraction(30, 1), 44100, 2, LAYOUT_STEREO);
+
+    // Add some clips out of order
+    std::stringstream path;
+    path << TEST_MEDIA_PATH << "front3.png";
+    Clip clip1(path.str());
+    clip1.Layer(1);
+    t.AddClip(&clip1);
+
+    Clip clip2(path.str());
+    clip2.Layer(0);
+    t.AddClip(&clip2);
+
+    // Verify that the list of clips can be accessed
+    // through the Clips() method of a TimelineBase*
+    TimelineBase* base = &t;
+    auto l = base->Clips();
+    CHECK(l.size() == 2);
+    auto find1 = std::find(l.begin(), l.end(), &clip1);
+    auto find2 = std::find(l.begin(), l.end(), &clip2);
+    CHECK(find1 != l.end());
+    CHECK(find2 != l.end());
+}
+
 
 TEST_CASE( "Effect order", "[libopenshot][timeline]" )
 {


### PR DESCRIPTION
The code in TimelineBase / Timeline to implement the `Clips()` method was... weird, and didn't really do anything like what it was claimed to be doing. So I fixed it, and added a unit test to verify that the required functionality (accessing `Timeline::Clips()` through a `TimelineBase*`) works as expected.