### PR TITLE
Avoid a bug in ImageMagick or cassert headers

### DIFF
--- a/src/ChunkReader.cpp
+++ b/src/ChunkReader.cpp
@@ -10,6 +10,8 @@
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
+#include <fstream>
+
 #include "ChunkReader.h"
 #include "Exceptions.h"
 #include "FFmpegReader.h"

--- a/src/Clip.cpp
+++ b/src/Clip.cpp
@@ -14,14 +14,17 @@
 #include "Exceptions.h"
 #include "FFmpegReader.h"
 #include "FrameMapper.h"
-#ifdef USE_IMAGEMAGICK
-	#include "ImageReader.h"
-	#include "TextReader.h"
-#endif
 #include "QtImageReader.h"
 #include "ChunkReader.h"
 #include "DummyReader.h"
 #include "Timeline.h"
+#include "ZmqLogger.h"
+
+#ifdef USE_IMAGEMAGICK
+    #include "MagickUtilities.h"
+    #include "ImageReader.h"
+    #include "TextReader.h"
+#endif
 
 #include <Qt>
 

--- a/src/FFmpegReader.cpp
+++ b/src/FFmpegReader.cpp
@@ -18,6 +18,7 @@
 #include "FFmpegReader.h"
 #include "Exceptions.h"
 #include "Timeline.h"
+#include "ZmqLogger.h"
 
 #include <thread>    // for std::this_thread::sleep_for
 #include <chrono>    // for std::chrono::milliseconds

--- a/src/Frame.cpp
+++ b/src/Frame.cpp
@@ -10,6 +10,11 @@
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
+#include <thread>    // for std::this_thread::sleep_for
+#include <chrono>    // for std::chrono::milliseconds
+#include <sstream>
+#include <iomanip>
+
 #include "Frame.h"
 #include <OpenShotAudio.h>
 
@@ -27,8 +32,9 @@
 #include <QPointF>
 #include <QWidget>
 
-#include <thread>    // for std::this_thread::sleep_for
-#include <chrono>    // for std::chrono::milliseconds
+#ifdef USE_IMAGEMAGICK
+    #include "MagickUtilities.h"
+#endif
 
 using namespace std;
 using namespace openshot;

--- a/src/Frame.h
+++ b/src/Frame.h
@@ -21,23 +21,27 @@
 	#undef int64
 #endif
 
-
-#include <iomanip>
-#include <sstream>
 #include <queue>
-#include <QApplication>
-#include <QImage>
 #include <memory>
-#include <unistd.h>
-#include "ZmqLogger.h"
+
 #include "ChannelLayouts.h"
 #include "AudioBufferSource.h"
 #include "AudioResampler.h"
 #include "Fraction.h"
+
 #include <OpenShotAudio.h>
+
+#include <QColor>
+#include <QImage>
+
 #ifdef USE_IMAGEMAGICK
-	#include "MagickUtilities.h"
+// Forward declare Magick::Image
+namespace Magick {
+    class Image;
+}
 #endif
+
+class QApplication;
 
 namespace openshot
 {

--- a/src/FrameMapper.cpp
+++ b/src/FrameMapper.cpp
@@ -17,6 +17,7 @@
 #include "FrameMapper.h"
 #include "Exceptions.h"
 #include "Clip.h"
+#include "ZmqLogger.h"
 
 using namespace std;
 using namespace openshot;

--- a/src/MagickUtilities.h
+++ b/src/MagickUtilities.h
@@ -14,6 +14,13 @@
 
 #ifdef USE_IMAGEMAGICK
 
+    // Avoid a bug in the interaction between ImageMagick
+    // and the standard C insertion headers, which can
+    // cause functions used by macros in the standard C
+    // assertion code to be put in an ImageMagick library
+    // namespace instead of the global namespace
+    #include <cassert>
+
 // Exclude a warning message with IM6 headers
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wignored-qualifiers"

--- a/src/Qt/PlayerPrivate.cpp
+++ b/src/Qt/PlayerPrivate.cpp
@@ -13,6 +13,7 @@
 
 #include "PlayerPrivate.h"
 #include "Exceptions.h"
+#include "ZmqLogger.h"
 
 #include <thread>    // for std::this_thread::sleep_for
 #include <chrono>    // for std::chrono milliseconds, high_resolution_clock

--- a/src/Qt/VideoCacheThread.cpp
+++ b/src/Qt/VideoCacheThread.cpp
@@ -12,8 +12,9 @@
 
 #include "VideoCacheThread.h"
 #include "Exceptions.h"
-#include <algorithm>
+#include "ZmqLogger.h"
 
+#include <algorithm>
 #include <thread>    // for std::this_thread::sleep_for
 #include <chrono>    // for std::chrono::milliseconds
 

--- a/src/Qt/VideoPlaybackThread.cpp
+++ b/src/Qt/VideoPlaybackThread.cpp
@@ -12,6 +12,7 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
 #include "VideoPlaybackThread.h"
+#include "ZmqLogger.h"
 
 namespace openshot
 {

--- a/src/TrackedObjectBBox.cpp
+++ b/src/TrackedObjectBBox.cpp
@@ -11,6 +11,8 @@
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
+#include <fstream>
+
 #include "TrackedObjectBBox.h"
 
 #include "Clip.h"


### PR DESCRIPTION
At least on Debian bullseye as at today, the ImageMagick headers
include &lt;cassert&gt; with an ImageMagick namespace current. <cassert>
and the headers it then pulls in also do not set the namespace.
Those headers then declare functions such as __assert_fail, which
end up in the ImageMagick namespace. This causes failures in other
parts of the build, such as the ZeroMQ code. This seems to be a
bug in either the ImageMagick headers or the &lt;cassert&gt; header, but
can be easily worked around by including &lt;cassert&gt; before any
ImageMagick header. This change does so.