### PR TITLE
Revert final_cache size breakage to unbreak OpenShot caching

### DIFF
--- a/src/Timeline.cpp
+++ b/src/Timeline.cpp
@@ -80,11 +80,12 @@ Timeline::Timeline(int width, int height, Fraction fps, int sample_rate, int cha
 	info.acodec = "openshot::timeline";
 	info.vcodec = "openshot::timeline";
 
-    // Init cache
-    final_cache = new CacheMemory();
-
 	// Init max image size
 	SetMaxSize(info.width, info.height);
+
+	// Init cache
+	final_cache = new CacheMemory();
+	final_cache->SetMaxBytesFromInfo(max_concurrent_frames * 4, info.width, info.height, info.sample_rate, info.channels);
 }
 
 // Delegating constructor that copies parameters from a provided ReaderInfo
@@ -95,7 +96,7 @@ Timeline::Timeline(const ReaderInfo info) :
 // Constructor for the timeline (which loads a JSON structure from a file path, and initializes a timeline)
 Timeline::Timeline(const std::string& projectPath, bool convert_absolute_paths) :
 		is_open(false), auto_map_clips(true), managed_cache(true), path(projectPath),
-        max_concurrent_frames(OPEN_MP_NUM_PROCESSORS) {
+		max_concurrent_frames(OPEN_MP_NUM_PROCESSORS) {
 
 	// Create CrashHandler and Attach (incase of errors)
 	CrashHandler::Instance();
@@ -212,11 +213,12 @@ Timeline::Timeline(const std::string& projectPath, bool convert_absolute_paths) 
 	info.has_video = true;
 	info.has_audio = true;
 
-    // Init cache
-    final_cache = new CacheMemory();
-
 	// Init max image size
 	SetMaxSize(info.width, info.height);
+
+	// Init cache
+	final_cache = new CacheMemory();
+	final_cache->SetMaxBytesFromInfo(max_concurrent_frames * 4, info.width, info.height, info.sample_rate, info.channels);
 }
 
 Timeline::~Timeline() {
@@ -1064,7 +1066,7 @@ void Timeline::SetJsonValue(const Json::Value root) {
 			// on it's parent timeline. Setting the parent timeline of the clip here
 			// allows attaching it to an object when exporting the project (because)
 			// the exporter script initializes the clip and it's effects 
-			// before setting it's parent timeline.
+			// before setting its parent timeline.
 			c->ParentTimeline(this);
 
 			// Load Json into Clip
@@ -1530,7 +1532,4 @@ void Timeline::SetMaxSize(int width, int height) {
 	// Update preview settings
 	preview_width = display_ratio_size.width();
 	preview_height = display_ratio_size.height();
-
-	// Update timeline cache size
-    final_cache->SetMaxBytesFromInfo(max_concurrent_frames * 4, preview_width, preview_height, info.sample_rate, info.channels);
 }


### PR DESCRIPTION
Reverting the "Adjusting Timeline final_cache to match the video caching thread max_frames, so one doesn't clobber the other." part of a previous commit.

Adjusting the cache size in `SetMaxSize()` ignores OpenShot's cache preferences. This prevents using a cache larger than the preview buffer, which is often a desirable thing. The initial size set for `final_cache` on initialization is merely a starting point, meant to be overridden by OpenShot based on preferences.

This partially reverts commit 0c4e1bcce4d8cbdc1edc752fe3339acf94ac8eb1.

My OpenShot PR OpenShot/openshot-qt#4075 (which I will now close) was based on confusion created by the fallout from this change. (I thought the Timeline cache was removed along with the Clip cache, since it appeared to be non-persistent due to the tiny cache forced by `SetMaxSize()`!)