### PR TITLE
Add explicit QtSvg dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
         sudo apt install \
           cmake swig doxygen graphviz curl lcov \
           libasound2-dev \
-          qtbase5-dev qtbase5-dev-tools \
+          qtbase5-dev qtbase5-dev-tools libqt5svg5-dev \
           libfdk-aac-dev libavcodec-dev libavformat-dev libavdevice-dev libavutil-dev libavfilter-dev libswscale-dev libpostproc-dev libswresample-dev \
           libzmq3-dev libmagick++-dev \
           libopencv-dev libprotobuf-dev protobuf-compiler

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -284,7 +284,7 @@ endif ()
 
 ################# QT5 ###################
 # Find QT5 libraries
-set(_qt_components Core Gui Widgets)
+set(_qt_components Core Gui Widgets Svg)
 find_package(Qt5 COMPONENTS ${_qt_components} REQUIRED)
 
 foreach(_qt_comp IN LISTS _qt_components)


### PR DESCRIPTION
A QtImageReader unit test failure building Fedora packages made me realize that we have a silent dependency on QtSvg. Normally it's pulled in by QtGui, so it's not an issue, but that assumes it's been _installed_ at all — which isn't a good assumption, when packaging for Linux distros. So, better to make that dependency explicit.
