### PR TITLE
CI: Validate repository licensing with Reuse

### DIFF
--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -1,3 +1,7 @@
+# © OpenShot Studios, LLC
+#
+# SPDX-License-Identifier: LGPL-3.0-or-later
+
 # Workflow to run 'reuse lint' via the reuse-action script,
 # which will flag any files added or changed in the repo
 # that don't have valid, verifiable license data associated

--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -1,0 +1,24 @@
+# Workflow to run 'reuse lint' via the reuse-action script,
+# which will flag any files added or changed in the repo
+# that don't have valid, verifiable license data associated
+# with them. See the .reuse/ directory in the repo, and
+# for more information visit https://reuse.software/
+
+name: Validate source licensing
+
+on:
+  # Triggers the workflow on push or pull request events but only for the develop branch
+  push:
+    branches: [ develop ]
+  pull_request:
+    branches: [ develop ]
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+jobs:
+  check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: REUSE Compliance Check
+        uses: fsfe/reuse-action@v1.1.1


### PR DESCRIPTION
Using a pre-packaged action from the Marketplace, the workflow will validate that the repo remains in compliance with the [Reuse standards](https://reuse.software/) for license management.

All new files should be tagged with both copyright and license identifier metadata, either directly via in-source comments, or for binary files, with a metadata block inserted into the `.reuse/dep5` file in the repo.

For more details see the existing source files, as well as the `.reuse/` and `LICENSES/` subdirs. Or just ping me for more info.