### PR TITLE
CMake: USE_SWIG_DEPENDENCIES for CMake 3.20+

### DIFF
--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -95,6 +95,12 @@ if (DEFINED _inc)
   set_property(SOURCE openshot.i PROPERTY INCLUDE_DIRECTORIES ${_inc})
 endif()
 
+### (FINALLY!)
+### Properly manage dependencies (regenerate bindings after changes)
+if (CMAKE_VERSION VERSION_GREATER 3.20)
+  set_property(SOURCE openshot.i PROPERTY USE_SWIG_DEPENDENCIES TRUE)
+endif()
+
 ### Add the SWIG interface file (which defines all the SWIG methods)
 if (CMAKE_VERSION VERSION_LESS 3.8.0)
   swig_add_module(pyopenshot python openshot.i)

--- a/bindings/ruby/CMakeLists.txt
+++ b/bindings/ruby/CMakeLists.txt
@@ -111,6 +111,12 @@ if (DEFINED _inc)
   set_property(SOURCE openshot.i PROPERTY INCLUDE_DIRECTORIES ${_inc})
 endif()
 
+### (FINALLY!)
+### Properly manage dependencies (regenerate bindings after changes)
+if (CMAKE_VERSION VERSION_GREATER 3.20)
+  set_property(SOURCE openshot.i PROPERTY USE_SWIG_DEPENDENCIES TRUE)
+endif()
+
 ### Add the SWIG interface file (which defines all the SWIG methods)
 if (CMAKE_VERSION VERSION_LESS 3.8.0)
 	swig_add_module(rbopenshot ruby openshot.i)


### PR DESCRIPTION
**(F---ING _FINALLY!!!_)**

Mostly a developer convenience, when building using the newest CMake 3.20 or later, the SWIG targets will be configured with `USE_SWIG_DEPENDENCIES` set to `TRUE`, which causes the target to automatically set up dependencies on all of the files referenced by the SWIG bindings.

Which means, when you make changes to `Frame.h` or `Clip.h` or whatever, the bindings will be automatically regenerated, and you no longer have to `rm -r build/bindings` in order to force a re-sync with the header files.
