### PR TITLE
Fix SVG Cmake regression (we don't need QtSvg)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -284,7 +284,7 @@ endif ()
 
 ################# QT5 ###################
 # Find QT5 libraries
-set(_qt_components Core Gui Widgets Svg)
+set(_qt_components Core Gui Widgets)
 find_package(Qt5 COMPONENTS ${_qt_components} REQUIRED)
 
 foreach(_qt_comp IN LISTS _qt_components)


### PR DESCRIPTION
Fix SVG cmake regression (we don't need QtSvg to be installed for libopenshot to work), and our Linux build server does not include it. @ferdnyc This one is related to https://github.com/OpenShot/libopenshot/pull/731.

**Maybe this needs some additional thought...** 
libopenshot + QtSvg - Resvg == GOOD
libopenshot - QtSvg + Resvg == GOOD
libopenshot - QtSvg - Resvg == BAD :man_shrugging: 