### PR TITLE
Support for anamorphic profiles, i.e. non-square pixels (including waveform fixes)

### DIFF
--- a/src/FFmpegWriter.cpp
+++ b/src/FFmpegWriter.cpp
@@ -1143,6 +1143,10 @@ AVStream *FFmpegWriter::add_video_stream() {
 	c->codec_id = codec->id;
 	c->codec_type = AVMEDIA_TYPE_VIDEO;
 
+	// Set sample aspect ratio
+    c->sample_aspect_ratio.num = info.pixel_ratio.num;
+    c->sample_aspect_ratio.den = info.pixel_ratio.den;
+
 	/* Init video encoder options */
 	if (info.video_bit_rate >= 1000
 #if (LIBAVCODEC_VERSION_MAJOR >= 58)
@@ -1219,7 +1223,7 @@ AVStream *FFmpegWriter::add_video_stream() {
 		}
 	}
 
-//TODO: Implement variable bitrate feature (which actually works). This implementation throws
+    //TODO: Implement variable bitrate feature (which actually works). This implementation throws
 	//invalid bitrate errors and rc buffer underflow errors, etc...
 	//c->rc_min_rate = info.video_bit_rate;
 	//c->rc_max_rate = info.video_bit_rate;

--- a/src/Timeline.cpp
+++ b/src/Timeline.cpp
@@ -683,7 +683,7 @@ void Timeline::add_layer(std::shared_ptr<Frame> new_frame, Clip* source_clip, in
 	}
 
 	// Debug output
-	ZmqLogger::Instance()->AppendDebugMethod("Timeline::add_layer (Transform: Composite Image Layer: Completed)", "source_frame->number", source_frame->number, "new_frame->GetImage()->width()", new_frame->GetImage()->width());
+	ZmqLogger::Instance()->AppendDebugMethod("Timeline::add_layer (Transform: Composite Image Layer: Completed)", "source_frame->number", source_frame->number, "new_frame->GetImage()->width()", new_frame->GetImage()->width(), "new_frame->GetImage()->height()", new_frame->GetImage()->height());
 }
 
 // Update the list of 'opened' clips
@@ -1523,7 +1523,7 @@ void Timeline::ClearAllCache() {
 // Settings::Instance()->MAX_WIDTH and Settings::Instance()->MAX_HEIGHT.
 void Timeline::SetMaxSize(int width, int height) {
 	// Maintain aspect ratio regardless of what size is passed in
-	QSize display_ratio_size = QSize(info.display_ratio.num * info.pixel_ratio.ToFloat(), info.display_ratio.den * info.pixel_ratio.ToFloat());
+	QSize display_ratio_size = QSize(info.width, info.height);
 	QSize proposed_size = QSize(std::min(width, info.width), std::min(height, info.height));
 
 	// Scale QSize up to proposed size


### PR DESCRIPTION
Support for anamorphic profiles, i.e. non-square pixels. Fixes include Frame::Display, Frame::Save, and Timeline::SetMaxSize, all which had various issues. Added sample_aspect_ratio to FFmpegWriter, so the exported videos will continue to be anamorphic.

Also fixed some waveform issues, which were not appearing, or appearing squished, and sometimes containing gaps.