### PR TITLE
Enable Windows builds without unit tests

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -525,7 +525,7 @@ install(DIRECTORY .
 
 # On Windows, we copy project output DLLs into the tests dir
 # so that the unit test executables can find them
-if(CMAKE_VERSION VERSION_GREATER 3.13 AND WIN32)
+if(CMAKE_VERSION VERSION_GREATER 3.13 AND WIN32 AND BUILD_TESTING)
   # Copy the DLLs immediately after they're built
   add_custom_command(TARGET openshot POST_BUILD
     COMMAND

--- a/src/protobuf_messages/CMakeLists.txt
+++ b/src/protobuf_messages/CMakeLists.txt
@@ -68,7 +68,7 @@ install(FILES ${ProtoHeaders}
 
 # On Windows, we copy project output DLLs into the test dirs
 # so that the unit test executables can find them
-if(CMAKE_VERSION VERSION_GREATER 3.13 AND WIN32)
+if(CMAKE_VERSION VERSION_GREATER 3.13 AND WIN32 AND BUILD_TESTING)
   add_custom_command(TARGET openshot_protobuf POST_BUILD
     COMMAND
       ${CMAKE_COMMAND} -E copy_if_different


### PR DESCRIPTION
Just a quick-fix for a mistake I made that leaves Windows unable to build libopenshot if `-DBUILD_TESTING=0` is set on the CMake command line.
