### PR TITLE
Exceptions: Add py_message() for Python

### DIFF
--- a/bindings/python/openshot.i
+++ b/bindings/python/openshot.i
@@ -131,6 +131,9 @@
 	try {
 		$action
 	}
+	catch (openshot::ExceptionBase &e) {
+		SWIG_exception_fail(SWIG_RuntimeError, e.py_message().c_str());
+	}
 	catch (std::exception &e) {
 		SWIG_exception_fail(SWIG_RuntimeError, e.what());
 	}

--- a/src/Exceptions.h
+++ b/src/Exceptions.h
@@ -32,6 +32,7 @@
 #define OPENSHOT_EXCEPTIONS_H
 
 #include <string>
+#include <cstring>
 
 namespace openshot {
 
@@ -52,13 +53,49 @@ namespace openshot {
 			// return custom message
 			return m_message.c_str();
 		}
+        virtual std::string py_message() const {
+            // return complete message for Python exception handling
+            return m_message;
+        }
 	};
 
+    class FrameExceptionBase : public ExceptionBase
+    {
+    public:
+        int64_t frame_number;
+        FrameExceptionBase(std::string message, int64_t frame_number=-1)
+            : ExceptionBase(message), frame_number(frame_number) { }
+        virtual std::string py_message() const override {
+            // return complete message for Python exception handling
+            std::string out_msg(m_message +
+                (frame_number > 0
+                 ? " at frame " + std::to_string(frame_number)
+                 : ""));
+            return out_msg;
+        }
+    };
+
+
+    class FileExceptionBase : public ExceptionBase
+    {
+    public:
+        std::string file_path;
+        FileExceptionBase(std::string message, std::string file_path="")
+            : ExceptionBase(message), file_path(file_path) { }
+        virtual std::string py_message() const override {
+            // return complete message for Python exception handling
+            std::string out_msg(m_message +
+                (file_path != ""
+                 ? " for file " + file_path
+                 : ""));
+            return out_msg;
+        }
+    };
+
 	/// Exception when a required chunk is missing
-	class ChunkNotFound : public ExceptionBase
+	class ChunkNotFound : public FrameExceptionBase
 	{
 	public:
-		int64_t frame_number;
 		int64_t chunk_number;
 		int64_t chunk_frame;
 		/**
@@ -70,7 +107,7 @@ namespace openshot {
 		 * @param chunk_frame The chunk frame
 		 */
 		ChunkNotFound(std::string message, int64_t frame_number, int64_t chunk_number, int64_t chunk_frame)
-			: ExceptionBase(message), frame_number(frame_number), chunk_number(chunk_number), chunk_frame(chunk_frame) { }
+			: FrameExceptionBase(message, frame_number), chunk_number(chunk_number), chunk_frame(chunk_frame) { }
 		virtual ~ChunkNotFound() noexcept {}
 	};
 
@@ -90,58 +127,54 @@ namespace openshot {
 	};
 
 	/// Exception when decoding audio packet
-	class ErrorDecodingAudio : public ExceptionBase
+	class ErrorDecodingAudio : public FrameExceptionBase
 	{
 	public:
-		int64_t frame_number;
 		/**
 		 * @brief Constructor
 		 *
 		 * @param message A message to accompany the exception
 		 * @param frame_number The frame number being processed
 		 */
-		ErrorDecodingAudio(std::string message, int64_t frame_number)
-			: ExceptionBase(message), frame_number(frame_number) { }
+		ErrorDecodingAudio(std::string message, int64_t frame_number=-1)
+			: FrameExceptionBase(message, frame_number) { }
 		virtual ~ErrorDecodingAudio() noexcept {}
 	};
 
 	/// Exception when encoding audio packet
-	class ErrorEncodingAudio : public ExceptionBase
+	class ErrorEncodingAudio : public FrameExceptionBase
 	{
 	public:
-		int64_t frame_number;
 		/**
 		 * @brief Constructor
 		 *
 		 * @param message A message to accompany the exception
 		 * @param frame_number The frame number being processed
 		 */
-		ErrorEncodingAudio(std::string message, int64_t frame_number)
-			: ExceptionBase(message), frame_number(frame_number) { }
+		ErrorEncodingAudio(std::string message, int64_t frame_number=-1)
+			: FrameExceptionBase(message, frame_number) { }
 		virtual ~ErrorEncodingAudio() noexcept {}
 	};
 
 	/// Exception when encoding audio packet
-	class ErrorEncodingVideo : public ExceptionBase
+	class ErrorEncodingVideo : public FrameExceptionBase
 	{
 	public:
-		int64_t frame_number;
 		/**
 		 * @brief Constructor
 		 *
 		 * @param message A message to accompany the exception
 		 * @param frame_number The frame number being processed
 		 */
-		ErrorEncodingVideo(std::string message, int64_t frame_number)
-			: ExceptionBase(message), frame_number(frame_number) { }
+		ErrorEncodingVideo(std::string message, int64_t frame_number=-1)
+			: FrameExceptionBase(message, frame_number) { }
 		virtual ~ErrorEncodingVideo() noexcept {}
 	};
 
 	/// Exception when an invalid # of audio channels are detected
-	class InvalidChannels : public ExceptionBase
+	class InvalidChannels : public FileExceptionBase
 	{
 	public:
-		std::string file_path;
 		/**
 		 * @brief Constructor
 		 *
@@ -149,15 +182,14 @@ namespace openshot {
 		 * @param file_path (optional) The input file being processed
 		 */
 		InvalidChannels(std::string message, std::string file_path="")
-			: ExceptionBase(message), file_path(file_path) { }
+			: FileExceptionBase(message, file_path) { }
 		virtual ~InvalidChannels() noexcept {}
 	};
 
 	/// Exception when no valid codec is found for a file
-	class InvalidCodec : public ExceptionBase
+	class InvalidCodec : public FileExceptionBase
 	{
 	public:
-		std::string file_path;
 		/**
 		 * @brief Constructor
 		 *
@@ -165,15 +197,14 @@ namespace openshot {
 		 * @param file_path (optional) The input file being processed
 		 */
 		InvalidCodec(std::string message, std::string file_path="")
-			: ExceptionBase(message), file_path(file_path) { }
+			: FileExceptionBase(message, file_path) { }
 		virtual ~InvalidCodec() noexcept {}
 	};
 
 	/// Exception for files that can not be found or opened
-	class InvalidFile : public ExceptionBase
+	class InvalidFile : public FileExceptionBase
 	{
 	public:
-		std::string file_path;
 		/**
 		 * @brief Constructor
 		 *
@@ -181,15 +212,14 @@ namespace openshot {
 		 * @param file_path The input file being processed
 		 */
 		InvalidFile(std::string message, std::string file_path)
-			: ExceptionBase(message), file_path(file_path) { }
+			: FileExceptionBase(message, file_path) { }
 		virtual ~InvalidFile() noexcept {}
 	};
 
 	/// Exception when no valid format is found for a file
-	class InvalidFormat : public ExceptionBase
+	class InvalidFormat : public FileExceptionBase
 	{
 	public:
-		std::string file_path;
 		/**
 		 * @brief Constructor
 		 *
@@ -197,15 +227,14 @@ namespace openshot {
 		 * @param file_path (optional) The input file being processed
 		 */
 		InvalidFormat(std::string message, std::string file_path="")
-			: ExceptionBase(message), file_path(file_path) { }
+			: FileExceptionBase(message, file_path) { }
 		virtual ~InvalidFormat() noexcept {}
 	};
 
 	/// Exception for invalid JSON
-	class InvalidJSON : public ExceptionBase
+	class InvalidJSON : public FileExceptionBase
 	{
 	public:
-		std::string file_path;
 		/**
 		 * @brief Constructor
 		 *
@@ -213,15 +242,14 @@ namespace openshot {
 		 * @param file_path (optional) The input file being processed
 		 */
 		InvalidJSON(std::string message, std::string file_path="")
-			: ExceptionBase(message), file_path(file_path) { }
+			: FileExceptionBase(message, file_path) { }
 		virtual ~InvalidJSON() noexcept {}
 	};
 
 	/// Exception when invalid encoding options are used
-	class InvalidOptions : public ExceptionBase
+	class InvalidOptions : public FileExceptionBase
 	{
 	public:
-		std::string file_path;
 		/**
 		 * @brief Constructor
 		 *
@@ -229,15 +257,14 @@ namespace openshot {
 		 * @param file_path (optional) The input file being processed
 		 */
 		InvalidOptions(std::string message, std::string file_path="")
-			: ExceptionBase(message), file_path(file_path) { }
+			: FileExceptionBase(message, file_path) { }
 		virtual ~InvalidOptions() noexcept {}
 	};
 
 	/// Exception when invalid sample rate is detected during encoding
-	class InvalidSampleRate : public ExceptionBase
+	class InvalidSampleRate : public FileExceptionBase
 	{
 	public:
-		std::string file_path;
 		/**
 		 * @brief Constructor
 		 *
@@ -245,7 +272,7 @@ namespace openshot {
 		 * @param file_path (optional) The input file being processed
 		 */
 		InvalidSampleRate(std::string message, std::string file_path="")
-			: ExceptionBase(message), file_path(file_path) { }
+			: FileExceptionBase(message, file_path) { }
 		virtual ~InvalidSampleRate() noexcept {}
 	};
 
@@ -263,13 +290,19 @@ namespace openshot {
 		InvalidJSONKey(std::string message, std::string json)
 			: ExceptionBase(message), json(json) { }
 		virtual ~InvalidJSONKey() noexcept {}
+        std::string py_message() const override {
+            std::string out_msg = m_message +
+                " for JSON data " +
+                (json.size() > 100 ? " (abbreviated): " : ": ")
+                + json.substr(0, 99);
+            return out_msg;
+        }
 	};
 
 	/// Exception when no streams are found in the file
-	class NoStreamsFound : public ExceptionBase
+	class NoStreamsFound : public FileExceptionBase
 	{
 	public:
-		std::string file_path;
 		/**
 		 * @brief Constructor
 		 *
@@ -277,7 +310,7 @@ namespace openshot {
 		 * @param file_path (optional) The input file being processed
 		 */
 		NoStreamsFound(std::string message, std::string file_path="")
-			: ExceptionBase(message), file_path(file_path) { }
+			: FileExceptionBase(message, file_path) { }
 		virtual ~NoStreamsFound() noexcept {}
 	};
 
@@ -297,6 +330,12 @@ namespace openshot {
 		OutOfBoundsFrame(std::string message, int64_t frame_requested, int64_t max_frames)
 			: ExceptionBase(message), FrameRequested(frame_requested), MaxFrames(max_frames) { }
 		virtual ~OutOfBoundsFrame() noexcept {}
+        std::string py_message() const override {
+            std::string out_msg(m_message
+                + " Frame requested: " + std::to_string(FrameRequested)
+                + " Max frames: " + std::to_string(MaxFrames));
+            return out_msg;
+        }
 	};
 
 	/// Exception for an out of bounds key-frame point.
@@ -315,13 +354,18 @@ namespace openshot {
 		OutOfBoundsPoint(std::string message, int point_requested, int max_points)
 			: ExceptionBase(message), PointRequested(point_requested), MaxPoints(max_points) { }
 		virtual ~OutOfBoundsPoint() noexcept {}
+        std::string py_message() const override {
+            std::string out_msg(m_message
+                + " Point requested: " + std::to_string(PointRequested)
+                + " Max point: " + std::to_string(MaxPoints));
+            return out_msg;
+        }
 	};
 
 	/// Exception when memory could not be allocated
-	class OutOfMemory : public ExceptionBase
+	class OutOfMemory : public FileExceptionBase
 	{
 	public:
-		std::string file_path;
 		/**
 		 * @brief Constructor
 		 *
@@ -329,15 +373,14 @@ namespace openshot {
 		 * @param file_path (optional) The input file being processed
 		 */
 		OutOfMemory(std::string message, std::string file_path="")
-			: ExceptionBase(message), file_path(file_path) { }
+			: FileExceptionBase(message, file_path) { }
 		virtual ~OutOfMemory() noexcept {}
 	};
 
 	/// Exception when a reader is closed, and a frame is requested
-	class ReaderClosed : public ExceptionBase
+	class ReaderClosed : public FileExceptionBase
 	{
 	public:
-		std::string file_path;
 		/**
 		 * @brief Constructor
 		 *
@@ -345,15 +388,14 @@ namespace openshot {
 		 * @param file_path (optional) The input file being processed
 		 */
 		ReaderClosed(std::string message, std::string file_path="")
-			: ExceptionBase(message), file_path(file_path) { }
+			: FileExceptionBase(message, file_path) { }
 		virtual ~ReaderClosed() noexcept {}
 	};
 
 	/// Exception when resample fails
-	class ResampleError : public ExceptionBase
+	class ResampleError : public FileExceptionBase
 	{
 	public:
-		std::string file_path;
 		/**
 		 * @brief Constructor
 		 *
@@ -361,7 +403,7 @@ namespace openshot {
 		 * @param file_path (optional) The input file being processed
 		 */
 		ResampleError(std::string message, std::string file_path="")
-			: ExceptionBase(message), file_path(file_path) { }
+			: FileExceptionBase(message, file_path) { }
 		virtual ~ResampleError() noexcept {}
 	};
 
@@ -371,10 +413,9 @@ namespace openshot {
 	/// Exception when too many seek attempts happen
 	class
 	__attribute__ ((deprecated(TMS_DEP_MSG)))
-	TooManySeeks : public ExceptionBase
+	TooManySeeks : public FileExceptionBase
 	{
 	public:
-		std::string file_path;
 		/**
 		 * @brief Constructor
 		 *
@@ -387,10 +428,9 @@ namespace openshot {
 #endif
 
 	/// Exception when a writer is closed, and a frame is requested
-	class WriterClosed : public ExceptionBase
+	class WriterClosed : public FileExceptionBase
 	{
 	public:
-		std::string file_path;
 		/**
 		 * @brief Constructor
 		 *
@@ -398,7 +438,7 @@ namespace openshot {
 		 * @param file_path (optional) The output file being written
 		 */
 		WriterClosed(std::string message, std::string file_path="")
-			: ExceptionBase(message), file_path(file_path) { }
+			: FileExceptionBase(message, file_path) { }
 		virtual ~WriterClosed() noexcept {}
 	};
 }


### PR DESCRIPTION
- Most exceptions are now based on one of two new base classes,  FileExceptionBase and FrameExceptionBase. Both inherit from ExceptionBase.
- **All** exception classes derived from ExceptionBase now export a `py_message()` method
  (inherited or defined) which constructs a message for Python that includes **all** arguments to the exception, not just the `why()` text.
- Python's exception handling is updated to catch `openshot::ExceptionBase` and display `py_message()` instead of `why()`
- (I didn't modify `why()` because it returns `char*`; `py_message()` returns a `std::string`. `why()` is a `const` method not conducive to constructing and returning a temporary `char*`.)