### PR TITLE
Resvg: Add support for v0.11.0+, enable in GitHub CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,9 +157,11 @@ jobs:
       - name: Build Resvg (if enabled and not cached)
         if: ${{ steps.use-resvg.outputs.value }} && (steps.cache-resvg.outputs.cache-hit != 'true')
         run: |
-          pushd resvg/c-api
-          cargo build --release
-          popd
+          if [ -d "resvg/c-api" ]; then
+            pushd resvg/c-api
+            cargo build --release
+            popd
+          fi
 
       - name: Build libopenshot
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,14 @@ jobs:
           repository: OpenShot/libopenshot-audio
           path: audio
 
+      - name: Checkout Resvg
+        if: ${{ matrix.compiler.cc == 'clang' && runner.os == 'linux' }}
+        uses: actions/checkout@v2
+        with:
+          repository: RazrFalcon/resvg
+          path: resvg
+          branch: v0.11.0
+
       - uses: haya14busa/action-cond@v1
         id: generator
         with:
@@ -54,6 +62,12 @@ jobs:
           cond: ${{ matrix.compiler.cc == 'gcc' && runner.os == 'linux' }}
           if_true: "-DENABLE_COVERAGE:BOOL=1"
 
+      - uses: haya14busa/action-cond@v1
+        id: use-resvg
+        with:
+          cond: ${{ matrix.compiler.cc == 'clang' && runner.os == 'linux' }}
+          if_true: "-DResvg_ROOT:PATH=./resvg"
+
       - name: Install Linux dependencies
         if: ${{ runner.os == 'linux' }}
         run: |
@@ -63,9 +77,11 @@ jobs:
             cmake swig doxygen graphviz curl lcov \
             libasound2-dev \
             qtbase5-dev qtbase5-dev-tools libqt5svg5-dev \
-            libfdk-aac-dev libavcodec-dev libavformat-dev libavutil-dev libswscale-dev libswresample-dev \
+            libfdk-aac-dev libavcodec-dev libavformat-dev \
+            libavutil-dev libswscale-dev libswresample-dev \
             libzmq3-dev libmagick++-dev libbabl-dev \
-            libopencv-dev libprotobuf-dev protobuf-compiler
+            libopencv-dev libprotobuf-dev protobuf-compiler \
+            cargo
           # Install catch2 package from Ubuntu 20.10, since for some reason
           # even 20.04 only has Catch 1.12.1 available.
           wget https://launchpad.net/ubuntu/+archive/primary/+files/catch2_2.13.0-1_all.deb
@@ -103,13 +119,20 @@ jobs:
               mingw-w64-x86_64-swig
 
       - uses: actions/cache@v2
-        id: cache
+        id: cache-audio
         with:
           path: audio/build
           key: audio-${{ runner.os }}-${{ matrix.compiler.cxx }}-${{ hashFiles('audio/CMakeLists.txt') }}
 
+      - uses: actions/cache@v2
+        if: ${{ steps.use-resvg.outputs.value }}
+        id: cache-resvg
+        with:
+          path: resvg/target
+          key: resvg-${{ runner.os }}-${{ matrix.compiler.cxx }}-${{ hashFiles('resvg/Cargo.toml') }}
+
       - name: Build OpenShotAudio (if not cached)
-        if: steps.cache.outputs.cache-hit != 'true'
+        if: steps.cache-audio.outputs.cache-hit != 'true'
         run: |
           pushd audio
           if [ ! -d build ]; then
@@ -129,6 +152,13 @@ jobs:
               ${CMAKE_EXTRA}
           fi
           cmake --build build
+          popd
+
+      - name: Build Resvg (if enabled and not cached)
+        if: ${{ steps.use-resvg.outputs.value }} && (steps.cache-resvg.outputs.cache-hit != 'true')
+        run: |
+          pushd resvg/c-api
+          cargo build --release
           popd
 
       - name: Build libopenshot
@@ -157,7 +187,8 @@ jobs:
             -DCMAKE_INSTALL_PREFIX="${{ github.workspace }}/install" \
             -DOpenShotAudio_ROOT="./audio/build" \
             ${CMAKE_EXTRA} \
-            "${{ steps.coverage.outputs.value }}"
+            "${{ steps.coverage.outputs.value }}" \
+            "${{ steps.use-resvg.outputs.value }}"
           cmake --build build -- VERBOSE=1
 
       - name: Test libopenshot

--- a/cmake/Modules/FindResvg.cmake
+++ b/cmake/Modules/FindResvg.cmake
@@ -41,6 +41,28 @@ Copyright (c) 2020, FeRD (Frank Dana) <ferdnyc@gmail.com>
 #]=======================================================================]
 include(FindPackageHandleStandardArgs)
 
+### Macro: parse_resvg_version
+#
+# Read the resvg.h file and extract the definition
+# for RESVG_VERSION, to use as our version string.
+macro (parse_resvg_version)
+  set(_header "${Resvg_INCLUDE_DIRS}/resvg.h")
+  if(EXISTS "${_header}")
+    #message(STATUS "Parsing Resvg version from ${_header}")
+    file(STRINGS "${_header}" _version_def
+      REGEX "^#define[ \t]+RESVG_VERSION[ \t]+\".*\"[ \t]*$")
+    string(REGEX REPLACE
+      "^.*RESVG_VERSION[ \t]+\"(.*)\".*$"
+      "\\1"
+      Resvg_VERSION "${_version_def}")
+    #message(STATUS "Found Resvg version: ${Resvg_VERSION}")
+  endif()
+endmacro()
+
+###
+### Begin discovery
+###
+
 # CMake 3.4+ only: Convert relative paths to absolute
 if(DEFINED RESVGDIR AND CMAKE_VERSION VERSION_GREATER 3.4)
   get_filename_component(RESVGDIR "${RESVGDIR}" ABSOLUTE
@@ -58,8 +80,11 @@ find_path(Resvg_INCLUDE_DIRS
     /usr/include
     /usr/local/include
   PATH_SUFFIXES
-    resvg
+    c-api
     capi/include
+    resvg
+    resvg/include
+    resvg/c-api
     resvg/capi/include
 )
 
@@ -82,20 +107,24 @@ find_library(Resvg_LIBRARIES
 if (Resvg_INCLUDE_DIRS AND Resvg_LIBRARIES)
   set(Resvg_FOUND TRUE)
 endif()
+parse_resvg_version()
+
 set(Resvg_LIBRARIES ${Resvg_LIBRARIES} CACHE STRING "The Resvg library link path")
 set(Resvg_INCLUDE_DIRS ${Resvg_INCLUDE_DIRS} CACHE STRING "The Resvg include directories")
 set(Resvg_DEFINITIONS "" CACHE STRING "The Resvg CFLAGS")
+set(Resvg_VERSION ${Resvg_VERSION} CACHE STRING "The Resvg version in use")
 
 mark_as_advanced(Resvg_LIBRARIES Resvg_INCLUDE_DIRS Resvg_DEFINITIONS)
 
 # Give a nice error message if some of the required vars are missing.
 find_package_handle_standard_args(Resvg
-  "Could NOT find Resvg, using Qt SVG parsing instead"
-  Resvg_LIBRARIES Resvg_INCLUDE_DIRS )
+  REQUIRED_VARS Resvg_LIBRARIES Resvg_INCLUDE_DIRS
+  VERSION_VAR Resvg_VERSION
+)
 
 # Export target
 if(Resvg_FOUND AND NOT TARGET Resvg::Resvg)
-  message(STATUS "Creating IMPORTED target Resvg::Resvg")
+  #message(STATUS "Creating IMPORTED target Resvg::Resvg")
   if (WIN32)
     # Windows mis-links SHARED library targets
     add_library(Resvg::Resvg UNKNOWN IMPORTED)

--- a/src/QtImageReader.cpp
+++ b/src/QtImageReader.cpp
@@ -49,11 +49,11 @@ QtImageReader::QtImageReader(std::string path, bool inspect_reader) : path{QStri
     // Initialize the Resvg options
     resvg_options.loadSystemFonts();
 #endif
-	// Open and Close the reader, to populate its attributes (such as height, width, etc...)
-	if (inspect_reader) {
-		Open();
-		Close();
-	}
+    // Open and Close the reader, to populate its attributes (such as height, width, etc...)
+    if (inspect_reader) {
+        Open();
+        Close();
+    }
 }
 
 QtImageReader::~QtImageReader()
@@ -63,10 +63,10 @@ QtImageReader::~QtImageReader()
 // Open image file
 void QtImageReader::Open()
 {
-	// Open reader if not already open
-	if (!is_open)
-	{
-		bool loaded = false;
+    // Open reader if not already open
+    if (!is_open)
+    {
+        bool loaded = false;
         QSize default_svg_size;
 
         // Check for SVG files and rasterizing them to QImages
@@ -77,95 +77,95 @@ void QtImageReader::Open()
             }
         }
 
-		if (!loaded) {
-			// Attempt to open file using Qt's build in image processing capabilities
-			// AutoTransform enables exif data to be parsed and auto transform the image
-			// to the correct orientation
-			image = std::make_shared<QImage>();
+        if (!loaded) {
+            // Attempt to open file using Qt's build in image processing capabilities
+            // AutoTransform enables exif data to be parsed and auto transform the image
+            // to the correct orientation
+            image = std::make_shared<QImage>();
             QImageReader imgReader( path );
             imgReader.setAutoTransform( true );
             loaded = imgReader.read(image.get());
-		}
+        }
 
-		if (!loaded) {
-			// raise exception
-			throw InvalidFile("File could not be opened.", path.toStdString());
-		}
+        if (!loaded) {
+            // raise exception
+            throw InvalidFile("File could not be opened.", path.toStdString());
+        }
 
-		// Update image properties
-		info.has_audio = false;
-		info.has_video = true;
-		info.has_single_image = true;
-		#if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
-			// byteCount() is deprecated from Qt 5.10
-			info.file_size = image->sizeInBytes();
-		#else
-			info.file_size = image->byteCount();
-		#endif
-		info.vcodec = "QImage";
-		if (!default_svg_size.isEmpty()) {
-		    // Use default SVG size (if detected)
+        // Update image properties
+        info.has_audio = false;
+        info.has_video = true;
+        info.has_single_image = true;
+        #if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
+            // byteCount() is deprecated from Qt 5.10
+            info.file_size = image->sizeInBytes();
+        #else
+            info.file_size = image->byteCount();
+        #endif
+        info.vcodec = "QImage";
+        if (!default_svg_size.isEmpty()) {
+            // Use default SVG size (if detected)
             info.width = default_svg_size.width();
             info.height = default_svg_size.height();
-		} else {
-		    // Use Qt Image size as a fallback
+        } else {
+            // Use Qt Image size as a fallback
             info.width = image->width();
             info.height = image->height();
-		}
-		info.pixel_ratio.num = 1;
-		info.pixel_ratio.den = 1;
-		info.duration = 60 * 60 * 1;  // 1 hour duration
-		info.fps.num = 30;
-		info.fps.den = 1;
-		info.video_timebase.num = 1;
-		info.video_timebase.den = 30;
-		info.video_length = round(info.duration * info.fps.ToDouble());
+        }
+        info.pixel_ratio.num = 1;
+        info.pixel_ratio.den = 1;
+        info.duration = 60 * 60 * 1;  // 1 hour duration
+        info.fps.num = 30;
+        info.fps.den = 1;
+        info.video_timebase.num = 1;
+        info.video_timebase.den = 30;
+        info.video_length = round(info.duration * info.fps.ToDouble());
 
-		// Calculate the DAR (display aspect ratio)
-		Fraction size(info.width * info.pixel_ratio.num, info.height * info.pixel_ratio.den);
+        // Calculate the DAR (display aspect ratio)
+        Fraction size(info.width * info.pixel_ratio.num, info.height * info.pixel_ratio.den);
 
-		// Reduce size fraction
-		size.Reduce();
+        // Reduce size fraction
+        size.Reduce();
 
-		// Set the ratio based on the reduced fraction
-		info.display_ratio.num = size.num;
-		info.display_ratio.den = size.den;
+        // Set the ratio based on the reduced fraction
+        info.display_ratio.num = size.num;
+        info.display_ratio.den = size.den;
 
-		// Set current max size
-		max_size.setWidth(info.width);
-		max_size.setHeight(info.height);
+        // Set current max size
+        max_size.setWidth(info.width);
+        max_size.setHeight(info.height);
 
-		// Mark as "open"
-		is_open = true;
-	}
+        // Mark as "open"
+        is_open = true;
+    }
 }
 
 // Close image file
 void QtImageReader::Close()
 {
-	// Close all objects, if reader is 'open'
-	if (is_open)
-	{
-		// Mark as "closed"
-		is_open = false;
+    // Close all objects, if reader is 'open'
+    if (is_open)
+    {
+        // Mark as "closed"
+        is_open = false;
 
-		// Delete the image
-		image.reset();
+        // Delete the image
+        image.reset();
 
-		info.vcodec = "";
-		info.acodec = "";
-	}
+        info.vcodec = "";
+        info.acodec = "";
+    }
 }
 
 // Get an openshot::Frame object for a specific frame number of this reader.
 std::shared_ptr<Frame> QtImageReader::GetFrame(int64_t requested_frame)
 {
-	// Check for open reader (or throw exception)
-	if (!is_open)
-		throw ReaderClosed("The Image is closed.  Call Open() before calling this method.", path.toStdString());
+    // Check for open reader (or throw exception)
+    if (!is_open)
+        throw ReaderClosed("The Image is closed.  Call Open() before calling this method.", path.toStdString());
 
-	// Create a scoped lock, allowing only a single thread to run the following code at one time
-	const GenericScopedLock<CriticalSection> lock(getFrameCriticalSection);
+    // Create a scoped lock, allowing only a single thread to run the following code at one time
+    const GenericScopedLock<CriticalSection> lock(getFrameCriticalSection);
 
     // Calculate max image size
     QSize current_max_size = calculate_max_size();
@@ -197,8 +197,8 @@ std::shared_ptr<Frame> QtImageReader::GetFrame(int64_t requested_frame)
             sample_count, info.channels);
     image_frame->AddImage(cached_image);
 
-	// return frame object
-	return image_frame;
+    // return frame object
+    return image_frame;
 }
 
 // Calculate the max_size QSize, based on parent timeline and parent clip settings
@@ -332,53 +332,53 @@ QSize QtImageReader::load_svg_path(QString) {
 // Generate JSON string of this object
 std::string QtImageReader::Json() const {
 
-	// Return formatted string
-	return JsonValue().toStyledString();
+    // Return formatted string
+    return JsonValue().toStyledString();
 }
 
 // Generate Json::Value for this object
 Json::Value QtImageReader::JsonValue() const {
 
-	// Create root json object
-	Json::Value root = ReaderBase::JsonValue(); // get parent properties
-	root["type"] = "QtImageReader";
-	root["path"] = path.toStdString();
+    // Create root json object
+    Json::Value root = ReaderBase::JsonValue(); // get parent properties
+    root["type"] = "QtImageReader";
+    root["path"] = path.toStdString();
 
-	// return JsonValue
-	return root;
+    // return JsonValue
+    return root;
 }
 
 // Load JSON string into this object
 void QtImageReader::SetJson(const std::string value) {
 
-	// Parse JSON string into JSON objects
-	try
-	{
-		const Json::Value root = openshot::stringToJson(value);
-		// Set all values that match
-		SetJsonValue(root);
-	}
-	catch (const std::exception& e)
-	{
-		// Error parsing JSON (or missing keys)
-		throw InvalidJSON("JSON is invalid (missing keys or invalid data types)");
-	}
+    // Parse JSON string into JSON objects
+    try
+    {
+        const Json::Value root = openshot::stringToJson(value);
+        // Set all values that match
+        SetJsonValue(root);
+    }
+    catch (const std::exception& e)
+    {
+        // Error parsing JSON (or missing keys)
+        throw InvalidJSON("JSON is invalid (missing keys or invalid data types)");
+    }
 }
 
 // Load Json::Value into this object
 void QtImageReader::SetJsonValue(const Json::Value root) {
 
-	// Set parent data
-	ReaderBase::SetJsonValue(root);
+    // Set parent data
+    ReaderBase::SetJsonValue(root);
 
-	// Set data from Json (if key is found)
-	if (!root["path"].isNull())
-		path = QString::fromStdString(root["path"].asString());
+    // Set data from Json (if key is found)
+    if (!root["path"].isNull())
+        path = QString::fromStdString(root["path"].asString());
 
-	// Re-Open path, and re-init everything (if needed)
-	if (is_open)
-	{
-		Close();
-		Open();
-	}
+    // Re-Open path, and re-init everything (if needed)
+    if (is_open)
+    {
+        Close();
+        Open();
+    }
 }

--- a/src/QtImageReader.h
+++ b/src/QtImageReader.h
@@ -31,19 +31,35 @@
 #ifndef OPENSHOT_QIMAGE_READER_H
 #define OPENSHOT_QIMAGE_READER_H
 
-#include <cmath>
-#include <ctime>
-#include <iostream>
-#include <omp.h>
-#include <stdio.h>
 #include <memory>
+#include <string>
+
+#include <QString>
+#include <QSize>
 
 #include "ReaderBase.h"
+#include "Json.h"
+
+#if USE_RESVG == 1
+	// If defined and found in CMake, utilize the libresvg for parsing
+	// SVG files and rasterizing them to QImages.
+	#include "ResvgQt.h"
+
+    #define RESVG_VERSION_MIN(a, b) (\
+        RESVG_MAJOR_VERSION > a \
+        || (RESVG_MAJOR_VERSION == a && RESVG_MINOR_VERSION >= b) \
+    )
+#else
+    #define RESVG_VERSION_MIN(a, b) 0
+#endif
+
+class QImage;
 
 namespace openshot
 {
-	// Forward decl
-	class CacheBase;
+    // Forward decl
+    class CacheBase;
+    class Frame;
 
 	/**
 	 * @brief This class uses the Qt library, to open image files, and return
@@ -72,6 +88,10 @@ namespace openshot
 		std::shared_ptr<QImage> cached_image;	///> Scaled for performance
 		bool is_open;	///> Is Reader opened
 		QSize max_size;	///> Current max_size as calculated with Clip properties
+
+#if RESVG_VERSION_MIN(0, 11)
+        ResvgOptions resvg_options;
+#endif
 
 		/// Load an SVG file with Resvg or fallback with Qt
         ///


### PR DESCRIPTION
This PR adds in support for Resvg version `v0.11.0` and later (up to the current `v0.19.0`), which were previously  unsupported due to changes in the API. This makes Resvg much easier to integrate, as the old versions we _have_ been relying on require patching to be compatible with the current Qt5 LTS (5.15.x series).

In addition, the Resvg Find module is enhanced with version detection and reporting (if available, Resvg v0.5.0 and earlier didn't report the version number in the headers so it isn't available).

The Linux clang++ builds in our CI matrix are extended to perform a cached build of Resvg, and to use it when setting up libopenshot so that we can unit-test the integration.