### PR TITLE
Use $<INSTALL_PREFIX> generator expression, to set mac library path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,98 +1,174 @@
 name: libopenshot CI Build
 on: [push, pull_request]
+
 jobs:
   build:
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.sys.os }}
     strategy:
       matrix:
-        os: [ubuntu-18.04, ubuntu-20.04]
+        sys:
+          - { os: ubuntu-18.04, shell: bash }
+          - { os: ubuntu-latest, shell: bash }
+          - { os: macos-latest, shell: bash }
+          - { os: windows-latest, shell: 'msys2 {0}' }
         compiler:
-         - { cc: gcc, cpp: g++ }
-         - { cc: clang, cpp: clang++ }
+          - { cc: gcc, cxx: g++ }
+          - { cc: clang, cxx: clang++ }
+        exclude:
+          # Windows clang isn't being our friend,
+          # JUCE seems to think it can use _get_tzname there
+          # (it can't)
+          - sys: { os: windows-latest, shell: 'msys2 {0}' }
+            compiler: { cc: clang, cxx: clang++ }
+    defaults:
+      run:
+        shell: "${{ matrix.sys.shell }}"
     env:
       CC: ${{ matrix.compiler.cc }}
-      CXX: ${{ matrix.compiler.cpp }}
+      CXX: ${{ matrix.compiler.cxx }}
       CODECOV_TOKEN: 'dc94d508-39d3-4369-b1c6-321749f96f7c'
 
     steps:
-    - uses: actions/checkout@v2
-      with:
-        # Work around a codecov issue detecting commit SHAs
-        # see: https://community.codecov.io/t/issue-detecting-commit-sha-please-run-actions-checkout-with-fetch-depth-1-or-set-to-0/2571
-        fetch-depth: 0
+      - uses: actions/checkout@v2
+        with:
+          # Work around a codecov issue detecting commit SHAs
+          # see: https://community.codecov.io/t/issue-detecting-commit-sha-please-run-actions-checkout-with-fetch-depth-1-or-set-to-0/2571
+          fetch-depth: 0
 
-    - name: Checkout OpenShotAudio
-      uses: actions/checkout@v2
-      with:
-        repository: OpenShot/libopenshot-audio
-        path: audio
+      - name: Checkout OpenShotAudio
+        uses: actions/checkout@v2
+        with:
+          repository: OpenShot/libopenshot-audio
+          path: audio
 
-    - uses: haya14busa/action-cond@v1
-      id: coverage
-      with:
-        cond: ${{ matrix.compiler.cc == 'gcc' }}
-        if_true: "-DENABLE_COVERAGE:BOOL=1"
-        if_false: "-DENABLE_COVERAGE:BOOL=0"
+      - uses: haya14busa/action-cond@v1
+        id: generator
+        with:
+          cond: ${{ runner.os == 'Windows' }}
+          if_true: "MinGW Makefiles"
+          if_false: "Unix Makefiles"
 
-    - name: Install dependencies
-      shell: bash
-      run: |
-        sudo apt update
-        sudo apt remove libzmq5  # See actions/virtual-environments#3317
-        sudo apt install \
-          cmake swig doxygen graphviz curl lcov \
-          libasound2-dev \
-          qtbase5-dev qtbase5-dev-tools libqt5svg5-dev \
-          libfdk-aac-dev libavcodec-dev libavformat-dev libavdevice-dev libavutil-dev libavfilter-dev libswscale-dev libpostproc-dev libswresample-dev \
-          libzmq3-dev libmagick++-dev \
-          libopencv-dev libprotobuf-dev protobuf-compiler
-        # Install catch2 package from Ubuntu 20.10, since for some reason
-        # even 20.04 only has Catch 1.12.1 available.
-        wget https://launchpad.net/ubuntu/+archive/primary/+files/catch2_2.13.0-1_all.deb
-        sudo dpkg -i catch2_2.13.0-1_all.deb
+      - uses: haya14busa/action-cond@v1
+        id: coverage
+        with:
+          cond: ${{ matrix.compiler.cc == 'gcc' && runner.os == 'linux' }}
+          if_true: "-DENABLE_COVERAGE:BOOL=1"
 
-    - uses: actions/cache@v2
-      id: cache
-      with:
-        path: audio/build
-        key: audio-${{ matrix.os }}-${{ matrix.compiler.cpp }}-${{ hashFiles('audio/CMakeLists.txt') }}
+      - name: Install Linux dependencies
+        if: ${{ runner.os == 'linux' }}
+        run: |
+          sudo apt update
+          sudo apt remove libzmq5  # See actions/virtual-environments#3317
+          sudo apt install \
+            cmake swig doxygen graphviz curl lcov \
+            libasound2-dev \
+            qtbase5-dev qtbase5-dev-tools libqt5svg5-dev \
+            libfdk-aac-dev libavcodec-dev libavformat-dev libavutil-dev libswscale-dev libswresample-dev \
+            libzmq3-dev libmagick++-dev libbabl-dev \
+            libopencv-dev libprotobuf-dev protobuf-compiler
+          # Install catch2 package from Ubuntu 20.10, since for some reason
+          # even 20.04 only has Catch 1.12.1 available.
+          wget https://launchpad.net/ubuntu/+archive/primary/+files/catch2_2.13.0-1_all.deb
+          sudo dpkg -i catch2_2.13.0-1_all.deb
 
-    - name: Build OpenShotAudio (if not cached)
-      if: steps.cache.outputs.cache-hit != 'true'
-      shell: bash
-      run: |
-        pushd audio
-        if [ ! -d build ]; then
+      - name: Install macOS dependencies
+        if: ${{ runner.os == 'macos' }}
+        run: |
+          brew install \
+            qt5 ffmpeg zeromq cppzmq libomp opencv protobuf babl \
+            python3 swig catch2 doxygen graphviz
+
+      - name: Set up MSYS and install Windows dependencies
+        if: ${{ runner.os == 'Windows' }}
+        uses: msys2/setup-msys2@v2
+        with:
+          release: false
+          update: true
+          install: >-
+              mingw-w64-x86_64-gcc
+              mingw-w64-x86_64-clang
+              mingw-w64-x86_64-lld
+              mingw-w64-x86_64-make
+              mingw-w64-x86_64-cmake
+              mingw-w64-x86_64-pkgconf
+              mingw-w64-x86_64-qt5
+              mingw-w64-x86_64-libvpx
+              mingw-w64-x86_64-ffmpeg
+              mingw-w64-x86_64-zeromq
+              mingw-w64-x86_64-opencv
+              mingw-w64-x86_64-protobuf
+              mingw-w64-x86_64-babl
+              mingw-w64-x86_64-catch
+              mingw-w64-x86_64-python3
+              mingw-w64-x86_64-swig
+
+      - uses: actions/cache@v2
+        id: cache
+        with:
+          path: audio/build
+          key: audio-${{ runner.os }}-${{ matrix.compiler.cxx }}-${{ hashFiles('audio/CMakeLists.txt') }}
+
+      - name: Build OpenShotAudio (if not cached)
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: |
+          pushd audio
+          if [ ! -d build ]; then
+            mkdir build
+            if [ "_${{ runner.os }}" == "_macOS" ]; then
+              export CMAKE_EXTRA="${CMAKE_EXTRA} -DCMAKE_OSX_DEPLOYMENT_TARGET=10.9"
+            fi
+            if [ "_${{ runner.os }}_${{ matrix.compiler.cc }}" == "_macOS_clang" ]; then
+              export CMAKE_EXTRA="${CMAKE_EXTRA} \
+                -DCMAKE_EXE_LINKER_FLAGS=-stdlib=libc++ \
+                -DCMAKE_MODULE_LINKER_FLAGS=-stdlib=libc++ \
+                -DCMAKE_SHARED_LINKER_FLAGS=-stdlib=libc++";
+            fi
+            cmake -B build -S . -G "${{ steps.generator.outputs.value }}" \
+              -DCMAKE_BUILD_TYPE="Debug" \
+              -DCMAKE_INSTALL_PREFIX="${{ github.workspace }}/install" \
+              ${CMAKE_EXTRA}
+          fi
+          cmake --build build
+          popd
+
+      - name: Build libopenshot
+        run: |
+          if [ "_${{ runner.os }}" == "_macOS" ]; then
+            export CMAKE_EXTRA="${CMAKE_EXTRA} -DCMAKE_OSX_DEPLOYMENT_TARGET=10.9 \
+            -DQt5_DIR=/usr/local/opt/qt@5/lib/cmake/Qt5 \
+            -DENABLE_RUBY=0";
+            export PATH="/usr/local/opt/qt@5/bin:$PATH";
+          fi
+          if [ "_${{ runner.os }}_${{ matrix.compiler.cc }}" == "_macOS_clang" ]; then
+            export CMAKE_EXTRA="${CMAKE_EXTRA} \
+            -DCMAKE_EXE_LINKER_FLAGS=-stdlib=libc++ \
+            -DCMAKE_MODULE_LINKER_FLAGS=-stdlib=libc++ \
+            -DCMAKE_SHARED_LINKER_FLAGS=-stdlib=libc++";
+          fi
+          if [ "_${{ runner.os }}" == "_Windows" ]; then
+            export CMAKE_EXTRA="${CMAKE_EXTRA} \
+              -DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=lld \
+              -DCMAKE_MODULE_LINKER_FLAGS=-fuse-ld=lld \
+              -DCMAKE_SHARED_LINKER_FLAGS=-fuse-ld=lld"
+          fi
           mkdir build
-          cmake -B build -S .
-        fi
-        cmake --build build
-        popd
+          cmake -B build -S . -G "${{ steps.generator.outputs.value }}" \
+            -DCMAKE_BUILD_TYPE="Debug" \
+            -DCMAKE_INSTALL_PREFIX="${{ github.workspace }}/install" \
+            -DOpenShotAudio_ROOT="./audio/build" \
+            ${CMAKE_EXTRA} \
+            "${{ steps.coverage.outputs.value }}"
+          cmake --build build -- VERBOSE=1
 
-    - name: Build libopenshot
-      shell: bash
-      run: |
-        mkdir build
-        pushd build
-        cmake -B . -S .. -DCMAKE_INSTALL_PREFIX:PATH="dist" -DCMAKE_BUILD_TYPE="Debug" -DOpenShotAudio_ROOT="../audio/build" "${{ steps.coverage.outputs.value }}"
-        cmake --build . -- VERBOSE=1
-        popd
+      - name: Test libopenshot
+        run: |
+          cmake --build build --target coverage -- VERBOSE=1
 
-    - name: Test libopenshot
-      shell: bash
-      run: |
-        pushd build
-        cmake --build . --target coverage -- VERBOSE=1
-        popd
+      - name: Install libopenshot
+        run: |
+          cmake --build build --target install -- VERBOSE=1
 
-    - name: Install libopenshot
-      shell: bash
-      run: |
-        pushd build
-        cmake --build . --target install -- VERBOSE=1
-        popd
-
-    - uses: codecov/codecov-action@v2.1.0
-      if: ${{ matrix.compiler.cc == 'gcc' }}
-      with:
-        file: build/coverage.info
+      - uses: codecov/codecov-action@v2.1.0
+        if: ${{ steps.coverage.outputs.value }}
+        with:
+          file: build/coverage.info

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,11 +177,14 @@ jobs:
       - name: macOS Library checks
         if: ${{ runner.os == 'macos' }}
         run: |
-          otool -l "${{ github.workspace }}/install/lib/libopenshot-audio.dylib"
+          echo "\n\n== libopenshot-audio.dylib =============================="
+          otool -D "${{ github.workspace }}/install/lib/libopenshot-audio.dylib"
           otool -L "${{ github.workspace }}/install/lib/libopenshot-audio.dylib"
-          otool -l "${{ github.workspace }}/install/lib/libopenshot.dylib"
+          echo "\n\n== libopenshot.dylib ===================================="
+          otool -D "${{ github.workspace }}/install/lib/libopenshot.dylib"
           otool -L "${{ github.workspace }}/install/lib/libopenshot.dylib"
-          otool -l "${{ github.workspace }}/install/lib/libopenshot_protobuf.dylib"
+          echo "\n\n== libopenshot_protobuf.dylib ==========================="
+          otool -D "${{ github.workspace }}/install/lib/libopenshot_protobuf.dylib"
           otool -L "${{ github.workspace }}/install/lib/libopenshot_protobuf.dylib"
 
       - uses: codecov/codecov-action@v2.1.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,6 +131,12 @@ jobs:
           cmake --build build
           popd
 
+      - name: Install OpenShotAudio
+        run: |
+          pushd audio
+          cmake --install build
+          popd
+
       - name: Build libopenshot
         run: |
           if [ "_${{ runner.os }}" == "_macOS" ]; then
@@ -167,6 +173,16 @@ jobs:
       - name: Install libopenshot
         run: |
           cmake --build build --target install -- VERBOSE=1
+
+      - name: macOS Library checks
+        if: ${{ runner.os == 'macos' }}
+        run: |
+          otool -l "${{ github.workspace }}/install/lib/libopenshot-audio.dylib"
+          otool -L "${{ github.workspace }}/install/lib/libopenshot-audio.dylib"
+          otool -l "${{ github.workspace }}/install/lib/libopenshot.dylib"
+          otool -L "${{ github.workspace }}/install/lib/libopenshot.dylib"
+          otool -l "${{ github.workspace }}/install/lib/libopenshot_protobuf.dylib"
+          otool -L "${{ github.workspace }}/install/lib/libopenshot_protobuf.dylib"
 
       - uses: codecov/codecov-action@v2.1.0
         if: ${{ steps.coverage.outputs.value }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,19 +7,19 @@ jobs:
     strategy:
       matrix:
         sys:
-          - { os: ubuntu-18.04, shell: bash }
-          - { os: ubuntu-latest, shell: bash }
-          - { os: macos-latest, shell: bash }
-          - { os: windows-latest, shell: 'msys2 {0}' }
+          - {os: ubuntu-18.04, shell: bash}
+          - {os: ubuntu-latest, shell: bash}
+          - {os: macos-latest, shell: bash}
+          - {os: windows-latest, shell: 'msys2 {0}'}
         compiler:
-          - { cc: gcc, cxx: g++ }
-          - { cc: clang, cxx: clang++ }
+          - {cc: gcc, cxx: g++}
+          - {cc: clang, cxx: clang++}
         exclude:
           # Windows clang isn't being our friend,
           # JUCE seems to think it can use _get_tzname there
           # (it can't)
-          - sys: { os: windows-latest, shell: 'msys2 {0}' }
-            compiler: { cc: clang, cxx: clang++ }
+          - sys: {os: windows-latest, shell: 'msys2 {0}'}
+            compiler: {cc: clang, cxx: clang++}
     defaults:
       run:
         shell: "${{ matrix.sys.shell }}"
@@ -27,6 +27,7 @@ jobs:
       CC: ${{ matrix.compiler.cc }}
       CXX: ${{ matrix.compiler.cxx }}
       CODECOV_TOKEN: 'dc94d508-39d3-4369-b1c6-321749f96f7c'
+      INSTALL_PATH: '${{ github.workspace }}/install'
 
     steps:
       - uses: actions/checkout@v2
@@ -63,7 +64,8 @@ jobs:
             cmake swig doxygen graphviz curl lcov \
             libasound2-dev \
             qtbase5-dev qtbase5-dev-tools libqt5svg5-dev \
-            libfdk-aac-dev libavcodec-dev libavformat-dev libavutil-dev libswscale-dev libswresample-dev \
+            libfdk-aac-dev libavcodec-dev libavformat-dev \
+            libavutil-dev libswscale-dev libswresample-dev \
             libzmq3-dev libmagick++-dev libbabl-dev \
             libopencv-dev libprotobuf-dev protobuf-compiler
           # Install catch2 package from Ubuntu 20.10, since for some reason
@@ -116,17 +118,14 @@ jobs:
             mkdir build
             if [ "_${{ runner.os }}" == "_macOS" ]; then
               export CMAKE_EXTRA="${CMAKE_EXTRA} \
-                -DCMAKE_OSX_DEPLOYMENT_TARGET=10.15"
-            fi
-            if [ "_${{ runner.os }}_${{ matrix.compiler.cc }}" == "_macOS_clang" ]; then
-              export CMAKE_EXTRA="${CMAKE_EXTRA} \
+                -DCMAKE_OSX_DEPLOYMENT_TARGET=10.15" \
                 -DCMAKE_EXE_LINKER_FLAGS=-stdlib=libc++ \
                 -DCMAKE_MODULE_LINKER_FLAGS=-stdlib=libc++ \
                 -DCMAKE_SHARED_LINKER_FLAGS=-stdlib=libc++";
             fi
             cmake -B build -S . -G "${{ steps.generator.outputs.value }}" \
               -DCMAKE_BUILD_TYPE="Debug" \
-              -DCMAKE_INSTALL_PREFIX="${{ github.workspace }}/install" \
+              -DCMAKE_INSTALL_PREFIX="${INSTALL_PATH}" \
               ${CMAKE_EXTRA}
           fi
           cmake --build build
@@ -147,7 +146,7 @@ jobs:
               -DENABLE_RUBY=0";
             export PATH="/usr/local/opt/qt@5/bin:$PATH";
           fi
-          if [ "_${{ runner.os }}_${{ matrix.compiler.cc }}" == "_macOS_clang" ]; then
+          if [ "_${{ runner.os }}" == "_macOS" ]; then
             export CMAKE_EXTRA="${CMAKE_EXTRA} \
               -DCMAKE_EXE_LINKER_FLAGS=-stdlib=libc++ \
               -DCMAKE_MODULE_LINKER_FLAGS=-stdlib=libc++ \
@@ -157,12 +156,12 @@ jobs:
             export CMAKE_EXTRA="${CMAKE_EXTRA} \
               -DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=lld \
               -DCMAKE_MODULE_LINKER_FLAGS=-fuse-ld=lld \
-              -DCMAKE_SHARED_LINKER_FLAGS=-fuse-ld=lld"
+              -DCMAKE_SHARED_LINKER_FLAGS=-fuse-ld=lld";
           fi
           mkdir build
           cmake -B build -S . -G "${{ steps.generator.outputs.value }}" \
             -DCMAKE_BUILD_TYPE="Debug" \
-            -DCMAKE_INSTALL_PREFIX="${{ github.workspace }}/install" \
+            -DCMAKE_INSTALL_PREFIX="${INSTALL_PATH}" \
             -DOpenShotAudio_ROOT="./audio/build" \
             ${CMAKE_EXTRA} \
             "${{ steps.coverage.outputs.value }}"
@@ -178,20 +177,7 @@ jobs:
 
       - name: macOS Library checks
         if: ${{ runner.os == 'macos' }}
-        run: |
-          pushd ${{ github.workspace }}/install
-          for lib in libopenshot-audio.dylib libopenshot.dylib libopenshot_protobuf.dylib; do
-            echo
-            echo "== ${lib} =============================="
-            otool -D "lib/${lib}"
-            otool -L "lib/${lib}"
-            otool -l "lib/${lib}" |grep -i path;
-          done
-          echo
-          echo "== openshot-player ===================================="
-          otool -L "bin/openshot-player"
-          otool -l "bin/openshot-player" |grep -i path
-          popd
+        run: cmake/scan-mac-libs.sh
 
       - uses: codecov/codecov-action@v2.1.0
         if: ${{ steps.coverage.outputs.value }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
         run: |
           brew install \
             qt5 ffmpeg zeromq cppzmq libomp opencv protobuf babl \
-            python3 swig catch2 doxygen graphviz
+            python3 swig catch2 doxygen graphviz gcc
 
       - name: Set up MSYS and install Windows dependencies
         if: ${{ runner.os == 'Windows' }}
@@ -115,7 +115,8 @@ jobs:
           if [ ! -d build ]; then
             mkdir build
             if [ "_${{ runner.os }}" == "_macOS" ]; then
-              export CMAKE_EXTRA="${CMAKE_EXTRA} -DCMAKE_OSX_DEPLOYMENT_TARGET=10.9"
+              export CMAKE_EXTRA="${CMAKE_EXTRA} \
+                -DCMAKE_OSX_DEPLOYMENT_TARGET=10.15"
             fi
             if [ "_${{ runner.os }}_${{ matrix.compiler.cc }}" == "_macOS_clang" ]; then
               export CMAKE_EXTRA="${CMAKE_EXTRA} \
@@ -140,16 +141,17 @@ jobs:
       - name: Build libopenshot
         run: |
           if [ "_${{ runner.os }}" == "_macOS" ]; then
-            export CMAKE_EXTRA="${CMAKE_EXTRA} -DCMAKE_OSX_DEPLOYMENT_TARGET=10.9 \
-            -DQt5_DIR=/usr/local/opt/qt@5/lib/cmake/Qt5 \
-            -DENABLE_RUBY=0";
+            export CMAKE_EXTRA="${CMAKE_EXTRA} \
+              -DCMAKE_OSX_DEPLOYMENT_TARGET=10.15 \
+              -DQt5_DIR=/usr/local/opt/qt@5/lib/cmake/Qt5 \
+              -DENABLE_RUBY=0";
             export PATH="/usr/local/opt/qt@5/bin:$PATH";
           fi
           if [ "_${{ runner.os }}_${{ matrix.compiler.cc }}" == "_macOS_clang" ]; then
             export CMAKE_EXTRA="${CMAKE_EXTRA} \
-            -DCMAKE_EXE_LINKER_FLAGS=-stdlib=libc++ \
-            -DCMAKE_MODULE_LINKER_FLAGS=-stdlib=libc++ \
-            -DCMAKE_SHARED_LINKER_FLAGS=-stdlib=libc++";
+              -DCMAKE_EXE_LINKER_FLAGS=-stdlib=libc++ \
+              -DCMAKE_MODULE_LINKER_FLAGS=-stdlib=libc++ \
+              -DCMAKE_SHARED_LINKER_FLAGS=-stdlib=libc++";
           fi
           if [ "_${{ runner.os }}" == "_Windows" ]; then
             export CMAKE_EXTRA="${CMAKE_EXTRA} \
@@ -177,18 +179,19 @@ jobs:
       - name: macOS Library checks
         if: ${{ runner.os == 'macos' }}
         run: |
-          echo "\\n\\n== libopenshot-audio.dylib =============================="
-          otool -D "${{ github.workspace }}/install/lib/libopenshot-audio.dylib"
-          otool -L "${{ github.workspace }}/install/lib/libopenshot-audio.dylib"
-          echo "\\n\\n== libopenshot.dylib ===================================="
-          otool -D "${{ github.workspace }}/install/lib/libopenshot.dylib"
-          otool -L "${{ github.workspace }}/install/lib/libopenshot.dylib"
-          echo "\\n\\n== libopenshot_protobuf.dylib ==========================="
-          otool -D "${{ github.workspace }}/install/lib/libopenshot_protobuf.dylib"
-          otool -L "${{ github.workspace }}/install/lib/libopenshot_protobuf.dylib"
-          echo "\\n\\n== openshot-player ===================================="
-          otool -L "${{ github.workspace }}/install/bin/openshot-player"
-
+          pushd ${{ github.workspace }}/install
+          for lib in libopenshot-audio.dylib libopenshot.dylib libopenshot_protobuf.dylib; do
+            echo
+            echo "== ${lib} =============================="
+            otool -D "lib/${lib}"
+            otool -L "lib/${lib}"
+            otool -l "lib/${lib}" |grep -i path;
+          done
+          echo
+          echo "== openshot-player ===================================="
+          otool -L "bin/openshot-player"
+          otool -l "bin/openshot-player" |grep -i path
+          popd
 
       - uses: codecov/codecov-action@v2.1.0
         if: ${{ steps.coverage.outputs.value }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,15 +177,18 @@ jobs:
       - name: macOS Library checks
         if: ${{ runner.os == 'macos' }}
         run: |
-          echo "\n\n== libopenshot-audio.dylib =============================="
+          echo "\\n\\n== libopenshot-audio.dylib =============================="
           otool -D "${{ github.workspace }}/install/lib/libopenshot-audio.dylib"
           otool -L "${{ github.workspace }}/install/lib/libopenshot-audio.dylib"
-          echo "\n\n== libopenshot.dylib ===================================="
+          echo "\\n\\n== libopenshot.dylib ===================================="
           otool -D "${{ github.workspace }}/install/lib/libopenshot.dylib"
           otool -L "${{ github.workspace }}/install/lib/libopenshot.dylib"
-          echo "\n\n== libopenshot_protobuf.dylib ==========================="
+          echo "\\n\\n== libopenshot_protobuf.dylib ==========================="
           otool -D "${{ github.workspace }}/install/lib/libopenshot_protobuf.dylib"
           otool -L "${{ github.workspace }}/install/lib/libopenshot_protobuf.dylib"
+          echo "\\n\\n== openshot-player ===================================="
+          otool -L "${{ github.workspace }}/install/bin/openshot-player"
+
 
       - uses: codecov/codecov-action@v2.1.0
         if: ${{ steps.coverage.outputs.value }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -218,6 +218,7 @@ if (ENABLE_COVERAGE AND DEFINED UNIT_TEST_TARGETS)
     "examples/*"
     "${CMAKE_CURRENT_BINARY_DIR}/bindings/*"
     "${CMAKE_CURRENT_BINARY_DIR}/src/*_autogen/*"
+    "${CMAKE_CURRENT_BINARY_DIR}/src/protobuf_messages/*"
     "audio/*"
   )
   setup_target_for_coverage_lcov(

--- a/cmake/scan-mac-libs.sh
+++ b/cmake/scan-mac-libs.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# Run otool to display some useful data about the structure of our
+# compiled macOS binary components
+
+cd "${INSTALL_PATH}"
+for lib in libopenshot-audio.dylib libopenshot.dylib libopenshot_protobuf.dylib; do
+    echo
+    echo "== ${lib} =============================="
+    otool -D "lib/${lib}"
+    otool -L "lib/${lib}"
+    echo
+    echo "${lib} load commands:"
+    otool -l "lib/${lib}"
+done
+echo
+echo "== openshot-player ===================================="
+otool -L "bin/openshot-player"
+echo
+echo "openshot-player load commands:"
+otool -l "bin/openshot-player"
+
+exit 0

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -69,9 +69,14 @@ endif()
 #	# Create test executable
 #	add_executable(openshot-example-opencv
 #			Example_opencv.cpp)
-#	
+#
 #	target_compile_definitions(openshot-example-opencv PRIVATE
 #	                           -DTEST_MEDIA_PATH="${TEST_MEDIA_PATH}" )
 #	# Link test executable to the new library
 #	target_link_libraries(openshot-example-opencv openshot)
 #endif()
+
+install(TARGETS openshot-player
+  COMPONENT runtime
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -152,9 +152,6 @@ set(QT_PLAYER_SOURCES
   Qt/VideoRenderer.cpp
   Qt/VideoRenderWidget.cpp)
 
-# Disable RPATH
-set(CMAKE_MACOSX_RPATH 0)
-
 ############### CREATE LIBRARY #################
 # Create shared openshot library
 add_library(openshot SHARED)
@@ -170,7 +167,6 @@ set_target_properties(openshot PROPERTIES
   AUTOMOC ON
   VERSION ${PROJECT_VERSION}
   SOVERSION ${PROJECT_SO_VERSION}
-  INSTALL_NAME_DIR "$<INSTALL_PREFIX>/lib"
 )
 
 # Location of our includes, both internally and when installed

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -170,7 +170,7 @@ set_target_properties(openshot PROPERTIES
   AUTOMOC ON
   VERSION ${PROJECT_VERSION}
   SOVERSION ${PROJECT_SO_VERSION}
-  INSTALL_NAME_DIR "${CMAKE_INSTALL_PREFIX}/lib"
+  INSTALL_NAME_DIR "$<INSTALL_PREFIX>/lib"
 )
 
 # Location of our includes, both internally and when installed

--- a/src/KeyFrame.cpp
+++ b/src/KeyFrame.cpp
@@ -576,8 +576,7 @@ void Keyframe::PrintValues(std::ostream* out) const {
     // Column widths
     std::vector<int> w{10, 12, 8, 11, 19};
 
-    *out << std::right << std::setfill(' ') << std::boolalpha
-         << std::setprecision(4);
+    *out << std::right << std::setfill(' ') << std::setprecision(4);
     // Headings
     *out << "│"
          << std::setw(w[0]) << "Frame# (X)" << " │"
@@ -600,7 +599,8 @@ void Keyframe::PrintValues(std::ostream* out) const {
              << std::setw(w[1]) << std::fixed << GetValue(i) << " │"
              << std::setw(w[2]) << std::defaultfloat << std::showpos
                                 << GetDelta(i) << " │ " << std::noshowpos
-             << std::setw(w[3]) << IsIncreasing(i) << " │ "
+             << std::setw(w[3])
+             << (IsIncreasing(i) ? "true" : "false") << " │ "
              << std::setw(w[4]) << std::left << GetRepeatFraction(i)
                                 << std::right << "│\n";
     }

--- a/src/protobuf_messages/CMakeLists.txt
+++ b/src/protobuf_messages/CMakeLists.txt
@@ -48,10 +48,9 @@ target_link_libraries(openshot_protobuf protobuf::libprotobuf)
 
 # Set SONAME and other library properties
 set_target_properties(openshot_protobuf PROPERTIES
-        VERSION ${PROJECT_VERSION}
-        SOVERSION ${PROJECT_SO_VERSION}
-        INSTALL_NAME_DIR "$<INSTALL_PREFIX>/lib"
-        )
+  VERSION ${PROJECT_VERSION}
+  SOVERSION ${PROJECT_SO_VERSION}
+  )
 
 # Install protobuf library and generated headers
 install(TARGETS openshot_protobuf

--- a/src/protobuf_messages/CMakeLists.txt
+++ b/src/protobuf_messages/CMakeLists.txt
@@ -50,7 +50,7 @@ target_link_libraries(openshot_protobuf protobuf::libprotobuf)
 set_target_properties(openshot_protobuf PROPERTIES
         VERSION ${PROJECT_VERSION}
         SOVERSION ${PROJECT_SO_VERSION}
-        INSTALL_NAME_DIR "${CMAKE_INSTALL_PREFIX}/lib"
+        INSTALL_NAME_DIR "$<INSTALL_PREFIX>/lib"
         )
 
 # Install protobuf library and generated headers


### PR DESCRIPTION
As the branch name notes, this is actually meant to be my exploration into using RPATH on macOS, something [CMake actually _recommends_](https://cmake.org/cmake/help/latest/prop_tgt/MACOSX_RPATH.html#prop_tgt:MACOSX_RPATH) these days. We're still forcibly disabling it.

Instead, we set `INSTALL_NAME_DIR` to `"${CMAKE_INSTALL_PREFIX}/lib"`, which is just _suuuper_ wrong. At the very least, we should be using `"$<INSTALL_PREFIX>/lib"` so that the path is configured (the same way CMake relinks Linux libraries) at install time.

So, this PR makes at least that change.

(Note: This is based on my PR #734 (had to be, to run the macOS CI builds), as presumably that will be merged before this.)