### PR TITLE
Protect values against integer overflow

### DIFF
--- a/src/DummyReader.cpp
+++ b/src/DummyReader.cpp
@@ -38,7 +38,7 @@ void DummyReader::init(Fraction fps, int width, int height, int sample_rate, int
 	// Set key info settings
 	info.has_audio = false;
 	info.has_video = true;
-	info.file_size = width * height * sizeof(int);
+	info.file_size = static_cast<size_t>(width * height * sizeof(int));
 	info.vcodec = "raw";
 	info.fps = fps;
 	info.width = width;

--- a/src/FFmpegReader.cpp
+++ b/src/FFmpegReader.cpp
@@ -1535,7 +1535,13 @@ void FFmpegReader::ProcessAudioPacket(int64_t requested_frame, int64_t target_fr
 							 audio_frame->nb_samples);       // number of input samples to convert
 
 	// Copy audio samples over original samples
-	memcpy(audio_buf, audio_converted->data[0], audio_converted->nb_samples * av_get_bytes_per_sample(AV_SAMPLE_FMT_S16) * info.channels);
+	memcpy(audio_buf,
+	       audio_converted->data[0],
+	       static_cast<size_t>(
+	           audio_converted->nb_samples
+	           * av_get_bytes_per_sample(AV_SAMPLE_FMT_S16)
+	           * info.channels)
+	      );
 
 	// Deallocate resample buffer
 	SWR_CLOSE(avr);

--- a/src/Frame.cpp
+++ b/src/Frame.cpp
@@ -438,8 +438,10 @@ juce::AudioSampleBuffer *Frame::GetAudioSampleBuffer()
 int64_t Frame::GetBytes()
 {
 	int64_t total_bytes = 0;
-	if (image)
-		total_bytes += (width * height * sizeof(char) * 4);
+	if (image) {
+		total_bytes += static_cast<int64_t>(
+		    width * height * sizeof(char) * 4);
+	}
 	if (audio) {
 		// approximate audio size (sample rate / 24 fps)
 		total_bytes += (sample_rate / 24.0) * sizeof(float);


### PR DESCRIPTION
I've been experimenting with GitHub's CodeQL scanning in my fork, and it flagged these eight memory-protection issues in the code. Easy enough to fix, and potentially heads off a future CVE over buffer overflow vulnerabilities.