### PR TITLE
Link catch-main wtih Catch2::Catch2

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -95,6 +95,7 @@ endif()
 # Create object library for test executable main(),
 # to avoid recompiling for every test
 add_library(catch-main OBJECT catch_main.cpp)
+target_link_libraries(catch-main PUBLIC Catch2::Catch2)
 
 foreach(tname ${OPENSHOT_TESTS})
   add_executable(openshot-${tname}-test ${tname}.cpp $<TARGET_OBJECTS:catch-main>)


### PR DESCRIPTION
Newer versions of Catch2 require C++14 to compile, a requirement that won't be propagated to the object library unless we link it to the IMPORTED Catch2::Catch2 target.

Fixes #707 (I _believe_)