### PR TITLE
Determine file type based on content, not extension

### DIFF
--- a/src/QtImageReader.cpp
+++ b/src/QtImageReader.cpp
@@ -85,6 +85,7 @@ void QtImageReader::Open()
 			image = std::make_shared<QImage>();
             QImageReader imgReader( path );
             imgReader.setAutoTransform( true );
+            imgReader.setDecideFormatFromContent( true );
             loaded = imgReader.read(image.get());
 		}
 


### PR DESCRIPTION
I have run in to an issue numerous times where an image is used in an render with a png file extension, but the file is actually a jpg, and vice versa.

When you try to write a video using this image you will get an error like below:

```
[mp3 @ 0x55c861a9e740] Estimating duration from bitrate, this may be inaccurate
terminate called after throwing an instance of 'openshot::InvalidFile'
  what():  File could not be opened.
Caught signal 6 (SIGABRT)
---- Unhandled Exception: Stack Trace ----
  /lib/x86_64-linux-gnu/libc.so.6 ( abort                                     + 0x141 )  [0x7f4525e9e921]
  /usr/lib/x86_64-linux-gnu/libstdc++.so.6 (                                           + 0x8c957)  [0x7f45264f3957]
  /usr/lib/x86_64-linux-gnu/libstdc++.so.6 (                                           + 0x92ae6)  [0x7f45264f9ae6]
  /usr/lib/x86_64-linux-gnu/libstdc++.so.6 (                                           + 0x92b21)  [0x7f45264f9b21]
  /usr/lib/x86_64-linux-gnu/libstdc++.so.6 (                                           + 0x92d54)  [0x7f45264f9d54]
  /usr/local/lib/libopenshot.so.21 ( openshot::QtImageReader::Open()           + 0x691 )  [0x7f4528656951]
  /usr/local/lib/libopenshot.so.21 ( openshot::QtImageReader::QtImageReader(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, bool)  + 0xd0  )
```

The file can not be read.

The provided fix will instead try to determine the file type from it's contents instead of relying on the file extension.

Now when a file is a jpg but has the wrong extension (i.e. png) it will still render without errors.

For more info: https://doc.qt.io/qt-5/qimagereader.html#decideFormatFromContent