### PR TITLE
Unit tests: Use == to compare strings

### DIFF
--- a/tests/FFmpegReader.cpp
+++ b/tests/FFmpegReader.cpp
@@ -300,6 +300,5 @@ TEST_CASE( "DisplayInfo", "[libopenshot][ffmpegreader]" )
 	r.DisplayInfo(&output);
 
 	// Compare a [0, expected.size()) substring of output to expected
-	auto compare_value = output.str().compare(0, expected.size(), expected);
-	CHECK(compare_value == 0);
+	CHECK(output.str().substr(0, expected.size()) == expected);
 }

--- a/tests/FFmpegWriter.cpp
+++ b/tests/FFmpegWriter.cpp
@@ -199,6 +199,5 @@ TEST_CASE( "DisplayInfo", "[libopenshot][ffmpegwriter]" )
 	w.Close();
 
 	// Compare a [0, expected.size()) substring of output to expected
-	auto compare_value = output.str().compare(0, expected.size(), expected);
-	CHECK(compare_value == 0);
+	CHECK(output.str().substr(0, expected.size()) == expected);
 }

--- a/tests/FrameMapper.cpp
+++ b/tests/FrameMapper.cpp
@@ -651,8 +651,7 @@ Target frame #: 10 mapped to original frame #:	(8 odd, 8 even)
 	mapping.PrintMapping(&mapping_out);
 
 	// Compare a [0, expected.size()) substring of output to expected
-	auto compare_value = mapping_out.str().compare(0, expected.size(), expected);
-	CHECK(compare_value == 0);
+	CHECK(mapping_out.str().substr(0, expected.size()) == expected);
 }
 
 TEST_CASE( "Json", "[libopenshot][framemapper]" )

--- a/tests/KeyFrame.cpp
+++ b/tests/KeyFrame.cpp
@@ -536,7 +536,7 @@ R"(     1       10.0000
    999    12345.6777)";
 
     // Ensure the two strings are equal up to the limits of 'expected'
-    CHECK(output.str().compare(0, expected.size(), expected) == 0);
+    CHECK(output.str().substr(0, expected.size()) == expected);
 }
 
 TEST_CASE( "PrintValues", "[libopenshot][keyframe]" )
@@ -582,7 +582,7 @@ R"(│Frame# (X) │     Y Value │ Delta Y │ Increasing? │ Repeat Fraction
 │      25   │     16.5446 │      +1 │        true │ Fraction(1, 2)     │)";
 
     // Ensure the two strings are equal up to the limits of 'expected'
-    CHECK(output.str().compare(0, expected.size(), expected) == 0);
+    CHECK(output.str().substr(0, expected.size()) == expected);
 }
 
 #ifdef USE_OPENCV


### PR DESCRIPTION
One of the new unit tests is failing on macOS. I have no idea why, because it's a string comparison built using `std::string::compare` so the only thing Catch2 is telling me is that `84 == 0` is false. (Duh.)

So, turns out it's better to compare strings directly using `==`. When there's a mismatch, Catch2 will output the contents of both strings rather than a meaningless `.compare()` numeric value.