### PR TITLE
Don't use right-aligned std::boolalpha

### DIFF
--- a/src/KeyFrame.cpp
+++ b/src/KeyFrame.cpp
@@ -576,8 +576,7 @@ void Keyframe::PrintValues(std::ostream* out) const {
     // Column widths
     std::vector<int> w{10, 12, 8, 11, 19};
 
-    *out << std::right << std::setfill(' ') << std::boolalpha
-         << std::setprecision(4);
+    *out << std::right << std::setfill(' ') << std::setprecision(4);
     // Headings
     *out << "│"
          << std::setw(w[0]) << "Frame# (X)" << " │"
@@ -600,7 +599,8 @@ void Keyframe::PrintValues(std::ostream* out) const {
              << std::setw(w[1]) << std::fixed << GetValue(i) << " │"
              << std::setw(w[2]) << std::defaultfloat << std::showpos
                                 << GetDelta(i) << " │ " << std::noshowpos
-             << std::setw(w[3]) << IsIncreasing(i) << " │ "
+             << std::setw(w[3])
+             << (IsIncreasing(i) ? "true" : "false") << " │ "
              << std::setw(w[4]) << std::left << GetRepeatFraction(i)
                                 << std::right << "│\n";
     }


### PR DESCRIPTION
Turns out, macOS's libc++ doesn't apply fill padding / alignment the same way other libs do. [Known issue due to ambiguity in the standard.](https://timsong-cpp.github.io/lwg-issues/2703) So we have to manually transform booleans into `"true"` / `"false"` strings, in order to right-align them consistently.