### PR TITLE
Fix babl builds on Windows by setting the babl_DIR CMake variable

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -102,7 +102,7 @@ windows-builder-x86:
     - try { Invoke-WebRequest -Uri "http://gitlab.openshot.org/OpenShot/libopenshot-audio/-/jobs/artifacts/$CI_COMMIT_REF_NAME/download?job=windows-builder-x86" -Headers @{"PRIVATE-TOKEN"="$ACCESS_TOKEN"} -OutFile "artifacts.zip" } catch { $_.Exception.Response.StatusCode.Value__ }
     - if (-not (Test-Path "artifacts.zip")) { Invoke-WebRequest -Uri "http://gitlab.openshot.org/OpenShot/libopenshot-audio/-/jobs/artifacts/develop/download?job=windows-builder-x86" -Headers @{"PRIVATE-TOKEN"="$ACCESS_TOKEN"} -OutFile "artifacts.zip" }
     - Expand-Archive -Path artifacts.zip -DestinationPath .
-    - $env:Path = "C:\msys64\mingw32\bin;C:\msys64\usr\bin;C:\msys64\usr\local\bin;" + $env:Path;
+    - $env:Path = "C:\msys64\mingw32\bin;C:\msys64\mingw32\lib\;C:\msys64\usr\bin;C:\msys64\usr\local\bin;" + $env:Path;
     - $env:MSYSTEM = "MINGW32"
     - cmake -B build -S . -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -D"CMAKE_INSTALL_PREFIX:PATH=$CI_PROJECT_DIR\build\install-x86" -D"OpenShotAudio_ROOT=$CI_PROJECT_DIR\build\install-x86" -D"PYTHON_MODULE_PATH=python" -D"RUBY_MODULE_PATH=ruby" -G "MinGW Makefiles" -D"CMAKE_BUILD_TYPE:STRING=Release" -D"CMAKE_CXX_FLAGS=-m32" -D"CMAKE_EXE_LINKER_FLAGS=-Wl,--large-address-aware" -D"CMAKE_C_FLAGS=-m32"
     - cmake --build build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -77,7 +77,6 @@ windows-builder-x64:
     - Expand-Archive -Path artifacts.zip -DestinationPath .
     - $env:Path = "C:\msys64\mingw64\bin;C:\msys64\usr\bin;C:\msys64\usr\local\bin;" + $env:Path;
     - $env:MSYSTEM = "MINGW64"
-    - $env:babl_DIR = "C:/msys64/mingw64"
     - cmake -B build -S . -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -D"babl_DIR=C:/msys64/mingw64" -D"CMAKE_INSTALL_PREFIX:PATH=$CI_PROJECT_DIR\build\install-x64" -D"OpenShotAudio_ROOT=$CI_PROJECT_DIR\build\install-x64" -D"PYTHON_MODULE_PATH=python" -D"RUBY_MODULE_PATH=ruby" -G "MinGW Makefiles" -D"CMAKE_BUILD_TYPE:STRING=Release"
     - cmake --build build
     - cmake --build build --target coverage
@@ -105,7 +104,6 @@ windows-builder-x86:
     - Expand-Archive -Path artifacts.zip -DestinationPath .
     - $env:Path = "C:\msys64\mingw32\bin;C:\msys64\usr\bin;C:\msys64\usr\local\bin;" + $env:Path;
     - $env:MSYSTEM = "MINGW32"
-    - $env:babl_DIR = "C:/msys64/mingw32"
     - cmake -B build -S . -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -D"babl_DIR=C:/msys64/mingw32" -D"CMAKE_INSTALL_PREFIX:PATH=$CI_PROJECT_DIR\build\install-x86" -D"OpenShotAudio_ROOT=$CI_PROJECT_DIR\build\install-x86" -D"PYTHON_MODULE_PATH=python" -D"RUBY_MODULE_PATH=ruby" -G "MinGW Makefiles" -D"CMAKE_BUILD_TYPE:STRING=Release" -D"CMAKE_CXX_FLAGS=-m32" -D"CMAKE_EXE_LINKER_FLAGS=-Wl,--large-address-aware" -D"CMAKE_C_FLAGS=-m32"
     - cmake --build build
     - cmake --build build --target coverage

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -78,7 +78,7 @@ windows-builder-x64:
     - $env:Path = "C:\msys64\mingw64\bin;C:\msys64\usr\bin;C:\msys64\usr\local\bin;" + $env:Path;
     - $env:MSYSTEM = "MINGW64"
     - $env:babl_DIR = "C:/msys64/mingw64"
-    - cmake -B build -S . -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -D"CMAKE_INSTALL_PREFIX:PATH=$CI_PROJECT_DIR\build\install-x64" -D"OpenShotAudio_ROOT=$CI_PROJECT_DIR\build\install-x64" -D"PYTHON_MODULE_PATH=python" -D"RUBY_MODULE_PATH=ruby" -G "MinGW Makefiles" -D"CMAKE_BUILD_TYPE:STRING=Release"
+    - cmake -B build -S . -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -D"babl_DIR=C:/msys64/mingw64" -D"CMAKE_INSTALL_PREFIX:PATH=$CI_PROJECT_DIR\build\install-x64" -D"OpenShotAudio_ROOT=$CI_PROJECT_DIR\build\install-x64" -D"PYTHON_MODULE_PATH=python" -D"RUBY_MODULE_PATH=ruby" -G "MinGW Makefiles" -D"CMAKE_BUILD_TYPE:STRING=Release"
     - cmake --build build
     - cmake --build build --target coverage
     - cmake --install build
@@ -106,7 +106,7 @@ windows-builder-x86:
     - $env:Path = "C:\msys64\mingw32\bin;C:\msys64\usr\bin;C:\msys64\usr\local\bin;" + $env:Path;
     - $env:MSYSTEM = "MINGW32"
     - $env:babl_DIR = "C:/msys64/mingw32"
-    - cmake -B build -S . -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -D"CMAKE_INSTALL_PREFIX:PATH=$CI_PROJECT_DIR\build\install-x86" -D"OpenShotAudio_ROOT=$CI_PROJECT_DIR\build\install-x86" -D"PYTHON_MODULE_PATH=python" -D"RUBY_MODULE_PATH=ruby" -G "MinGW Makefiles" -D"CMAKE_BUILD_TYPE:STRING=Release" -D"CMAKE_CXX_FLAGS=-m32" -D"CMAKE_EXE_LINKER_FLAGS=-Wl,--large-address-aware" -D"CMAKE_C_FLAGS=-m32"
+    - cmake -B build -S . -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -D"babl_DIR=C:/msys64/mingw32" -D"CMAKE_INSTALL_PREFIX:PATH=$CI_PROJECT_DIR\build\install-x86" -D"OpenShotAudio_ROOT=$CI_PROJECT_DIR\build\install-x86" -D"PYTHON_MODULE_PATH=python" -D"RUBY_MODULE_PATH=ruby" -G "MinGW Makefiles" -D"CMAKE_BUILD_TYPE:STRING=Release" -D"CMAKE_CXX_FLAGS=-m32" -D"CMAKE_EXE_LINKER_FLAGS=-Wl,--large-address-aware" -D"CMAKE_C_FLAGS=-m32"
     - cmake --build build
     - cmake --build build --target coverage
     - cmake --install build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -77,6 +77,7 @@ windows-builder-x64:
     - Expand-Archive -Path artifacts.zip -DestinationPath .
     - $env:Path = "C:\msys64\mingw64\bin;C:\msys64\usr\bin;C:\msys64\usr\local\bin;" + $env:Path;
     - $env:MSYSTEM = "MINGW64"
+    - $env:babl_DIR = "C:/msys64/mingw64"
     - cmake -B build -S . -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -D"CMAKE_INSTALL_PREFIX:PATH=$CI_PROJECT_DIR\build\install-x64" -D"OpenShotAudio_ROOT=$CI_PROJECT_DIR\build\install-x64" -D"PYTHON_MODULE_PATH=python" -D"RUBY_MODULE_PATH=ruby" -G "MinGW Makefiles" -D"CMAKE_BUILD_TYPE:STRING=Release"
     - cmake --build build
     - cmake --build build --target coverage
@@ -102,8 +103,9 @@ windows-builder-x86:
     - try { Invoke-WebRequest -Uri "http://gitlab.openshot.org/OpenShot/libopenshot-audio/-/jobs/artifacts/$CI_COMMIT_REF_NAME/download?job=windows-builder-x86" -Headers @{"PRIVATE-TOKEN"="$ACCESS_TOKEN"} -OutFile "artifacts.zip" } catch { $_.Exception.Response.StatusCode.Value__ }
     - if (-not (Test-Path "artifacts.zip")) { Invoke-WebRequest -Uri "http://gitlab.openshot.org/OpenShot/libopenshot-audio/-/jobs/artifacts/develop/download?job=windows-builder-x86" -Headers @{"PRIVATE-TOKEN"="$ACCESS_TOKEN"} -OutFile "artifacts.zip" }
     - Expand-Archive -Path artifacts.zip -DestinationPath .
-    - $env:Path = "C:\msys64\mingw32\bin;C:\msys64\mingw32\lib\;C:\msys64\usr\bin;C:\msys64\usr\local\bin;" + $env:Path;
+    - $env:Path = "C:\msys64\mingw32\bin;C:\msys64\usr\bin;C:\msys64\usr\local\bin;" + $env:Path;
     - $env:MSYSTEM = "MINGW32"
+    - $env:babl_DIR = "C:/msys64/mingw32"
     - cmake -B build -S . -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -D"CMAKE_INSTALL_PREFIX:PATH=$CI_PROJECT_DIR\build\install-x86" -D"OpenShotAudio_ROOT=$CI_PROJECT_DIR\build\install-x86" -D"PYTHON_MODULE_PATH=python" -D"RUBY_MODULE_PATH=ruby" -G "MinGW Makefiles" -D"CMAKE_BUILD_TYPE:STRING=Release" -D"CMAKE_CXX_FLAGS=-m32" -D"CMAKE_EXE_LINKER_FLAGS=-Wl,--large-address-aware" -D"CMAKE_C_FLAGS=-m32"
     - cmake --build build
     - cmake --build build --target coverage

--- a/doc/INSTALL-LINUX.md
+++ b/doc/INSTALL-LINUX.md
@@ -147,6 +147,7 @@ software packages available to download and install.
                         libavformat-dev \
                         libavresample-dev \
                         libavutil-dev \
+                        libbabl-dev \
                         libfdk-aac-dev \
                         libfreetype6-dev \
                         libjsoncpp-dev \

--- a/doc/INSTALL-MAC.md
+++ b/doc/INSTALL-MAC.md
@@ -151,6 +151,7 @@ brew install unittest-cpp --cc=gcc-4.8. You must specify the c++ compiler with t
 brew install qt5
 brew install cmake
 brew install zeromq
+brew install babl
 ```
 
 ## Mac Build Instructions (libopenshot-audio)

--- a/doc/INSTALL-WINDOWS.md
+++ b/doc/INSTALL-WINDOWS.md
@@ -201,6 +201,7 @@ pacman -S mingw64/mingw-w64-x86_64-python3-pip
 pacman -S mingw32/mingw-w64-i686-zeromq
 pacman -S mingw64/mingw-w64-x86_64-python3-pyzmq
 pacman -S mingw64/mingw-w64-x86_64-python3-cx_Freeze
+pacman -S mingw64/mingw-w64-x86_64-ninja
 pacman -S git
 
 # Install ImageMagick if needed (OPTIONAL and NOT NEEDED)
@@ -220,6 +221,7 @@ pacman -S mingw32/mingw-w64-i686-python3-pip
 pacman -S mingw32/mingw-w64-i686-zeromq
 pacman -S mingw32/mingw-w64-i686-python3-pyzmq
 pacman -S mingw32/mingw-w64-i686-python3-cx_Freeze
+pacman -S mingw32/mingw-w64-i686-ninja
 pacman -S git
 
 # Install ImageMagick if needed (OPTIONAL and NOT NEEDED)
@@ -234,6 +236,7 @@ pip3 install slacker
 pip3 install tinys3
 pip3 install github3.py
 pip3 install requests
+pip3 install meson
 ```  
 
 7) Download Unittest++ (https://github.com/unittest-cpp/unittest-cpp) into /MSYS2/[USER]/unittest-cpp-master/
@@ -243,7 +246,17 @@ cmake -G "MSYS Makefiles" ../ -DCMAKE_MAKE_PROGRAM=mingw32-make -DCMAKE_INSTALL_
 mingw32-make install
 ```
 
-8) ZMQ++ Header (This might not be needed anymore)
+8) Install babl pixel encoding and color space conversion engine (https://gegl.org/babl/)
+
+``` 
+git clone https://gitlab.gnome.org/GNOME/babl.git
+cd babl
+meson build --prefix=C:/msys64/mingw32
+cd build
+meson install
+```
+
+9) ZMQ++ Header (This might not be needed anymore)
   NOTE: Download and copy zmq.hpp into the /c/msys64/mingw64/include/ folder
 
 ## Manual Dependencies


### PR DESCRIPTION
Apparently, on Windows, the `Findbabl.cmake` file does not locate the full path of the INCLUDE or LIBRARY files for Babl. Setting a specific Cmake variable, fixes the issue. This is related to https://github.com/OpenShot/libopenshot/pull/716.