### PR TITLE
Protecting a caption effect with no Clip (i.e. effect added directly to timeline)

### DIFF
--- a/src/effects/Caption.cpp
+++ b/src/effects/Caption.cpp
@@ -129,7 +129,7 @@ std::shared_ptr<openshot::Frame> Caption::GetFrame(std::shared_ptr<openshot::Fra
 	Timeline* timeline = NULL;
 	Fraction fps;
 	double scale_factor = 1.0; // amount of scaling needed for text (based on preview window size)
-	if (clip->ParentTimeline() != NULL) {
+	if (clip && clip->ParentTimeline() != NULL) {
 		timeline = (Timeline*) clip->ParentTimeline();
 	} else if (this->ParentTimeline() != NULL) {
 		timeline = (Timeline*) this->ParentTimeline();


### PR DESCRIPTION
This can't happen in openshot-qt, but it can definitely happen when using the OpenShot Cloud API or libopenshot directly, to add the Caption effect directly to a layer (affecting many different clips)