### PR TITLE
Rewrite Crop effect using QPainter

### DIFF
--- a/src/AudioReaderSource.cpp
+++ b/src/AudioReaderSource.cpp
@@ -30,6 +30,10 @@
 
 #include "AudioReaderSource.h"
 #include "Exceptions.h"
+#include "Frame.h"
+#include "ZmqLogger.h"
+
+#include <OpenShotAudio.h>
 
 using namespace std;
 using namespace openshot;

--- a/src/AudioReaderSource.h
+++ b/src/AudioReaderSource.h
@@ -31,8 +31,8 @@
 #ifndef OPENSHOT_AUDIOREADERSOURCE_H
 #define OPENSHOT_AUDIOREADERSOURCE_H
 
-#include <iomanip>
 #include "ReaderBase.h"
+
 #include <OpenShotAudio.h>
 
 /// This namespace is the default namespace for all code in the openshot library

--- a/src/CacheBase.h
+++ b/src/CacheBase.h
@@ -32,11 +32,13 @@
 #define OPENSHOT_CACHE_BASE_H
 
 #include <memory>
-#include <cstdlib>
-#include "Frame.h"
+
 #include "Json.h"
 
+#include <OpenShotAudio.h>
+
 namespace openshot {
+	class Frame;
 
 	/**
 	 * @brief All cache managers in libopenshot are based on this CacheBase class

--- a/src/CacheDisk.cpp
+++ b/src/CacheDisk.cpp
@@ -30,7 +30,9 @@
 
 #include "CacheDisk.h"
 #include "Exceptions.h"
+#include "Frame.h"
 #include "QtUtilities.h"
+
 #include <Qt>
 #include <QString>
 #include <QTextStream>

--- a/src/CacheDisk.h
+++ b/src/CacheDisk.h
@@ -34,11 +34,13 @@
 #include <map>
 #include <deque>
 #include <memory>
+
 #include "CacheBase.h"
-#include "Frame.h"
+
 #include <QDir>
 
 namespace openshot {
+	class Frame;
 
 	/**
 	 * @brief This class is a disk-based cache manager for Frame objects.

--- a/src/CacheMemory.cpp
+++ b/src/CacheMemory.cpp
@@ -30,6 +30,7 @@
 
 #include "CacheMemory.h"
 #include "Exceptions.h"
+#include "Frame.h"
 
 using namespace std;
 using namespace openshot;

--- a/src/CacheMemory.h
+++ b/src/CacheMemory.h
@@ -34,10 +34,11 @@
 #include <map>
 #include <deque>
 #include <memory>
+
 #include "CacheBase.h"
-#include "Frame.h"
 
 namespace openshot {
+	class Frame;
 
 	/**
 	 * @brief This class is a memory-based cache manager for Frame objects.

--- a/src/ChunkReader.h
+++ b/src/ChunkReader.h
@@ -31,16 +31,16 @@
 #ifndef OPENSHOT_CHUNK_READER_H
 #define OPENSHOT_CHUNK_READER_H
 
-#include "ReaderBase.h"
 #include <string>
 #include <memory>
 
-#include "Frame.h"
+#include "ReaderBase.h"
 #include "Json.h"
 #include "CacheMemory.h"
 
 namespace openshot
 {
+	class Frame;
 
 	/**
 	 * @brief This struct holds the location of a frame within a chunk.
@@ -137,7 +137,7 @@ namespace openshot
 		void SetChunkSize(int64_t new_size) { chunk_size = new_size; };
 
 		/// Get the cache object used by this reader (always return NULL for this reader)
-		openshot::CacheMemory* GetCache() override { return NULL; };
+		openshot::CacheMemory* GetCache() override { return nullptr; };
 
 		/// @brief Get an openshot::Frame object for a specific frame number of this reader.
 		/// @returns				The requested frame (containing the image and audio)

--- a/src/DummyReader.cpp
+++ b/src/DummyReader.cpp
@@ -30,6 +30,7 @@
 
 #include "DummyReader.h"
 #include "Exceptions.h"
+#include "Frame.h"
 
 using namespace openshot;
 

--- a/src/ImageReader.cpp
+++ b/src/ImageReader.cpp
@@ -33,6 +33,7 @@
 
 #include "ImageReader.h"
 #include "Exceptions.h"
+#include "Frame.h"
 
 using namespace openshot;
 

--- a/src/Qt/VideoCacheThread.h
+++ b/src/Qt/VideoCacheThread.h
@@ -34,6 +34,7 @@
 #include "../OpenMPUtilities.h"
 #include "../ReaderBase.h"
 #include "../RendererBase.h"
+#include "../CacheBase.h"
 
 namespace openshot
 {

--- a/src/QtHtmlReader.cpp
+++ b/src/QtHtmlReader.cpp
@@ -32,6 +32,8 @@
 
 #include "QtHtmlReader.h"
 #include "Exceptions.h"
+#include "Frame.h"
+
 #include <QImage>
 #include <QPainter>
 #include <QTextDocument>

--- a/src/QtImageReader.cpp
+++ b/src/QtImageReader.cpp
@@ -34,11 +34,12 @@
 #include "Clip.h"
 #include "CacheMemory.h"
 #include "Timeline.h"
-#include <QtCore/QString>
-#include <QtGui/QImage>
-#include <QtGui/QPainter>
-#include <QtGui/QIcon>
-#include <QtGui/QImageReader>
+
+#include <QString>
+#include <QImage>
+#include <QPainter>
+#include <QIcon>
+#include <QImageReader>
 
 #if USE_RESVG == 1
 	// If defined and found in CMake, utilize the libresvg for parsing

--- a/src/QtImageReader.h
+++ b/src/QtImageReader.h
@@ -31,14 +31,13 @@
 #ifndef OPENSHOT_QIMAGE_READER_H
 #define OPENSHOT_QIMAGE_READER_H
 
-#include <cmath>
-#include <ctime>
-#include <iostream>
-#include <omp.h>
-#include <stdio.h>
 #include <memory>
 
 #include "ReaderBase.h"
+
+#include <QImage>
+#include <QSize>
+#include <QString>
 
 namespace openshot
 {

--- a/src/QtTextReader.cpp
+++ b/src/QtTextReader.cpp
@@ -32,6 +32,8 @@
 
 #include "QtTextReader.h"
 #include "Exceptions.h"
+#include "Frame.h"
+
 #include <QImage>
 #include <QPainter>
 

--- a/src/QtTextReader.h
+++ b/src/QtTextReader.h
@@ -35,15 +35,12 @@
 
 #include "ReaderBase.h"
 
-#include <cmath>
-#include <ctime>
-#include <iostream>
-#include <omp.h>
-#include <stdio.h>
 #include <memory>
+
 #include "CacheMemory.h"
 #include "Enums.h"
 
+#include <QFont>
 
 class QImage;
 

--- a/src/ReaderBase.cpp
+++ b/src/ReaderBase.cpp
@@ -29,6 +29,8 @@
  */
 
 #include "ReaderBase.h"
+#include "ClipBase.h"
+#include "Frame.h"
 
 using namespace openshot;
 

--- a/src/ReaderBase.h
+++ b/src/ReaderBase.h
@@ -31,26 +31,23 @@
 #ifndef OPENSHOT_READER_BASE_H
 #define OPENSHOT_READER_BASE_H
 
-#include <iostream>
-#include <iomanip>
+#include <map>
 #include <memory>
-#include <cstdlib>
-#include <sstream>
-#include "CacheMemory.h"
+#include <string>
+#include <vector>
+
 #include "ChannelLayouts.h"
-#include "ClipBase.h"
 #include "Fraction.h"
-#include "Frame.h"
 #include "Json.h"
-#include "ZmqLogger.h"
-#include <QString>
-#include <QGraphicsItem>
-#include <QGraphicsScene>
-#include <QGraphicsPixmapItem>
-#include <QPixmap>
+
+#include <OpenShotAudio.h>
 
 namespace openshot
 {
+	class ClipBase;
+	class CacheBase;
+	class Frame;
+
 	/**
 	 * @brief This struct contains info about a media file, such as height, width, frames per second, etc...
 	 *

--- a/src/TextReader.cpp
+++ b/src/TextReader.cpp
@@ -33,6 +33,7 @@
 
 #include "TextReader.h"
 #include "Exceptions.h"
+#include "Frame.h"
 
 using namespace openshot;
 

--- a/src/effects/Caption.cpp
+++ b/src/effects/Caption.cpp
@@ -38,6 +38,8 @@
 #include <QRect>
 #include <QPen>
 #include <QBrush>
+#include <QPainter>
+#include <QPainterPath>
 
 using namespace openshot;
 

--- a/src/effects/Crop.cpp
+++ b/src/effects/Crop.cpp
@@ -30,6 +30,13 @@
 
 #include "Crop.h"
 #include "Exceptions.h"
+#include "KeyFrame.h"
+
+#include <QImage>
+#include <QPainter>
+#include <QRectF>
+#include <QRect>
+#include <QSize>
 
 using namespace openshot;
 
@@ -68,80 +75,57 @@ std::shared_ptr<openshot::Frame> Crop::GetFrame(std::shared_ptr<openshot::Frame>
 	// Get the frame's image
 	std::shared_ptr<QImage> frame_image = frame->GetImage();
 
-    // Get transparent color target image (which will become the cropped image)
-    auto cropped_image = std::make_shared<QImage>(
-            frame_image->width(), frame_image->height(), QImage::Format_RGBA8888_Premultiplied);
-    cropped_image->fill(QColor(QString::fromStdString("transparent")));
-
 	// Get current keyframe values
 	double left_value = left.GetValue(frame_number);
 	double top_value = top.GetValue(frame_number);
 	double right_value = right.GetValue(frame_number);
 	double bottom_value = bottom.GetValue(frame_number);
 
-    // Get the current shift amount (if any... to slide the image around in the cropped area)
+    // Get the current shift amount
     double x_shift = x.GetValue(frame_number);
     double y_shift = y.GetValue(frame_number);
 
-	// Get pixel array pointers
-	unsigned char *pixels = (unsigned char *) frame_image->bits();
-    unsigned char *cropped_pixels = (unsigned char *) cropped_image->bits();
+	QSize sz = frame_image->size();
 
-	// Get pixels sizes of all crop sides
-	int top_bar_height = top_value * frame_image->height();
-	int bottom_bar_height = bottom_value * frame_image->height();
-	int left_bar_width = left_value * frame_image->width();
-	int right_bar_width = right_value * frame_image->width();
-	int column_offset = x_shift * frame_image->width();
-	int row_offset = y_shift * frame_image->height();
+    // Compute destination rectangle to paint into
+    QRectF paint_r(
+            left_value * sz.width(), top_value * sz.height(),
+            std::max(0.0, 1.0 - left_value - right_value) * sz.width(),
+            std::max(0.0, 1.0 - top_value - bottom_value) * sz.height());
 
-	// Image copy variables
-	int image_width = frame_image->width();
-    int src_start = left_bar_width;
-    int dst_start = left_bar_width;
-    int copy_length = frame_image->width() - right_bar_width - left_bar_width;
+    // Copy rectangle is destination translated by offsets
+    QRectF copy_r = paint_r;
+    copy_r.translate(x_shift * sz.width(), y_shift * sz.height());
 
-    // Adjust for x offset
-    int copy_offset = 0;
-
-    if (column_offset < 0) {
-        // dest to the right
-        src_start += column_offset;
-        if (src_start < 0) {
-            int diff = 0 - src_start; // how far under 0 are we?
-            src_start = 0;
-            dst_start += diff;
-            copy_offset = -diff;
-        } else {
-            copy_offset = 0;
-        }
-
-    } else {
-        // dest to the left
-        src_start += column_offset;
-        if (image_width - src_start >= copy_length) {
-            // We have plenty pixels, use original copy-length
-            copy_offset = 0;
-        } else {
-            // We don't have enough pixels, shorten copy-length
-            copy_offset = (image_width - src_start) - copy_length;
-        }
+    // Constrain offset copy rect to stay within image borders
+    if (copy_r.left() < 0) {
+        paint_r.setLeft(paint_r.left() - copy_r.left());
+        copy_r.setLeft(0);
+    }
+    if (copy_r.right() > sz.width()) {
+        paint_r.setRight(paint_r.right() - (copy_r.right() - sz.width()));
+        copy_r.setRight(sz.width());
+    }
+    if (copy_r.top() < 0) {
+        paint_r.setTop(paint_r.top() - copy_r.top());
+        copy_r.setTop(0);
+    }
+    if (copy_r.bottom() > sz.height()) {
+        paint_r.setBottom(paint_r.bottom() - (copy_r.bottom() - sz.height()));
+        copy_r.setBottom(sz.height());
     }
 
-	// Loop through rows of pixels
-	for (int row = 0; row < frame_image->height(); row++) {
-        int adjusted_row = row - row_offset;
-	    // Is this row visible?
-        if (adjusted_row >= top_bar_height && adjusted_row < (frame_image->height() - bottom_bar_height) && (copy_length + copy_offset > 0)) {
-            // Copy image (row by row, with offsets for x and y offset, and src/dst starting points for column filtering)
-            memcpy(&cropped_pixels[((adjusted_row * frame_image->width()) + dst_start) * 4],
-                   &pixels[((row * frame_image->width()) + src_start) * 4],
-                   sizeof(char) * (copy_length + copy_offset) * 4);
-		}
-	}
+    QImage cropped(sz, QImage::Format_RGBA8888_Premultiplied);
+    cropped.fill(Qt::transparent);
+
+    const QImage src(*frame_image);
+
+    QPainter p(&cropped);
+    p.drawImage(paint_r, src, copy_r);
+    p.end();
 
 	// Set frame image
-	frame->AddImage(cropped_image);
+	frame->AddImage(std::make_shared<QImage>(cropped.copy()));
 
 	// return the modified frame
 	return frame;

--- a/src/effects/Crop.cpp
+++ b/src/effects/Crop.cpp
@@ -40,15 +40,14 @@
 
 using namespace openshot;
 
-/// Blank constructor, useful when using Json to load the effect properties
-Crop::Crop() : left(0.0), top(0.0), right(0.0), bottom(0.0), x(0.0), y(0.0) {
-	// Init effect properties
-	init_effect_details();
-}
+/// Default constructor, useful when using Json to load the effect properties
+Crop::Crop() : Crop::Crop(0.0, 0.0, 0.0, 0.0, 0.0, 0.0) {}
 
-// Default constructor
-Crop::Crop(Keyframe left, Keyframe top, Keyframe right, Keyframe bottom) :
-		left(left), top(top), right(right), bottom(bottom), x(0.0), y(0.0)
+Crop::Crop(
+    Keyframe left, Keyframe top,
+    Keyframe right, Keyframe bottom,
+    Keyframe x, Keyframe y) :
+		left(left), top(top), right(right), bottom(bottom), x(x), y(y)
 {
 	// Init effect properties
 	init_effect_details();

--- a/src/effects/Crop.h
+++ b/src/effects/Crop.h
@@ -76,7 +76,10 @@ namespace openshot
 		/// @param top The curve to adjust the top bar size (between 0 and 1)
 		/// @param right The curve to adjust the right bar size (between 0 and 1)
 		/// @param bottom The curve to adjust the bottom bar size (between 0 and 1)
-		Crop(Keyframe left, Keyframe top, Keyframe right, Keyframe bottom);
+        /// @param x x-offset of original image in output frame (-1.0 - 1.0)
+        /// @param y y-offset of original image in output frame (-1.0 - 1.0)
+		Crop(Keyframe left, Keyframe top, Keyframe right, Keyframe bottom,
+             Keyframe x=0.0, Keyframe y=0.0);
 
 		/// @brief This method is required for all derived classes of ClipBase, and returns a
 		/// new openshot::Frame object. All Clip keyframes and effects are resolved into
@@ -84,7 +87,10 @@ namespace openshot
 		///
 		/// @returns A new openshot::Frame object
 		/// @param frame_number The frame number (starting at 1) of the clip or effect on the timeline.
-		std::shared_ptr<openshot::Frame> GetFrame(int64_t frame_number) override { return GetFrame(std::make_shared<openshot::Frame>(), frame_number); }
+		std::shared_ptr<openshot::Frame>
+        GetFrame(int64_t frame_number) override {
+            return GetFrame(std::make_shared<openshot::Frame>(), frame_number);
+        }
 
 		/// @brief This method is required for all derived classes of ClipBase, and returns a
 		/// modified openshot::Frame object
@@ -95,7 +101,8 @@ namespace openshot
 		/// @returns The modified openshot::Frame object
 		/// @param frame The frame object that needs the clip or effect applied to it
 		/// @param frame_number The frame number (starting at 1) of the clip or effect on the timeline.
-		std::shared_ptr<openshot::Frame> GetFrame(std::shared_ptr<openshot::Frame> frame, int64_t frame_number) override;
+		std::shared_ptr<openshot::Frame>
+        GetFrame(std::shared_ptr<openshot::Frame> frame, int64_t frame_number) override;
 
 		// Get and Set JSON methods
 		std::string Json() const override; ///< Generate JSON string of this object

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -64,6 +64,8 @@ set(OPENSHOT_TESTS
   ReaderBase
   Settings
   Timeline
+  # Effects
+  Crop
 )
 
 # ImageMagick related test files

--- a/tests/CacheDisk.cpp
+++ b/tests/CacheDisk.cpp
@@ -34,6 +34,7 @@
 #include <catch2/catch.hpp>
 
 #include "CacheDisk.h"
+#include "Frame.h"
 #include "Json.h"
 
 using namespace openshot;

--- a/tests/CacheMemory.cpp
+++ b/tests/CacheMemory.cpp
@@ -34,6 +34,7 @@
 #include <catch2/catch.hpp>
 
 #include "CacheMemory.h"
+#include "Frame.h"
 #include "Json.h"
 
 using namespace openshot;

--- a/tests/Crop.cpp
+++ b/tests/Crop.cpp
@@ -1,0 +1,164 @@
+/**
+ * @file
+ * @brief Unit tests for openshot::Crop effect
+ * @author Jonathan Thomas <jonathan@openshot.org>
+ * @author FeRD (Frank Dana) <ferdnyc@gmail.com>
+ *
+ * @ref License
+ */
+
+/* LICENSE
+ *
+ * Copyright (c) 2008-2021 OpenShot Studios, LLC
+ * <http://www.openshotstudios.com/>. This file is part of
+ * OpenShot Library (libopenshot), an open-source project dedicated to
+ * delivering high quality video editing and animation solutions to the
+ * world. For more information visit <http://www.openshot.org/>.
+ *
+ * OpenShot Library (libopenshot) is free software: you can redistribute it
+ * and/or modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * OpenShot Library (libopenshot) is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with OpenShot Library. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <memory>
+
+#include <catch2/catch.hpp>
+
+#include "Frame.h"
+#include "effects/Crop.h"
+
+#include <QColor>
+#include <QImage>
+#include <QPainter>
+#include <QSize>
+
+TEST_CASE( "default constructor", "[libopenshot][effect][crop]" )
+{
+    // solid green frame
+    auto f = std::make_shared<openshot::Frame>(1, 1280, 720, "#00ff00");
+
+    // Default constructor should have no cropping
+    openshot::Crop e;
+
+    auto f_out = e.GetFrame(f, 1);
+    std::shared_ptr<QImage> i = f_out->GetImage();
+
+    // Check pixels near edges (should all be green)
+    std::vector<QColor> pixels {
+        i->pixelColor(400, 2),
+        i->pixelColor(1279, 500),
+        i->pixelColor(800, 718),
+        i->pixelColor(1, 200)
+    };
+
+    QColor green{Qt::green};
+    CHECK(pixels[0] == green);
+    CHECK(pixels[1] == green);
+    CHECK(pixels[2] == green);
+    CHECK(pixels[3] == green);
+}
+
+TEST_CASE( "basic cropping", "[libopenshot][effect][crop]" )
+{
+    auto frame = std::make_shared<openshot::Frame>(1, 1280, 720, "#00ff00");
+
+    // Crop 10% off the input frame on all four sides
+    openshot::Keyframe left(0.1);
+    openshot::Keyframe top(0.1);
+    openshot::Keyframe right(0.1);
+    openshot::Keyframe bottom(0.1);
+    openshot::Crop e(left, top, right, bottom);
+
+    auto frame_out = e.GetFrame(frame, 1);
+    std::shared_ptr<QImage> i = frame_out->GetImage();
+
+    QSize sz(1280, 720);
+    CHECK(i->size() == sz);
+
+    // Green inside the crop region, transparent outside
+    QColor green{Qt::green};
+    QColor trans{Qt::transparent};
+
+    QColor center_pixel = i->pixelColor(640, 360);
+    CHECK(center_pixel == green);
+
+    std::vector<QColor> edge_pixels {
+        i->pixelColor(50, 200),
+        i->pixelColor(400, 20),
+        i->pixelColor(1250, 500),
+        i->pixelColor(800, 715)
+    };
+    CHECK(edge_pixels[0] == trans);
+    CHECK(edge_pixels[1] == trans);
+    CHECK(edge_pixels[2] == trans);
+    CHECK(edge_pixels[3] == trans);
+}
+
+TEST_CASE( "region collapsing", "[libopenshot][effect][crop]" )
+{
+    auto frame = std::make_shared<openshot::Frame>(1, 1920, 1080, "#ff00ff");
+
+    // Crop 50% off left and right sides (== crop out entire image)
+    openshot::Keyframe left(0.4);
+    openshot::Keyframe right(0.6);
+    openshot::Keyframe none(0.0);
+    openshot::Crop e(left, none, right, none);
+
+    auto frame_out = e.GetFrame(frame, 1);
+    auto i = frame_out->GetImage();
+
+    // Only true if all pixels have been cropped away (as expected)
+    CHECK(i->allGray());
+}
+
+TEST_CASE( "x/y offsets", "[libopenshot][effect][crop]" )
+{
+    auto frame = std::make_shared<openshot::Frame>(1, 1280, 720, "#ff0000");
+    auto frame_img = frame->GetImage();
+    QImage img(*frame_img);
+
+    // Make input frame left-half red, right-half blue
+    QPainter p(&img);
+    p.fillRect(QRect(640, 0, 640, 720), Qt::blue);
+    p.end();
+
+    frame->AddImage(std::make_shared<QImage>(img));
+
+    // Crop 20% off all four sides, and shift the source window x +33⅓ %
+    openshot::Keyframe sides(0.2);
+    openshot::Keyframe x(0.3);
+    openshot::Crop e(sides, sides, sides, sides, x);
+
+    auto frame_out = e.GetFrame(frame, 1);
+    std::shared_ptr<QImage> i = frame_out->GetImage();
+
+    // Entire cropped region should be blue (due to x-offset), and will be
+    // off-center (due to being only 50% wide instead of 60%)
+    QColor blue{Qt::blue};
+    QColor trans{Qt::transparent};
+
+    std::vector<QColor> edge_pixels {
+        i->pixelColor(258, 146),
+        i->pixelColor(894, 146),
+        i->pixelColor(894, 574),
+        i->pixelColor(258, 574)
+    };
+    CHECK(edge_pixels[0] == blue);
+    CHECK(edge_pixels[1] == blue);
+    CHECK(edge_pixels[2] == blue);
+    CHECK(edge_pixels[3] == blue);
+
+    // This pixel would normally be inside the cropping.
+    // The x-offset moves it outside of the source image area,
+    // so it becomes a transparent pixel
+    CHECK(i->pixelColor(900, 360) == trans);
+}


### PR DESCRIPTION
The crop effect was using some frankly byzantine pointer math and `memcpy()` calls to implement what a couple of `QRect`s and `QPainter::drawImage()` can make child's play. So, this PR rewrites it to use exactly those tools. The operations performed are the same, just without the bit-banging.

(Actually, the algorithm here is slightly improved. With the previous implementation, setting both the left and right crop sizes to `0.5` left a thin sliver of visible image in the output. Ditto top and bottom. Here, that's eliminated, and left `0.5` + right `0.5` == crop out the entire frame.)