### PR TITLE
Include FFmpegUtilities.h earlier

### DIFF
--- a/src/FFmpegReader.cpp
+++ b/src/FFmpegReader.cpp
@@ -13,6 +13,8 @@
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
+#include "FFmpegUtilities.h"
+
 #include "FFmpegReader.h"
 #include "Exceptions.h"
 #include "Timeline.h"

--- a/src/FFmpegWriter.cpp
+++ b/src/FFmpegWriter.cpp
@@ -13,6 +13,8 @@
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
+#include "FFmpegUtilities.h"
+
 #include "FFmpegWriter.h"
 #include "Exceptions.h"
 


### PR DESCRIPTION
It's a minor thing, but including `FFmpegUtilities.h` _before_ any libopenshot headers changes compiler warnings from this:

```text
src/FFmpegWriter.cpp: In member function ‘void openshot::FFmpegWriter::flush_encoders()’:
src/FFmpegWriter.cpp:835:39: warning: ‘void av_init_packet(AVPacket*)’ is deprecated [-Wdeprecated-declarations]
  835 |                         av_init_packet(&pkt);
      |                         ~~~~~~~~~~~~~~^~~~~~
In file included from /usr/include/ffmpeg/libavcodec/bsf.h:30,
                 from /usr/include/ffmpeg/libavcodec/avcodec.h:44,
                 from src/FFmpegUtilities.h:38,
                 from src/ChannelLayouts.h:17,
                 from src/Frame.h:33,
                 from src/CacheBase.h:21,
                 from src/CacheMemory.h:19,
                 from src/ReaderBase.h:19,
                 from src/FFmpegWriter.h:19,
                 from src/FFmpegWriter.cpp:16:
/usr/include/ffmpeg/libavcodec/packet.h:488:6: note: declared here
  488 | void av_init_packet(AVPacket *pkt);
      |      ^~~~~~~~~~~~~~
src/FFmpegWriter.cpp:888:27: warning: ‘void av_init_packet(AVPacket*)’ is deprecated [-Wdeprecated-declarations]
  888 |             av_init_packet(&pkt);
      |             ~~~~~~~~~~~~~~^~~~~~
In file included from /usr/include/ffmpeg/libavcodec/bsf.h:30,
                 from /usr/include/ffmpeg/libavcodec/avcodec.h:44,
                 from src/FFmpegUtilities.h:38,
                 from src/ChannelLayouts.h:17,
                 from src/Frame.h:33,
                 from src/CacheBase.h:21,
                 from src/CacheMemory.h:19,
                 from src/ReaderBase.h:19,
                 from src/FFmpegWriter.h:19,
                 from src/FFmpegWriter.cpp:16:
/usr/include/ffmpeg/libavcodec/packet.h:488:6: note: declared here
  488 | void av_init_packet(AVPacket *pkt);
      |      ^~~~~~~~~~~~~~
src/FFmpegWriter.cpp: In member function ‘void openshot::FFmpegWriter::write_audio_packets(bool)’:
src/FFmpegWriter.cpp:1823:23: warning: ‘void av_init_packet(AVPacket*)’ is deprecated [-Wdeprecated-declarations]
 1823 |         av_init_packet(&pkt);
      |         ~~~~~~~~~~~~~~^~~~~~
In file included from /usr/include/ffmpeg/libavcodec/bsf.h:30,
                 from /usr/include/ffmpeg/libavcodec/avcodec.h:44,
                 from src/FFmpegUtilities.h:38,
                 from src/ChannelLayouts.h:17,
                 from src/Frame.h:33,
                 from src/CacheBase.h:21,
                 from src/CacheMemory.h:19,
                 from src/ReaderBase.h:19,
                 from src/FFmpegWriter.h:19,
                 from src/FFmpegWriter.cpp:16:
/usr/include/ffmpeg/libavcodec/packet.h:488:6: note: declared here
  488 | void av_init_packet(AVPacket *pkt);
      |      ^~~~~~~~~~~~~~
src/FFmpegWriter.cpp: In member function ‘bool openshot::FFmpegWriter::write_video_packet(std::shared_ptr<openshot::Frame>, AVFrame*)’:
src/FFmpegWriter.cpp:2021:31: warning: ‘void av_init_packet(AVPacket*)’ is deprecated [-Wdeprecated-declarations]
 2021 |                 av_init_packet(&pkt);
      |                 ~~~~~~~~~~~~~~^~~~~~
In file included from /usr/include/ffmpeg/libavcodec/bsf.h:30,
                 from /usr/include/ffmpeg/libavcodec/avcodec.h:44,
                 from src/FFmpegUtilities.h:38,
                 from src/ChannelLayouts.h:17,
                 from src/Frame.h:33,
                 from src/CacheBase.h:21,
                 from src/CacheMemory.h:19,
                 from src/ReaderBase.h:19,
                 from src/FFmpegWriter.h:19,
                 from src/FFmpegWriter.cpp:16:
/usr/include/ffmpeg/libavcodec/packet.h:488:6: note: declared here
  488 | void av_init_packet(AVPacket *pkt);
      |      ^~~~~~~~~~~~~~
src/FFmpegWriter.cpp:2045:31: warning: ‘void av_init_packet(AVPacket*)’ is deprecated [-Wdeprecated-declarations]
 2045 |                 av_init_packet(&pkt);
      |                 ~~~~~~~~~~~~~~^~~~~~
In file included from /usr/include/ffmpeg/libavcodec/bsf.h:30,
                 from /usr/include/ffmpeg/libavcodec/avcodec.h:44,
                 from src/FFmpegUtilities.h:38,
                 from src/ChannelLayouts.h:17,
                 from src/Frame.h:33,
                 from src/CacheBase.h:21,
                 from src/CacheMemory.h:19,
                 from src/ReaderBase.h:19,
                 from src/FFmpegWriter.h:19,
                 from src/FFmpegWriter.cpp:16:
/usr/include/ffmpeg/libavcodec/packet.h:488:6: note: declared here
  488 | void av_init_packet(AVPacket *pkt);
      |      ^~~~~~~~~~~~~~
```

to this:

```text
src/FFmpegWriter.cpp: In member function ‘void openshot::FFmpegWriter::flush_encoders()’:
src/FFmpegWriter.cpp:837:39: warning: ‘void av_init_packet(AVPacket*)’ is deprecated [-Wdeprecated-declarations]
  837 |                         av_init_packet(&pkt);
      |                         ~~~~~~~~~~~~~~^~~~~~
In file included from /usr/include/ffmpeg/libavcodec/bsf.h:30,
                 from /usr/include/ffmpeg/libavcodec/avcodec.h:44,
                 from src/FFmpegUtilities.h:38,
                 from src/FFmpegWriter.cpp:16:
/usr/include/ffmpeg/libavcodec/packet.h:488:6: note: declared here
  488 | void av_init_packet(AVPacket *pkt);
      |      ^~~~~~~~~~~~~~
src/FFmpegWriter.cpp:890:27: warning: ‘void av_init_packet(AVPacket*)’ is deprecated [-Wdeprecated-declarations]
  890 |             av_init_packet(&pkt);
      |             ~~~~~~~~~~~~~~^~~~~~
In file included from /usr/include/ffmpeg/libavcodec/bsf.h:30,
                 from /usr/include/ffmpeg/libavcodec/avcodec.h:44,
                 from src/FFmpegUtilities.h:38,
                 from src/FFmpegWriter.cpp:16:
/usr/include/ffmpeg/libavcodec/packet.h:488:6: note: declared here
  488 | void av_init_packet(AVPacket *pkt);
      |      ^~~~~~~~~~~~~~
src/FFmpegWriter.cpp: In member function ‘void openshot::FFmpegWriter::write_audio_packets(bool)’:
src/FFmpegWriter.cpp:1825:23: warning: ‘void av_init_packet(AVPacket*)’ is deprecated [-Wdeprecated-declarations]
 1825 |         av_init_packet(&pkt);
      |         ~~~~~~~~~~~~~~^~~~~~
In file included from /usr/include/ffmpeg/libavcodec/bsf.h:30,
                 from /usr/include/ffmpeg/libavcodec/avcodec.h:44,
                 from src/FFmpegUtilities.h:38,
                 from src/FFmpegWriter.cpp:16:
/usr/include/ffmpeg/libavcodec/packet.h:488:6: note: declared here
  488 | void av_init_packet(AVPacket *pkt);
      |      ^~~~~~~~~~~~~~
src/FFmpegWriter.cpp: In member function ‘bool openshot::FFmpegWriter::write_video_packet(std::shared_ptr<openshot::Frame>, AVFrame*)’:
src/FFmpegWriter.cpp:2023:31: warning: ‘void av_init_packet(AVPacket*)’ is deprecated [-Wdeprecated-declarations]
 2023 |                 av_init_packet(&pkt);
      |                 ~~~~~~~~~~~~~~^~~~~~
In file included from /usr/include/ffmpeg/libavcodec/bsf.h:30,
                 from /usr/include/ffmpeg/libavcodec/avcodec.h:44,
                 from src/FFmpegUtilities.h:38,
                 from src/FFmpegWriter.cpp:16:
/usr/include/ffmpeg/libavcodec/packet.h:488:6: note: declared here
  488 | void av_init_packet(AVPacket *pkt);
      |      ^~~~~~~~~~~~~~
src/FFmpegWriter.cpp:2047:31: warning: ‘void av_init_packet(AVPacket*)’ is deprecated [-Wdeprecated-declarations]
 2047 |                 av_init_packet(&pkt);
      |                 ~~~~~~~~~~~~~~^~~~~~
In file included from /usr/include/ffmpeg/libavcodec/bsf.h:30,
                 from /usr/include/ffmpeg/libavcodec/avcodec.h:44,
                 from src/FFmpegUtilities.h:38,
                 from src/FFmpegWriter.cpp:16:
/usr/include/ffmpeg/libavcodec/packet.h:488:6: note: declared here
  488 | void av_init_packet(AVPacket *pkt);
      |      ^~~~~~~~~~~~~~
```

Which, you know... is the difference between readable and WTF?
