### PR TITLE
Only get rotation from metadata if 0 keyframes

### DIFF
--- a/src/Clip.cpp
+++ b/src/Clip.cpp
@@ -122,11 +122,8 @@ void Clip::init_reader_settings() {
 // Init reader's rotation (if any)
 void Clip::init_reader_rotation() {
 	// Only init rotation from reader when needed
-	if (rotation.GetCount() > 1)
+	if (rotation.GetCount() > 0)
 		// Do nothing if more than 1 rotation Point
-		return;
-	else if (rotation.GetCount() == 1 && rotation.GetValue(1) != 0.0)
-		// Do nothing if 1 Point, and it's not the default value
 		return;
 
 	// Init rotation

--- a/src/Clip.cpp
+++ b/src/Clip.cpp
@@ -121,9 +121,8 @@ void Clip::init_reader_settings() {
 
 // Init reader's rotation (if any)
 void Clip::init_reader_rotation() {
-	// Only init rotation from reader when needed
+	// Dont init rotation if clip has keyframes
 	if (rotation.GetCount() > 0)
-		// Do nothing if more than 1 rotation Point
 		return;
 
 	// Init rotation


### PR DESCRIPTION
Changing rotation data assumed that a video file's starting rotation is 0 degrees.

This change allows users to set a 0 degree keyframe when there is only one rotation keyframe.