### PR TITLE
Unit tests: Fix accidental duplication

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -95,6 +95,7 @@ endforeach()
 catch_discover_tests(
   openshot-Settings-test
   TEST_LIST Settings_EXTRA_TESTS
+  TEST_SPEC "[environment]"
   TEST_PREFIX Settings:
   TEST_SUFFIX "(enabled)"
   TEST_WORKING_DIR "${_test_dir}"


### PR DESCRIPTION
When I removed BlackMagic support, I also made a minor adjustment to how I duplicate the extra Settings test that runs with and without an envvar set. While the new way is _cleaner_, it also requires that the test be defined correctly, or it'll unnecessarily duplicate _all_ Settings tests.

This PR adds the necessary constraints to ensure that only the test tagged as `[environment]` is duplicated.