### PR TITLE
CMake: Set -DDEBUG for debug builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,6 +99,12 @@ if(ENABLE_TESTS)
   set(BUILD_TESTING ${ENABLE_TESTS})
 endif()
 
+### JUCE requires one of -DDEBUG or -DNDEBUG set on the
+### compile command line. CMake automatically sets -DNDEBUG
+### on all non-debug configs, so we'll just add -DDEBUG to
+### the debug build flags
+set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -DDEBUG")
+
 #### Work around a GCC < 9 bug with handling of _Pragma() in macros
 #### See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=55578
 if ((${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU") AND


### PR DESCRIPTION
We already do this in libopenshot-audio for JUCE, but that flag doesn't propagate through the `EXPORTED` interface (and probably shouldn't be forced to), so we should do it here as well.