### PR TITLE
FFmpeg: Move av/swresample decision into CMake

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -288,13 +288,16 @@ mark_as_advanced(QT_VERSION_STR)
 
 ################### FFMPEG #####################
 # Find FFmpeg libraries (used for video encoding / decoding)
-find_package(FFmpeg REQUIRED COMPONENTS avcodec avformat avutil swscale)
+find_package(FFmpeg REQUIRED
+  COMPONENTS avcodec avformat avutil swscale
+  OPTIONAL_COMPONENTS swresample avresample
+)
 
 set(all_comps avcodec avformat avutil swscale)
 set(version_comps avcodec avformat avutil)
 
 # Pick a resampler.  Prefer swresample if possible
-if(TARGET FFmpeg::swresample AND ${avformat_VERSION} VERSION_GREATER "57.0.0")
+if(TARGET FFmpeg::swresample AND ${FFmpeg_avformat_VERSION} VERSION_GREATER "57.0.0")
   set(resample_lib swresample)
   set(USE_SW TRUE)
 else()
@@ -307,9 +310,9 @@ foreach(ff_comp IN LISTS all_comps)
   if(TARGET FFmpeg::${ff_comp})
     target_link_libraries(openshot PUBLIC FFmpeg::${ff_comp})
     # Keep track of some FFmpeg lib versions, to embed in our version header
-    if(${ff_comp} IN_LIST version_comps AND ${ff_comp}_VERSION)
+    if(${ff_comp} IN_LIST version_comps AND FFmpeg_${ff_comp}_VERSION)
       string(TOUPPER ${ff_comp} v_name)
-      set(${v_name}_VERSION_STR ${${ff_comp}_VERSION} CACHE STRING "${ff_comp} version used" FORCE)
+      set(${v_name}_VERSION_STR ${FFmpeg_${ff_comp}_VERSION} CACHE STRING "${ff_comp} version used" FORCE)
       mark_as_advanced(${v_name}_VERSION_STR)
     endif()
   endif()
@@ -322,8 +325,8 @@ set(FFMPEG_USE_SWRESAMPLE ${USE_SW} CACHE BOOL "libswresample used for audio res
 mark_as_advanced(FFMPEG_USE_SWRESAMPLE)
 
 # Version check for hardware-acceleration code
-if(USE_HW_ACCEL AND avcodec_VERSION)
-  if(${avcodec_VERSION} VERSION_GREATER "57.107.100")
+if(USE_HW_ACCEL AND FFmpeg_avcodec_VERSION)
+  if(${FFmpeg_avcodec_VERSION} VERSION_GREATER "57.107.100")
     set(HAVE_HW_ACCEL TRUE)
   endif()
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -291,12 +291,17 @@ mark_as_advanced(QT_VERSION_STR)
 find_package(FFmpeg REQUIRED COMPONENTS avcodec avformat avutil swscale)
 
 set(all_comps avcodec avformat avutil swscale)
-if(TARGET FFmpeg::swresample)
-  list(APPEND all_comps swresample)
-else()
-  list(APPEND all_comps avresample)
-endif()
 set(version_comps avcodec avformat avutil)
+
+# Pick a resampler.  Prefer swresample if possible
+if(TARGET FFmpeg::swresample AND ${avformat_VERSION} VERSION_GREATER "57.0.0")
+  set(resample_lib swresample)
+  set(USE_SW TRUE)
+else()
+  set(resample_lib avresample)
+  set(USE_SW FALSE)
+endif()
+list(APPEND all_comps ${resample_lib})
 
 foreach(ff_comp IN LISTS all_comps)
   if(TARGET FFmpeg::${ff_comp})
@@ -310,9 +315,15 @@ foreach(ff_comp IN LISTS all_comps)
   endif()
 endforeach()
 
+# Indicate which resampler we linked with, and set a config header flag
+add_feature_info("FFmpeg ${resample_lib}" TRUE "Audio resampling uses ${resample_lib}")
+# Set the appropriate flag in OpenShotVersion.h
+set(FFMPEG_USE_SWRESAMPLE ${USE_SW} CACHE BOOL "libswresample used for audio resampling" FORCE)
+mark_as_advanced(FFMPEG_USE_SWRESAMPLE)
+
 # Version check for hardware-acceleration code
 if(USE_HW_ACCEL AND avcodec_VERSION)
-  if(${avcodec_VERSION} VERSION_GREATER 57.107.100)
+  if(${avcodec_VERSION} VERSION_GREATER "57.107.100")
     set(HAVE_HW_ACCEL TRUE)
   endif()
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -326,7 +326,7 @@ mark_as_advanced(FFMPEG_USE_SWRESAMPLE)
 
 # Version check for hardware-acceleration code
 if(USE_HW_ACCEL AND FFmpeg_avcodec_VERSION)
-  if(${FFmpeg_avcodec_VERSION} VERSION_GREATER "57.107.100")
+  if(${FFmpeg_avcodec_VERSION} VERSION_GREATER "57.106")
     set(HAVE_HW_ACCEL TRUE)
   endif()
 endif()

--- a/src/FFmpegUtilities.h
+++ b/src/FFmpegUtilities.h
@@ -31,269 +31,302 @@
 #ifndef OPENSHOT_FFMPEG_UTILITIES_H
 #define OPENSHOT_FFMPEG_UTILITIES_H
 
-	// Required for libavformat to build on Windows
-	#ifndef INT64_C
-	#define INT64_C(c) (c ## LL)
-	#define UINT64_C(c) (c ## ULL)
-	#endif
+#include "OpenShotVersion.h"  // For FFMPEG_USE_SWRESAMPLE
 
-	#ifndef IS_FFMPEG_3_2
-	#define IS_FFMPEG_3_2 (LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(57, 64, 101))
-	#endif
-
-	#ifndef USE_HW_ACCEL
-	#define USE_HW_ACCEL (LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(57, 107, 100))
-	#endif
-
-	// Include the FFmpeg headers
-	extern "C" {
-		#include <libavcodec/avcodec.h>
-		#include <libavformat/avformat.h>
-	#if (LIBAVFORMAT_VERSION_MAJOR >= 57)
-		#include <libavutil/hwcontext.h> //PM
-	#endif
-		#include <libswscale/swscale.h>
-		// Change this to the first version swrescale works
-	#if (LIBAVFORMAT_VERSION_MAJOR >= 57)
-			#define USE_SW
-	#endif
-	#ifdef USE_SW
-		#include <libswresample/swresample.h>
-	#else
-		#include <libavresample/avresample.h>
-	#endif
-		#include <libavutil/mathematics.h>
-		#include <libavutil/pixfmt.h>
-		#include <libavutil/pixdesc.h>
-
-		// libavutil changed folders at some point
-		#if LIBAVFORMAT_VERSION_MAJOR >= 53
-			#include <libavutil/opt.h>
-		#else
-			#include <libavcodec/opt.h>
-		#endif
-
-		// channel header refactored
-		#if LIBAVFORMAT_VERSION_MAJOR >= 54
-			#include <libavutil/channel_layout.h>
-		#endif
-
-		#if IS_FFMPEG_3_2
-			#include "libavutil/imgutils.h"
-		#endif
-	}
-
-	// This was removed from newer versions of FFmpeg (but still used in libopenshot)
-	#ifndef AVCODEC_MAX_AUDIO_FRAME_SIZE
-		#define AVCODEC_MAX_AUDIO_FRAME_SIZE 192000 // 1 second of 48khz 32bit audio
-	#endif
-	#ifndef AV_ERROR_MAX_STRING_SIZE
-		#define AV_ERROR_MAX_STRING_SIZE 64
-	#endif
-	#ifndef AUDIO_PACKET_ENCODING_SIZE
-		#define AUDIO_PACKET_ENCODING_SIZE 768000		// 48khz * S16 (2 bytes) * max channels (8)
-	#endif
-
-	// This wraps an unsafe C macro to be C++ compatible function
-	inline static const std::string av_make_error_string(int errnum)
-	{
-		char errbuf[AV_ERROR_MAX_STRING_SIZE];
-		av_strerror(errnum, errbuf, AV_ERROR_MAX_STRING_SIZE);
-		return (std::string)errbuf;
-	}
-
-	// Redefine the C macro to use our new C++ function
-	#undef av_err2str
-	#define av_err2str(errnum) av_make_error_string(errnum).c_str()
-
-	// Define this for compatibility
-	#ifndef PixelFormat
-		#define PixelFormat AVPixelFormat
-	#endif
-	#ifndef PIX_FMT_RGBA
-		#define PIX_FMT_RGBA AV_PIX_FMT_RGBA
-	#endif
-	#ifndef PIX_FMT_NONE
-		#define PIX_FMT_NONE AV_PIX_FMT_NONE
-	#endif
-	#ifndef PIX_FMT_RGB24
-		#define PIX_FMT_RGB24 AV_PIX_FMT_RGB24
-	#endif
-	#ifndef PIX_FMT_YUV420P
-		#define PIX_FMT_YUV420P AV_PIX_FMT_YUV420P
-	#endif
-	#ifndef PIX_FMT_YUV444P
-		#define PIX_FMT_YUV444P AV_PIX_FMT_YUV444P
-	#endif
-
-	// Does ffmpeg pixel format contain an alpha channel?
-    inline static const bool ffmpeg_has_alpha(PixelFormat pix_fmt) {
-        const AVPixFmtDescriptor *fmt_desc = av_pix_fmt_desc_get(pix_fmt);
-        return bool(fmt_desc->flags & AV_PIX_FMT_FLAG_ALPHA);
-    }
-
-	// FFmpeg's libavutil/common.h defines an RSHIFT incompatible with Ruby's
-	// definition in ruby/config.h, so we move it to FF_RSHIFT
-	#ifdef RSHIFT
-		#define FF_RSHIFT(a, b) RSHIFT(a, b)
-		#undef RSHIFT
-	#endif
-
-	#ifdef USE_SW
-		#define SWR_CONVERT(ctx, out, linesize, out_count, in, linesize2, in_count) \
-			swr_convert(ctx, out, out_count, (const uint8_t **)in, in_count)
-		#define SWR_ALLOC() swr_alloc()
-		#define SWR_CLOSE(ctx) {}
-		#define SWR_FREE(ctx) swr_free(ctx)
-		#define SWR_INIT(ctx)  swr_init(ctx)
-		#define SWRCONTEXT SwrContext
-	#else
-		#define SWR_CONVERT(ctx, out, linesize, out_count, in, linesize2, in_count) \
-			avresample_convert(ctx, out, linesize, out_count, (uint8_t **)in, linesize2, in_count)
-		#define SWR_ALLOC() avresample_alloc_context()
-		#define SWR_CLOSE(ctx) avresample_close(ctx)
-		#define SWR_FREE(ctx) avresample_free(ctx)
-		#define SWR_INIT(ctx)  avresample_open(ctx)
-		#define SWRCONTEXT AVAudioResampleContext
-	#endif
-
-
-	#if (LIBAVFORMAT_VERSION_MAJOR >= 58)
-		#define AV_REGISTER_ALL
-		#define AVCODEC_REGISTER_ALL
-		#define AV_FILENAME url
-		#define AV_SET_FILENAME(oc, f) oc->AV_FILENAME = av_strdup(f)
-		#define MY_INPUT_BUFFER_PADDING_SIZE AV_INPUT_BUFFER_PADDING_SIZE
-		#define AV_ALLOCATE_FRAME() av_frame_alloc()
-		#define AV_ALLOCATE_IMAGE(av_frame, pix_fmt, width, height) av_image_alloc(av_frame->data, av_frame->linesize, width, height, pix_fmt, 1)
-		#define AV_RESET_FRAME(av_frame) av_frame_unref(av_frame)
-		#define AV_FREE_FRAME(av_frame) av_frame_free(av_frame)
-		#define AV_FREE_PACKET(av_packet) av_packet_unref(av_packet)
-		#define AV_FREE_CONTEXT(av_context) avcodec_free_context(&av_context)
-		#define AV_GET_CODEC_TYPE(av_stream) av_stream->codecpar->codec_type
-		#define AV_FIND_DECODER_CODEC_ID(av_stream) av_stream->codecpar->codec_id
-		#define AV_GET_CODEC_CONTEXT(av_stream, av_codec) \
-			({ AVCodecContext *context = avcodec_alloc_context3(av_codec); \
-			   avcodec_parameters_to_context(context, av_stream->codecpar); \
-			   context; })
-		#define AV_GET_CODEC_PAR_CONTEXT(av_stream, av_codec) av_codec;
-		#define AV_GET_CODEC_FROM_STREAM(av_stream,codec_in)
-		#define AV_GET_CODEC_ATTRIBUTES(av_stream, av_context) av_stream->codecpar
-		#define AV_GET_CODEC_PIXEL_FORMAT(av_stream, av_context) (AVPixelFormat) av_stream->codecpar->format
-		#define AV_GET_SAMPLE_FORMAT(av_stream, av_context) av_stream->codecpar->format
-		#define AV_GET_IMAGE_SIZE(pix_fmt, width, height) av_image_get_buffer_size(pix_fmt, width, height, 1)
-		#define AV_COPY_PICTURE_DATA(av_frame, buffer, pix_fmt, width, height) av_image_fill_arrays(av_frame->data, av_frame->linesize, buffer, pix_fmt, width, height, 1)
-		#define AV_OUTPUT_CONTEXT(output_context, path) avformat_alloc_output_context2( output_context, NULL, NULL, path)
-		#define AV_OPTION_FIND(priv_data, name) av_opt_find(priv_data, name, NULL, 0, 0)
-		#define AV_OPTION_SET( av_stream, priv_data, name, value, avcodec) 	av_opt_set(priv_data, name, value, 0); avcodec_parameters_from_context(av_stream->codecpar, avcodec);
-		#define AV_FORMAT_NEW_STREAM(oc, st_codec_ctx, av_codec, av_st) 	av_st = avformat_new_stream(oc, NULL);\
-			if (!av_st) \
-				throw OutOfMemory("Could not allocate memory for the video stream.", path); \
-			c = avcodec_alloc_context3(av_codec); \
-			st_codec_ctx = c; \
-			av_st->codecpar->codec_id = av_codec->id;
-		#define AV_COPY_PARAMS_FROM_CONTEXT(av_stream, av_codec_ctx) avcodec_parameters_from_context(av_stream->codecpar, av_codec_ctx);
-	#elif IS_FFMPEG_3_2
-		#define AV_REGISTER_ALL av_register_all();
-		#define AVCODEC_REGISTER_ALL	avcodec_register_all();
-		#define AV_FILENAME filename
-		#define AV_SET_FILENAME(oc, f) snprintf(oc->AV_FILENAME, sizeof(oc->AV_FILENAME), "%s", f)
-		#define MY_INPUT_BUFFER_PADDING_SIZE FF_INPUT_BUFFER_PADDING_SIZE
-		#define AV_ALLOCATE_FRAME() av_frame_alloc()
-		#define AV_ALLOCATE_IMAGE(av_frame, pix_fmt, width, height) av_image_alloc(av_frame->data, av_frame->linesize, width, height, pix_fmt, 1)
-		#define AV_RESET_FRAME(av_frame) av_frame_unref(av_frame)
-		#define AV_FREE_FRAME(av_frame) av_frame_free(av_frame)
-		#define AV_FREE_PACKET(av_packet) av_packet_unref(av_packet)
-		#define AV_FREE_CONTEXT(av_context) avcodec_free_context(&av_context)
-		#define AV_GET_CODEC_TYPE(av_stream) av_stream->codecpar->codec_type
-		#define AV_FIND_DECODER_CODEC_ID(av_stream) av_stream->codecpar->codec_id
-		#define AV_GET_CODEC_CONTEXT(av_stream, av_codec) \
-			({ AVCodecContext *context = avcodec_alloc_context3(av_codec); \
-			   avcodec_parameters_to_context(context, av_stream->codecpar); \
-			   context; })
-		#define AV_GET_CODEC_PAR_CONTEXT(av_stream, av_codec) av_codec;
-		#define AV_GET_CODEC_FROM_STREAM(av_stream,codec_in)
-		#define AV_GET_CODEC_ATTRIBUTES(av_stream, av_context) av_stream->codecpar
-		#define AV_GET_CODEC_PIXEL_FORMAT(av_stream, av_context) (AVPixelFormat) av_stream->codecpar->format
-		#define AV_GET_SAMPLE_FORMAT(av_stream, av_context) av_stream->codecpar->format
-		#define AV_GET_IMAGE_SIZE(pix_fmt, width, height) av_image_get_buffer_size(pix_fmt, width, height, 1)
-		#define AV_COPY_PICTURE_DATA(av_frame, buffer, pix_fmt, width, height) av_image_fill_arrays(av_frame->data, av_frame->linesize, buffer, pix_fmt, width, height, 1)
-		#define AV_OUTPUT_CONTEXT(output_context, path) avformat_alloc_output_context2( output_context, NULL, NULL, path)
-		#define AV_OPTION_FIND(priv_data, name) av_opt_find(priv_data, name, NULL, 0, 0)
-		#define AV_OPTION_SET( av_stream, priv_data, name, value, avcodec) 	av_opt_set(priv_data, name, value, 0); avcodec_parameters_from_context(av_stream->codecpar, avcodec);
-		#define AV_FORMAT_NEW_STREAM(oc, st_codec, av_codec, av_st) 	av_st = avformat_new_stream(oc, NULL);\
-			if (!av_st) \
-				throw OutOfMemory("Could not allocate memory for the video stream.", path); \
-			_Pragma ("GCC diagnostic push"); \
-			_Pragma ("GCC diagnostic ignored \"-Wdeprecated-declarations\""); \
-			avcodec_get_context_defaults3(av_st->codec, av_codec); \
-			c = av_st->codec; \
-			_Pragma ("GCC diagnostic pop"); \
-			st_codec = c;
-		#define AV_COPY_PARAMS_FROM_CONTEXT(av_stream, av_codec) avcodec_parameters_from_context(av_stream->codecpar, av_codec);
-	#elif LIBAVFORMAT_VERSION_MAJOR >= 55
-		#define AV_REGISTER_ALL av_register_all();
-		#define AVCODEC_REGISTER_ALL	avcodec_register_all();
-		#define AV_FILENAME filename
-		#define AV_SET_FILENAME(oc, f) snprintf(oc->AV_FILENAME, sizeof(oc->AV_FILENAME), "%s", f)
-		#define MY_INPUT_BUFFER_PADDING_SIZE FF_INPUT_BUFFER_PADDING_SIZE
-		#define AV_ALLOCATE_FRAME() av_frame_alloc()
-		#define AV_ALLOCATE_IMAGE(av_frame, pix_fmt, width, height) avpicture_alloc((AVPicture *) av_frame, pix_fmt, width, height)
-		#define AV_RESET_FRAME(av_frame) av_frame_unref(av_frame)
-		#define AV_FREE_FRAME(av_frame) av_frame_free(av_frame)
-		#define AV_FREE_PACKET(av_packet) av_packet_unref(av_packet)
-		#define AV_FREE_CONTEXT(av_context) avcodec_close(av_context)
-		#define AV_GET_CODEC_TYPE(av_stream) av_stream->codec->codec_type
-		#define AV_FIND_DECODER_CODEC_ID(av_stream) av_stream->codec->codec_id
-		#define AV_GET_CODEC_CONTEXT(av_stream, av_codec) av_stream->codec
-		#define AV_GET_CODEC_PAR_CONTEXT(av_stream, av_codec) av_stream->codec
-		#define AV_GET_CODEC_FROM_STREAM(av_stream, codec_in) codec_in = av_stream->codec;
-		#define AV_GET_CODEC_ATTRIBUTES(av_stream, av_context) av_context
-		#define AV_GET_CODEC_PIXEL_FORMAT(av_stream, av_context) av_context->pix_fmt
-		#define AV_GET_SAMPLE_FORMAT(av_stream, av_context) av_context->sample_fmt
-		#define AV_GET_IMAGE_SIZE(pix_fmt, width, height) avpicture_get_size(pix_fmt, width, height)
-		#define AV_COPY_PICTURE_DATA(av_frame, buffer, pix_fmt, width, height) avpicture_fill((AVPicture *) av_frame, buffer, pix_fmt, width, height)
-		#define AV_OUTPUT_CONTEXT(output_context, path) oc = avformat_alloc_context()
-		#define AV_OPTION_FIND(priv_data, name) av_opt_find(priv_data, name, NULL, 0, 0)
-		#define AV_OPTION_SET(av_stream, priv_data, name, value, avcodec) av_opt_set (priv_data, name, value, 0)
-		#define AV_FORMAT_NEW_STREAM( oc,  av_context,  av_codec, av_st) av_st = avformat_new_stream(oc, av_codec); \
-			if (!av_st) \
-				throw OutOfMemory("Could not allocate memory for the video stream.", path); \
-			avcodec_get_context_defaults3(av_st->codec, av_codec); \
-			c = av_st->codec;
-		#define AV_COPY_PARAMS_FROM_CONTEXT(av_stream, av_codec)
-	#else
-		#define AV_REGISTER_ALL av_register_all();
-		#define AVCODEC_REGISTER_ALL	avcodec_register_all();
-		#define AV_FILENAME filename
-		#define AV_SET_FILENAME(oc, f) snprintf(oc->AV_FILENAME, sizeof(oc->AV_FILENAME), "%s", f)
-		#define MY_INPUT_BUFFER_PADDING_SIZE FF_INPUT_BUFFER_PADDING_SIZE
-		#define AV_ALLOCATE_FRAME() avcodec_alloc_frame()
-		#define AV_ALLOCATE_IMAGE(av_frame, pix_fmt, width, height) avpicture_alloc((AVPicture *) av_frame, pix_fmt, width, height)
-		#define AV_RESET_FRAME(av_frame) avcodec_get_frame_defaults(av_frame)
-		#define AV_FREE_FRAME(av_frame) avcodec_free_frame(av_frame)
-		#define AV_FREE_PACKET(av_packet) av_free_packet(av_packet)
-		#define AV_FREE_CONTEXT(av_context) avcodec_close(av_context)
-		#define AV_GET_CODEC_TYPE(av_stream) av_stream->codec->codec_type
-		#define AV_FIND_DECODER_CODEC_ID(av_stream) av_stream->codec->codec_id
-		#define AV_GET_CODEC_CONTEXT(av_stream, av_codec) av_stream->codec
-		#define AV_GET_CODEC_PAR_CONTEXT(av_stream, av_codec) av_stream->codec
-		#define AV_GET_CODEC_FROM_STREAM(av_stream, codec_in ) codec_in = av_stream->codec;
-		#define AV_GET_CODEC_ATTRIBUTES(av_stream, av_context) av_context
-		#define AV_GET_CODEC_PIXEL_FORMAT(av_stream, av_context) av_context->pix_fmt
-		#define AV_GET_SAMPLE_FORMAT(av_stream, av_context) av_context->sample_fmt
-		#define AV_GET_IMAGE_SIZE(pix_fmt, width, height) avpicture_get_size(pix_fmt, width, height)
-		#define AV_COPY_PICTURE_DATA(av_frame, buffer, pix_fmt, width, height) avpicture_fill((AVPicture *) av_frame, buffer, pix_fmt, width, height)
-		#define AV_OUTPUT_CONTEXT(output_context, path) oc = avformat_alloc_context()
-		#define AV_OPTION_FIND(priv_data, name) av_opt_find(priv_data, name, NULL, 0, 0)
-		#define AV_OPTION_SET(av_stream, priv_data, name, value, avcodec) av_opt_set (priv_data, name, value, 0)
-		#define AV_FORMAT_NEW_STREAM( oc,  av_context,  av_codec, av_st) av_st = avformat_new_stream(oc, av_codec); \
-			if (!av_st) \
-				throw OutOfMemory("Could not allocate memory for the video stream.", path); \
-			avcodec_get_context_defaults3(av_st->codec, av_codec); \
-			c = av_st->codec;
-		#define AV_COPY_PARAMS_FROM_CONTEXT(av_stream, av_codec)
-	#endif
-
-
+// Required for libavformat to build on Windows
+#ifndef INT64_C
+#define INT64_C(c) (c ## LL)
+#define UINT64_C(c) (c ## ULL)
 #endif
+
+#ifndef IS_FFMPEG_3_2
+#define IS_FFMPEG_3_2 (LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(57, 64, 101))
+#endif
+
+#ifndef USE_HW_ACCEL
+#define USE_HW_ACCEL (LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(57, 107, 100))
+#endif
+
+#ifndef USE_SW
+#define USE_SW FFMPEG_USE_SWRESAMPLE
+#endif
+
+// Include the FFmpeg headers
+extern "C" {
+    #include <libavcodec/avcodec.h>
+    #include <libavformat/avformat.h>
+
+#if (LIBAVFORMAT_VERSION_MAJOR >= 57)
+    #include <libavutil/hwcontext.h> //PM
+#endif
+    #include <libswscale/swscale.h>
+
+#if USE_SW
+    #include <libswresample/swresample.h>
+#else
+    #include <libavresample/avresample.h>
+#endif
+
+    #include <libavutil/mathematics.h>
+    #include <libavutil/pixfmt.h>
+    #include <libavutil/pixdesc.h>
+
+    // libavutil changed folders at some point
+#if LIBAVFORMAT_VERSION_MAJOR >= 53
+    #include <libavutil/opt.h>
+#else
+    #include <libavcodec/opt.h>
+#endif
+
+    // channel header refactored
+#if LIBAVFORMAT_VERSION_MAJOR >= 54
+    #include <libavutil/channel_layout.h>
+#endif
+
+#if IS_FFMPEG_3_2
+    #include "libavutil/imgutils.h"
+#endif
+}
+
+// This was removed from newer versions of FFmpeg (but still used in libopenshot)
+#ifndef AVCODEC_MAX_AUDIO_FRAME_SIZE
+    // 1 second of 48khz 32bit audio
+    #define AVCODEC_MAX_AUDIO_FRAME_SIZE 192000
+#endif
+#ifndef AV_ERROR_MAX_STRING_SIZE
+    #define AV_ERROR_MAX_STRING_SIZE 64
+#endif
+#ifndef AUDIO_PACKET_ENCODING_SIZE
+    // 48khz * S16 (2 bytes) * max channels (8)
+    #define AUDIO_PACKET_ENCODING_SIZE 768000
+#endif
+
+// This wraps an unsafe C macro to be C++ compatible function
+inline static const std::string av_make_error_string(int errnum)
+{
+    char errbuf[AV_ERROR_MAX_STRING_SIZE];
+    av_strerror(errnum, errbuf, AV_ERROR_MAX_STRING_SIZE);
+    return (std::string)errbuf;
+}
+
+// Redefine the C macro to use our new C++ function
+#undef av_err2str
+#define av_err2str(errnum) av_make_error_string(errnum).c_str()
+
+// Define this for compatibility
+#ifndef PixelFormat
+    #define PixelFormat AVPixelFormat
+#endif
+#ifndef PIX_FMT_RGBA
+    #define PIX_FMT_RGBA AV_PIX_FMT_RGBA
+#endif
+#ifndef PIX_FMT_NONE
+    #define PIX_FMT_NONE AV_PIX_FMT_NONE
+#endif
+#ifndef PIX_FMT_RGB24
+    #define PIX_FMT_RGB24 AV_PIX_FMT_RGB24
+#endif
+#ifndef PIX_FMT_YUV420P
+    #define PIX_FMT_YUV420P AV_PIX_FMT_YUV420P
+#endif
+#ifndef PIX_FMT_YUV444P
+    #define PIX_FMT_YUV444P AV_PIX_FMT_YUV444P
+#endif
+
+// Does ffmpeg pixel format contain an alpha channel?
+inline static const bool ffmpeg_has_alpha(PixelFormat pix_fmt) {
+    const AVPixFmtDescriptor *fmt_desc = av_pix_fmt_desc_get(pix_fmt);
+    return bool(fmt_desc->flags & AV_PIX_FMT_FLAG_ALPHA);
+}
+
+// FFmpeg's libavutil/common.h defines an RSHIFT incompatible with Ruby's
+// definition in ruby/config.h, so we move it to FF_RSHIFT
+#ifdef RSHIFT
+    #define FF_RSHIFT(a, b) RSHIFT(a, b)
+    #undef RSHIFT
+#endif
+
+// libswresample/libavresample API switching
+#if USE_SW
+    #define SWR_CONVERT(ctx, out, linesize, out_count, in, linesize2, in_count) \
+            swr_convert(ctx, out, out_count, (const uint8_t **)in, in_count)
+    #define SWR_ALLOC() swr_alloc()
+    #define SWR_CLOSE(ctx) {}
+    #define SWR_FREE(ctx) swr_free(ctx)
+    #define SWR_INIT(ctx)  swr_init(ctx)
+    #define SWRCONTEXT SwrContext
+
+#else
+    #define SWR_CONVERT(ctx, out, linesize, out_count, in, linesize2, in_count) \
+            avresample_convert(ctx, out, linesize, out_count, (uint8_t **)in, linesize2, in_count)
+    #define SWR_ALLOC() avresample_alloc_context()
+    #define SWR_CLOSE(ctx) avresample_close(ctx)
+    #define SWR_FREE(ctx) avresample_free(ctx)
+    #define SWR_INIT(ctx)  avresample_open(ctx)
+    #define SWRCONTEXT AVAudioResampleContext
+#endif
+
+
+#if (LIBAVFORMAT_VERSION_MAJOR >= 58)
+    #define AV_REGISTER_ALL
+    #define AVCODEC_REGISTER_ALL
+    #define AV_FILENAME url
+    #define AV_SET_FILENAME(oc, f) oc->AV_FILENAME = av_strdup(f)
+    #define MY_INPUT_BUFFER_PADDING_SIZE AV_INPUT_BUFFER_PADDING_SIZE
+    #define AV_ALLOCATE_FRAME() av_frame_alloc()
+    #define AV_ALLOCATE_IMAGE(av_frame, pix_fmt, width, height) \
+            av_image_alloc(av_frame->data, av_frame->linesize, width, height, pix_fmt, 1)
+    #define AV_RESET_FRAME(av_frame) av_frame_unref(av_frame)
+    #define AV_FREE_FRAME(av_frame) av_frame_free(av_frame)
+    #define AV_FREE_PACKET(av_packet) av_packet_unref(av_packet)
+    #define AV_FREE_CONTEXT(av_context) avcodec_free_context(&av_context)
+    #define AV_GET_CODEC_TYPE(av_stream) av_stream->codecpar->codec_type
+    #define AV_FIND_DECODER_CODEC_ID(av_stream) av_stream->codecpar->codec_id
+    #define AV_GET_CODEC_CONTEXT(av_stream, av_codec) \
+            ({ AVCodecContext *context = avcodec_alloc_context3(av_codec); \
+               avcodec_parameters_to_context(context, av_stream->codecpar); \
+               context; })
+    #define AV_GET_CODEC_PAR_CONTEXT(av_stream, av_codec) av_codec;
+    #define AV_GET_CODEC_FROM_STREAM(av_stream,codec_in)
+    #define AV_GET_CODEC_ATTRIBUTES(av_stream, av_context) av_stream->codecpar
+    #define AV_GET_CODEC_PIXEL_FORMAT(av_stream, av_context) (AVPixelFormat) av_stream->codecpar->format
+    #define AV_GET_SAMPLE_FORMAT(av_stream, av_context) av_stream->codecpar->format
+    #define AV_GET_IMAGE_SIZE(pix_fmt, width, height) \
+            av_image_get_buffer_size(pix_fmt, width, height, 1)
+    #define AV_COPY_PICTURE_DATA(av_frame, buffer, pix_fmt, width, height) \
+            av_image_fill_arrays(av_frame->data, av_frame->linesize, buffer, pix_fmt, width, height, 1)
+    #define AV_OUTPUT_CONTEXT(output_context, path) avformat_alloc_output_context2( output_context, NULL, NULL, path)
+    #define AV_OPTION_FIND(priv_data, name) av_opt_find(priv_data, name, NULL, 0, 0)
+    #define AV_OPTION_SET( av_stream, priv_data, name, value, avcodec) \
+            av_opt_set(priv_data, name, value, 0); \
+            avcodec_parameters_from_context(av_stream->codecpar, avcodec);
+    #define AV_FORMAT_NEW_STREAM(oc, st_codec_ctx, av_codec, av_st) \
+            av_st = avformat_new_stream(oc, NULL);\
+            if (!av_st) \
+                throw OutOfMemory("Could not allocate memory for the video stream.", path); \
+            c = avcodec_alloc_context3(av_codec); \
+            st_codec_ctx = c; \
+            av_st->codecpar->codec_id = av_codec->id;
+    #define AV_COPY_PARAMS_FROM_CONTEXT(av_stream, av_codec_ctx) \
+            avcodec_parameters_from_context(av_stream->codecpar, av_codec_ctx);
+
+#elif IS_FFMPEG_3_2
+    #define AV_REGISTER_ALL av_register_all();
+    #define AVCODEC_REGISTER_ALL    avcodec_register_all();
+    #define AV_FILENAME filename
+    #define AV_SET_FILENAME(oc, f) snprintf(oc->AV_FILENAME, sizeof(oc->AV_FILENAME), "%s", f)
+    #define MY_INPUT_BUFFER_PADDING_SIZE FF_INPUT_BUFFER_PADDING_SIZE
+    #define AV_ALLOCATE_FRAME() av_frame_alloc()
+    #define AV_ALLOCATE_IMAGE(av_frame, pix_fmt, width, height) \
+            av_image_alloc(av_frame->data, av_frame->linesize, width, height, pix_fmt, 1)
+    #define AV_RESET_FRAME(av_frame) av_frame_unref(av_frame)
+    #define AV_FREE_FRAME(av_frame) av_frame_free(av_frame)
+    #define AV_FREE_PACKET(av_packet) av_packet_unref(av_packet)
+    #define AV_FREE_CONTEXT(av_context) avcodec_free_context(&av_context)
+    #define AV_GET_CODEC_TYPE(av_stream) av_stream->codecpar->codec_type
+    #define AV_FIND_DECODER_CODEC_ID(av_stream) av_stream->codecpar->codec_id
+    #define AV_GET_CODEC_CONTEXT(av_stream, av_codec) \
+            ({ AVCodecContext *context = avcodec_alloc_context3(av_codec); \
+               avcodec_parameters_to_context(context, av_stream->codecpar); \
+               context; })
+    #define AV_GET_CODEC_PAR_CONTEXT(av_stream, av_codec) av_codec;
+    #define AV_GET_CODEC_FROM_STREAM(av_stream,codec_in)
+    #define AV_GET_CODEC_ATTRIBUTES(av_stream, av_context) av_stream->codecpar
+    #define AV_GET_CODEC_PIXEL_FORMAT(av_stream, av_context) \
+            (AVPixelFormat) av_stream->codecpar->format
+    #define AV_GET_SAMPLE_FORMAT(av_stream, av_context) av_stream->codecpar->format
+    #define AV_GET_IMAGE_SIZE(pix_fmt, width, height) av_image_get_buffer_size(pix_fmt, width, height, 1)
+    #define AV_COPY_PICTURE_DATA(av_frame, buffer, pix_fmt, width, height) \
+            av_image_fill_arrays(av_frame->data, av_frame->linesize, buffer, pix_fmt, width, height, 1)
+    #define AV_OUTPUT_CONTEXT(output_context, path) \
+            avformat_alloc_output_context2( output_context, NULL, NULL, path)
+    #define AV_OPTION_FIND(priv_data, name) av_opt_find(priv_data, name, NULL, 0, 0)
+    #define AV_OPTION_SET( av_stream, priv_data, name, value, avcodec) \
+            av_opt_set(priv_data, name, value, 0); \
+            avcodec_parameters_from_context(av_stream->codecpar, avcodec);
+    #define AV_FORMAT_NEW_STREAM(oc, st_codec, av_codec, av_st) \
+            av_st = avformat_new_stream(oc, NULL);\
+            if (!av_st) \
+                throw OutOfMemory("Could not allocate memory for the video stream.", path); \
+            _Pragma ("GCC diagnostic push"); \
+            _Pragma ("GCC diagnostic ignored \"-Wdeprecated-declarations\""); \
+            avcodec_get_context_defaults3(av_st->codec, av_codec); \
+            c = av_st->codec; \
+            _Pragma ("GCC diagnostic pop"); \
+            st_codec = c;
+    #define AV_COPY_PARAMS_FROM_CONTEXT(av_stream, av_codec) \
+            avcodec_parameters_from_context(av_stream->codecpar, av_codec);
+
+#elif LIBAVFORMAT_VERSION_MAJOR >= 55
+    #define AV_REGISTER_ALL av_register_all();
+    #define AVCODEC_REGISTER_ALL    avcodec_register_all();
+    #define AV_FILENAME filename
+    #define AV_SET_FILENAME(oc, f) snprintf(oc->AV_FILENAME, sizeof(oc->AV_FILENAME), "%s", f)
+    #define MY_INPUT_BUFFER_PADDING_SIZE FF_INPUT_BUFFER_PADDING_SIZE
+    #define AV_ALLOCATE_FRAME() av_frame_alloc()
+    #define AV_ALLOCATE_IMAGE(av_frame, pix_fmt, width, height) \
+            avpicture_alloc((AVPicture *) av_frame, pix_fmt, width, height)
+    #define AV_RESET_FRAME(av_frame) av_frame_unref(av_frame)
+    #define AV_FREE_FRAME(av_frame) av_frame_free(av_frame)
+    #define AV_FREE_PACKET(av_packet) av_packet_unref(av_packet)
+    #define AV_FREE_CONTEXT(av_context) avcodec_close(av_context)
+    #define AV_GET_CODEC_TYPE(av_stream) av_stream->codec->codec_type
+    #define AV_FIND_DECODER_CODEC_ID(av_stream) av_stream->codec->codec_id
+    #define AV_GET_CODEC_CONTEXT(av_stream, av_codec) av_stream->codec
+    #define AV_GET_CODEC_PAR_CONTEXT(av_stream, av_codec) av_stream->codec
+    #define AV_GET_CODEC_FROM_STREAM(av_stream, codec_in) codec_in = av_stream->codec;
+    #define AV_GET_CODEC_ATTRIBUTES(av_stream, av_context) av_context
+    #define AV_GET_CODEC_PIXEL_FORMAT(av_stream, av_context) av_context->pix_fmt
+    #define AV_GET_SAMPLE_FORMAT(av_stream, av_context) av_context->sample_fmt
+    #define AV_GET_IMAGE_SIZE(pix_fmt, width, height) avpicture_get_size(pix_fmt, width, height)
+    #define AV_COPY_PICTURE_DATA(av_frame, buffer, pix_fmt, width, height) \
+            avpicture_fill((AVPicture *) av_frame, buffer, pix_fmt, width, height)
+    #define AV_OUTPUT_CONTEXT(output_context, path) oc = avformat_alloc_context()
+    #define AV_OPTION_FIND(priv_data, name) av_opt_find(priv_data, name, NULL, 0, 0)
+    #define AV_OPTION_SET(av_stream, priv_data, name, value, avcodec) av_opt_set (priv_data, name, value, 0)
+    #define AV_FORMAT_NEW_STREAM( oc,  av_context,  av_codec, av_st) \
+            av_st = avformat_new_stream(oc, av_codec); \
+            if (!av_st) \
+                throw OutOfMemory("Could not allocate memory for the video stream.", path); \
+            avcodec_get_context_defaults3(av_st->codec, av_codec); \
+            c = av_st->codec;
+    #define AV_COPY_PARAMS_FROM_CONTEXT(av_stream, av_codec)
+
+#else
+    #define AV_REGISTER_ALL av_register_all();
+    #define AVCODEC_REGISTER_ALL    avcodec_register_all();
+    #define AV_FILENAME filename
+    #define AV_SET_FILENAME(oc, f) snprintf(oc->AV_FILENAME, sizeof(oc->AV_FILENAME), "%s", f)
+    #define MY_INPUT_BUFFER_PADDING_SIZE FF_INPUT_BUFFER_PADDING_SIZE
+    #define AV_ALLOCATE_FRAME() avcodec_alloc_frame()
+    #define AV_ALLOCATE_IMAGE(av_frame, pix_fmt, width, height) \
+            avpicture_alloc((AVPicture *) av_frame, pix_fmt, width, height)
+    #define AV_RESET_FRAME(av_frame) avcodec_get_frame_defaults(av_frame)
+    #define AV_FREE_FRAME(av_frame) avcodec_free_frame(av_frame)
+    #define AV_FREE_PACKET(av_packet) av_free_packet(av_packet)
+    #define AV_FREE_CONTEXT(av_context) avcodec_close(av_context)
+    #define AV_GET_CODEC_TYPE(av_stream) av_stream->codec->codec_type
+    #define AV_FIND_DECODER_CODEC_ID(av_stream) av_stream->codec->codec_id
+    #define AV_GET_CODEC_CONTEXT(av_stream, av_codec) av_stream->codec
+    #define AV_GET_CODEC_PAR_CONTEXT(av_stream, av_codec) av_stream->codec
+    #define AV_GET_CODEC_FROM_STREAM(av_stream, codec_in ) codec_in = av_stream->codec;
+    #define AV_GET_CODEC_ATTRIBUTES(av_stream, av_context) av_context
+    #define AV_GET_CODEC_PIXEL_FORMAT(av_stream, av_context) av_context->pix_fmt
+    #define AV_GET_SAMPLE_FORMAT(av_stream, av_context) av_context->sample_fmt
+    #define AV_GET_IMAGE_SIZE(pix_fmt, width, height) avpicture_get_size(pix_fmt, width, height)
+    #define AV_COPY_PICTURE_DATA(av_frame, buffer, pix_fmt, width, height) \
+            avpicture_fill((AVPicture *) av_frame, buffer, pix_fmt, width, height)
+    #define AV_OUTPUT_CONTEXT(output_context, path) oc = avformat_alloc_context()
+    #define AV_OPTION_FIND(priv_data, name) av_opt_find(priv_data, name, NULL, 0, 0)
+    #define AV_OPTION_SET(av_stream, priv_data, name, value, avcodec) av_opt_set (priv_data, name, value, 0)
+    #define AV_FORMAT_NEW_STREAM( oc,  av_context,  av_codec, av_st) \
+            av_st = avformat_new_stream(oc, av_codec); \
+            if (!av_st) \
+                throw OutOfMemory("Could not allocate memory for the video stream.", path); \
+            avcodec_get_context_defaults3(av_st->codec, av_codec); \
+            c = av_st->codec;
+    #define AV_COPY_PARAMS_FROM_CONTEXT(av_stream, av_codec)
+#endif
+
+
+#endif  // OPENSHOT_FFMPEG_UTILITIES_H

--- a/src/OpenShotVersion.h.in
+++ b/src/OpenShotVersion.h.in
@@ -51,6 +51,7 @@
 #cmakedefine01 HAVE_IMAGEMAGICK
 #cmakedefine01 HAVE_RESVG
 #cmakedefine01 HAVE_OPENCV
+#cmakedefine01 FFMPEG_USE_SWRESAMPLE
 #cmakedefine01 APPIMAGE_BUILD
 
 #include <sstream>


### PR DESCRIPTION
:heavy_check_mark:  <s> **Note: PR #694 MUST be merged before this PR.** </s>

I discovered with @BrennoCaldato 's help that having CMake decide which resampling library to link with, but having the code in the `FFmpegUtilities.h` header decide which one to _use_, wasn't really working out well in all cases. In some FFmpeg versions, CMake would link with libswresample, but the header would select the avresample API, resulting in a broken libopenshot build that didn't have the right set of library dependencies configured.

This PR moves the determination as to which resampling library to use into the `src/CMakeLists.txt` code, which will set flags to _tell_ `FFmpegUtilities.h` which one has been linked in (and therefore, which one to use). This ensures no broken builds due to mismatching configs.

Plus the choice can be displayed in the FeatureSummary at configure time:

<pre><code>
$ cmake -B build -S . -DOpenShotAudio_ROOT=../libopenshot-audio/build
[...]
-- Checking for module 'libavcodec'
--   Found libavcodec, version 58.91.100
-- Checking for module 'libavformat'
--   Found libavformat, version 58.45.100
-- Checking for module 'libavutil'
--   Found libavutil, version 56.51.100
-- Checking for module 'libswscale'
--   Found libswscale, version 5.7.100
-- Checking for module 'libswresample'
--   Found libswresample, version 3.7.100
-- Checking for module 'libavresample'
--   Found libavresample, version 4.0.0
-- Found FFmpeg: /usr/lib64/libavcodec.so;/usr/lib64/libavformat.so;/usr/lib64/libavutil.so;
/usr/lib64/libswscale.so;/usr/lib64/libswresample.so;/usr/lib64/libavresample.so 
(found version "4.3.2") found components: avcodec avformat avutil swscale swresample avresample
[...]
-- Build configuration:
-- The following features have been enabled:

<b> * FFmpeg swresample, Audio resampling uses swresample</b>
 * FFmpeg hwaccel, GPU-accelerated routines (FFmpeg 3.4+)
 * OpenCV algorithms, Use OpenCV algorithms
 * Parallel tests, Unit tests can use 4 processors
 * Unit tests, Compile unit tests for library functions
 * Non-default target 'coverage', Run unit tests and (if enabled) collect coverage data
 * Non-default target 'doc', Build formatted API documentation (HTML+SVG)
[...]
</code></pre>
