### PR TITLE
Clip: Fix has_video, add unit test

### DIFF
--- a/src/Clip.cpp
+++ b/src/Clip.cpp
@@ -23,6 +23,8 @@
 #include "DummyReader.h"
 #include "Timeline.h"
 
+#include <Qt>
+
 using namespace openshot;
 
 // Init default settings for a clip
@@ -486,7 +488,7 @@ void Clip::get_time_mapped_frame(std::shared_ptr<Frame> frame, int64_t frame_num
 	// Check for a valid time map curve
 	if (time.GetLength() > 1)
 	{
-		const GenericScopedLock<juce::CriticalSection> lock(getFrameCriticalSection);
+		const juce::GenericScopedLock<juce::CriticalSection> lock(getFrameCriticalSection);
 
 		// create buffer and resampler
 		juce::AudioSampleBuffer *samples = NULL;
@@ -703,8 +705,10 @@ std::shared_ptr<Frame> Clip::GetOrCreateFrame(int64_t number)
 			// This allows a clip to modify the pixels and audio of this frame without
 			// changing the underlying reader's frame data
 			auto reader_copy = std::make_shared<Frame>(*reader_frame.get());
-			reader_copy->SampleRate(reader_frame->SampleRate());
-			reader_copy->ChannelsLayout(reader_frame->ChannelsLayout());
+                        if (has_video.GetInt(number) == 0)
+                            reader_copy->AddColor(QColor(Qt::transparent));
+                        if (has_audio.GetInt(number) == 0)
+                            reader_copy->AddAudioSilence(reader_copy->GetAudioSamplesCount());
 			return reader_copy;
 		}
 
@@ -789,10 +793,10 @@ std::string Clip::PropertiesJSON(int64_t requested_frame) const {
 	// Add waveform choices (dropdown style)
 	root["waveform"]["choices"].append(add_property_choice_json("Yes", true, waveform));
 	root["waveform"]["choices"].append(add_property_choice_json("No", false, waveform));
-	
+
 	// Add the parentTrackedObject's properties
 	if (parentTrackedObject)
-	{	
+	{
 		// Convert Clip's frame position to Timeline's frame position
 		long clip_start_position = round(Position() * info.fps.ToDouble()) + 1;
 		long clip_start_frame = (Start() * info.fps.ToDouble()) + 1;
@@ -803,7 +807,7 @@ std::string Clip::PropertiesJSON(int64_t requested_frame) const {
 		double parentObject_frame_number = trackedObjectParentClipProperties["frame_number"];
 		// Get attached object properties
 		std::map< std::string, float > trackedObjectProperties = parentTrackedObject->GetBoxValues(parentObject_frame_number);
-		
+
 		// Correct the parent Tracked Object properties by the clip's reference system
 		float parentObject_location_x = trackedObjectProperties["cx"] - 0.5 + trackedObjectParentClipProperties["cx"];
 		float parentObject_location_y = trackedObjectProperties["cy"] - 0.5 + trackedObjectParentClipProperties["cy"];
@@ -829,7 +833,7 @@ std::string Clip::PropertiesJSON(int64_t requested_frame) const {
 		double timeline_frame_number = requested_frame + clip_start_position - clip_start_frame;
 
 		// Correct the parent Clip Object properties by the clip's reference system
-		float parentObject_location_x = parentClipObject->location_x.GetValue(timeline_frame_number); 
+		float parentObject_location_x = parentClipObject->location_x.GetValue(timeline_frame_number);
 		float parentObject_location_y = parentClipObject->location_y.GetValue(timeline_frame_number);
 		float parentObject_scale_x = parentClipObject->scale_x.GetValue(timeline_frame_number);
 		float parentObject_scale_y = parentClipObject->scale_y.GetValue(timeline_frame_number);
@@ -1051,7 +1055,7 @@ void Clip::SetJsonValue(const Json::Value root) {
 
 				// Create instance of effect
 				if ( (e = EffectInfo().CreateEffect(existing_effect["type"].asString()))) {
-					
+
 					// Load Json into Effect
 					e->SetJsonValue(existing_effect);
 
@@ -1176,7 +1180,7 @@ void Clip::AddEffect(EffectBase* effect)
 
 			// Iterate through effect's vector of Tracked Objects
 			for (auto const& trackedObject : effect->trackedObjects){
-				
+
 				// Cast the Tracked Object as TrackedObjectBBox
 				std::shared_ptr<TrackedObjectBBox> trackedObjectBBox = std::static_pointer_cast<TrackedObjectBBox>(trackedObject.second);
 
@@ -1185,7 +1189,7 @@ void Clip::AddEffect(EffectBase* effect)
 
 				// Add the Tracked Object to the timeline
 				parentTimeline->AddTrackedObject(trackedObjectBBox);
-			}	
+			}
 		}
 	}
     #endif
@@ -1386,7 +1390,7 @@ QTransform Clip::get_transform(std::shared_ptr<Frame> frame, int width, int heig
 		double timeline_frame_number = frame->number + clip_start_position - clip_start_frame;
 
 		// Get parent object's properties (Clip)
-		parentObject_location_x = parentClipObject->location_x.GetValue(timeline_frame_number); 
+		parentObject_location_x = parentClipObject->location_x.GetValue(timeline_frame_number);
 		parentObject_location_y = parentClipObject->location_y.GetValue(timeline_frame_number);
 		parentObject_scale_x = parentClipObject->scale_x.GetValue(timeline_frame_number);
 		parentObject_scale_y = parentClipObject->scale_y.GetValue(timeline_frame_number);
@@ -1421,8 +1425,8 @@ QTransform Clip::get_transform(std::shared_ptr<Frame> frame, int width, int heig
 			parentObject_scale_x = trackedObjectProperties["w"]*trackedObjectProperties["sx"];
 			parentObject_scale_y = trackedObjectProperties["h"]*trackedObjectProperties["sy"];
 			parentObject_rotation = trackedObjectProperties["r"] + trackedObjectParentClipProperties["rotation"];
-		} 
-		else 
+		}
+		else
 		{
 			// Access the parentTrackedObject's properties
 			std::map<std::string, float> trackedObjectProperties = parentTrackedObject->GetBoxValues(timeline_frame_number);
@@ -1452,7 +1456,7 @@ QTransform Clip::get_transform(std::shared_ptr<Frame> frame, int width, int heig
 
     float scaled_source_width = source_size.width() * sx;
 	float scaled_source_height = source_size.height() * sy;
-	
+
 	switch (gravity)
 	{
 		case (GRAVITY_TOP_LEFT):
@@ -1492,7 +1496,7 @@ QTransform Clip::get_transform(std::shared_ptr<Frame> frame, int width, int heig
 	ZmqLogger::Instance()->AppendDebugMethod("Clip::get_transform (Gravity)", "frame->number", frame->number, "source_clip->gravity", gravity, "scaled_source_width", scaled_source_width, "scaled_source_height", scaled_source_height);
 
 	QTransform transform;
-		
+
 	/* LOCATION, ROTATION, AND SCALE */
 	float r = rotation.GetValue(frame->number) + parentObject_rotation; // rotate in degrees
 	x += (width * (location_x.GetValue(frame->number) + parentObject_location_x )); // move in percentage of final width
@@ -1508,7 +1512,7 @@ QTransform Clip::get_transform(std::shared_ptr<Frame> frame, int width, int heig
 	if (!isEqual(x, 0) || !isEqual(y, 0)) {
 		// TRANSLATE/MOVE CLIP
 		transform.translate(x, y);
-	} 
+	}
 	if (!isEqual(r, 0) || !isEqual(shear_x_value, 0) || !isEqual(shear_y_value, 0)) {
 		// ROTATE CLIP (around origin_x, origin_y)
 		float origin_x_offset = (scaled_source_width * origin_x_value);

--- a/src/Frame.h
+++ b/src/Frame.h
@@ -91,7 +91,7 @@ namespace openshot
 	private:
 		std::shared_ptr<QImage> image;
 		std::shared_ptr<QImage> wave_image;
-		
+
 		std::shared_ptr<QApplication> previewApp;
 		juce::CriticalSection addingImageSection;
         juce::CriticalSection addingAudioSection;
@@ -142,10 +142,12 @@ namespace openshot
 
 		/// Add (or replace) pixel data to the frame (based on a solid color)
 		void AddColor(int new_width, int new_height, std::string new_color);
+                /// Add (or replace) pixel data (filled with new_color)
+		void AddColor(const QColor& new_color);
 
 		/// Add (or replace) pixel data to the frame
 		void AddImage(int new_width, int new_height, int bytes_per_pixel, QImage::Format type, const unsigned char *pixels_);
- 
+
 		/// Add (or replace) pixel data to the frame
 		void AddImage(std::shared_ptr<QImage> new_image);
 

--- a/tests/Clip.cpp
+++ b/tests/Clip.cpp
@@ -15,7 +15,12 @@
 
 #include <catch2/catch.hpp>
 
+#include <QColor>
+#include <QImage>
+#include <QSize>
+
 #include "Clip.h"
+#include "Enums.h"
 #include "Frame.h"
 #include "Fraction.h"
 #include "Timeline.h"
@@ -231,4 +236,42 @@ TEST_CASE( "verify parent Timeline", "[libopenshot][clip]" )
 	// Check size of frame image (with an associated timeline)
 	CHECK(640 == c1.GetFrame(1)->GetImage()->width());
 	CHECK(360 == c1.GetFrame(1)->GetImage()->height());
+}
+
+TEST_CASE( "has_video", "[libopenshot][clip]" )
+{
+    std::stringstream path;
+    path << TEST_MEDIA_PATH << "sintel_trailer-720p.mp4";
+    openshot::Clip c1(path.str());
+
+    c1.has_video.AddPoint(1.0, 0.0);
+    c1.has_video.AddPoint(5.0, -1.0, openshot::CONSTANT);
+    c1.has_video.AddPoint(10.0, 1.0, openshot::CONSTANT);
+
+    c1.Open();
+
+    auto trans_color = QColor(Qt::transparent);
+    auto f1 = c1.GetFrame(1);
+    CHECK(f1->has_image_data);
+
+    auto f2 = c1.GetFrame(5);
+    CHECK(f2->has_image_data);
+
+    auto f3 = c1.GetFrame(5);
+    CHECK(f3->has_image_data);
+
+    auto i1 = f1->GetImage();
+    QSize f1_size(f1->GetWidth(), f1->GetHeight());
+    CHECK(i1->size() == f1_size);
+    CHECK(i1->pixelColor(20, 20) == trans_color);
+
+    auto i2 = f2->GetImage();
+    QSize f2_size(f2->GetWidth(), f2->GetHeight());
+    CHECK(i2->size() == f2_size);
+    CHECK(i2->pixelColor(20, 20) != trans_color);
+
+    auto i3 = f3->GetImage();
+    QSize f3_size(f3->GetWidth(), f3->GetHeight());
+    CHECK(i3->size() == f3_size);
+    CHECK(i3->pixelColor(20, 20) != trans_color);
 }


### PR DESCRIPTION
Turns out, the ability to set `has_video` keyframes on Clip objects has been broken since the most recent compositing changes — it's ignored and the Clip always outputs video if the Reader provides any.

This PR fixes `has_video` by having `Clip::GetOrCreateFrame()` re-fill the copied Frame's image with Qt::transparent, if `has_video` evaluates to `0` for that frame.

It also fills the audio with silence, if `has_audio` evaluates to `0`, though Timeline was probably already taking care of that.

To accommodate this fix, a new overload is added to `Frame.cpp`: `Frame::AddColor(const QColor&)`. The existing `Frame::AddColor(int w, int h, std::string color)` is rewritten as a thin wrapper around `Frame::AddColor(const QColor&)`, to avoid code duplication.

A `has_video` unit test is added for the Clip class, which verifies that the frame image is transparent when `has_video` is `0`.

I'm not **100%** sure this DTRT for all permutations of readers that output video-only, readers that output audio-only, etc. It could use more testing. I know it works for video+audio clips, rendering the video invisible when `has_video == 0`.