### PR TITLE
Prevent crash when smallest frame detected in memory object is NULL

### DIFF
--- a/src/CacheDisk.cpp
+++ b/src/CacheDisk.cpp
@@ -294,7 +294,6 @@ std::shared_ptr<Frame> CacheDisk::GetSmallestFrame()
 {
 	// Create a scoped lock, to protect the cache from multiple threads
 	const GenericScopedLock<CriticalSection> lock(*cacheCriticalSection);
-	std::shared_ptr<openshot::Frame> f;
 
 	// Loop through frame numbers
 	std::deque<int64_t>::iterator itr;
@@ -305,10 +304,12 @@ std::shared_ptr<Frame> CacheDisk::GetSmallestFrame()
 			smallest_frame = *itr;
 	}
 
-	// Return frame
-	f = GetFrame(smallest_frame);
-
-	return f;
+    // Return frame (if any)
+    if (smallest_frame != -1) {
+        return GetFrame(smallest_frame);
+    } else {
+        return NULL;
+    }
 }
 
 // Gets the maximum bytes value

--- a/src/CacheMemory.cpp
+++ b/src/CacheMemory.cpp
@@ -168,7 +168,6 @@ std::shared_ptr<Frame> CacheMemory::GetSmallestFrame()
 {
 	// Create a scoped lock, to protect the cache from multiple threads
 	const GenericScopedLock<CriticalSection> lock(*cacheCriticalSection);
-	std::shared_ptr<openshot::Frame> f;
 
 	// Loop through frame numbers
 	std::deque<int64_t>::iterator itr;
@@ -179,10 +178,12 @@ std::shared_ptr<Frame> CacheMemory::GetSmallestFrame()
 			smallest_frame = *itr;
 	}
 
-	// Return frame
-	f = GetFrame(smallest_frame);
-
-	return f;
+	// Return frame (if any)
+	if (smallest_frame != -1) {
+        return GetFrame(smallest_frame);
+    } else {
+	    return NULL;
+	}
 }
 
 // Gets the maximum bytes value

--- a/src/Qt/VideoCacheThread.cpp
+++ b/src/Qt/VideoCacheThread.cpp
@@ -86,6 +86,7 @@ namespace openshot
     void VideoCacheThread::run()
     {
         // Types for storing time durations in whole and fractional milliseconds
+        std::shared_ptr<openshot::Frame> smallest_frame = NULL;
         using ms = std::chrono::milliseconds;
         using double_ms = std::chrono::duration<double, ms::period>;
 
@@ -107,13 +108,11 @@ namespace openshot
 						ZmqLogger::Instance()->AppendDebugMethod("VideoCacheThread::run (cache frame)", "position", position, "current_display_frame", current_display_frame, "max_concurrent_frames", max_concurrent_frames, "needed_frames", (position - current_display_frame));
 
 						// Force the frame to be generated
-						if (reader->GetCache()->GetSmallestFrame()) {
-							int64_t smallest_cached_frame = reader->GetCache()->GetSmallestFrame()->number;
-							if (smallest_cached_frame > current_display_frame) {
-								// Cache position has gotten too far away from current display frame.
-								// Reset the position to the current display frame.
-								position = current_display_frame;
-							}
+                        smallest_frame = reader->GetCache()->GetSmallestFrame();
+                        if (smallest_frame && smallest_frame->number > current_display_frame) {
+                            // Cache position has gotten too far away from current display frame.
+                            // Reset the position to the current display frame.
+                            position = current_display_frame;
 						}
 						reader->GetFrame(position);
 					}


### PR DESCRIPTION
Better protect video caching thread from accessing a NULL smallest frame object. I think this is the cause of many crashes when heavy use of OpenShot (i.e. fast scrubbing, fast forward, fast backward... anything too fast which might result in a data change, and thus a clearing of the cache while the video caching thread is accessing it)