### PR TITLE
Fraction: Operators for direct autoconverting multiplication and division, in both C++ and Python

### DIFF
--- a/bindings/python/openshot.i
+++ b/bindings/python/openshot.i
@@ -209,6 +209,31 @@
 		def values(self):
 			_items = self.GetMap()
 			return _items.values()
+		def __mul__(self, other):
+			if isinstance(other, Fraction):
+				return Fraction(self.num * other.num, self.den * other.den)
+			return float(self) * other
+		def __rmul__(self, other):
+			return other * float(self)
+		def __truediv__(self, other):
+			if isinstance(other, Fraction):
+				return Fraction(self.num * other.den, self.den * other.num)
+			return float(self) / other;
+		def __rtruediv__(self, other):
+			return other / float(self)
+		def __format__(self, format_spec):
+			integer_fmt = "bcdoxX"
+			float_fmt = "eEfFgGn%"
+			all_fmt = "".join(["s", integer_fmt, float_fmt])
+			if not format_spec or format_spec[-1] not in all_fmt:
+			  value = str(self)
+			elif format_spec[-1] in integer_fmt:
+				value = int(self)
+			elif format_spec[-1] in float_fmt:
+				value = float(self)
+			else:
+				value = str(self)
+			return "{value:{spec}}".format(value=value, spec=format_spec)
 	%}
 }
 

--- a/src/Fraction.h
+++ b/src/Fraction.h
@@ -64,7 +64,43 @@ public:
 
 	/// Return the reciprocal as a Fraction
 	Fraction Reciprocal() const;
+
+    // Multiplication and division
+
+    /// Multiply two Fraction objects together
+    openshot::Fraction operator*(openshot::Fraction other) {
+        return openshot::Fraction(num * other.num, den * other.den);
+    }
+
+    /// Divide a Fraction by another Fraction
+    openshot::Fraction operator/(openshot::Fraction other) {
+        return *this * other.Reciprocal();
+    }
+
+    /// Multiplication in the form (openshot_Fraction * numeric_value)
+    template<class numT>
+    numT operator*(const numT& other) const {
+        return static_cast<numT>(ToDouble() * other);
+    }
+
+    /// Division in the form (openshot_Fraction / numeric_value)
+    template<class numT>
+    numT operator/(const numT& other) const {
+        return static_cast<numT>(ToDouble() / other);
+    }
 };
+
+/// Multiplication in the form (numeric_value * openshot_Fraction)
+template<class numT>
+numT operator*(const numT& left, const openshot::Fraction& right) {
+    return static_cast<numT>(left * right.ToDouble());
+}
+
+/// Division in the form (numeric_value / openshot_Fraction)
+template<class numT>
+numT operator/(const numT& left, const openshot::Fraction& right) {
+    return static_cast<numT>(left / right.ToDouble());
+}
 
 // Stream output operator for openshot::Fraction
 template<class charT, class traits>

--- a/tests/Crop.cpp
+++ b/tests/Crop.cpp
@@ -7,27 +7,9 @@
  * @ref License
  */
 
-/* LICENSE
- *
- * Copyright (c) 2008-2021 OpenShot Studios, LLC
- * <http://www.openshotstudios.com/>. This file is part of
- * OpenShot Library (libopenshot), an open-source project dedicated to
- * delivering high quality video editing and animation solutions to the
- * world. For more information visit <http://www.openshot.org/>.
- *
- * OpenShot Library (libopenshot) is free software: you can redistribute it
- * and/or modify it under the terms of the GNU Lesser General Public License
- * as published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
- *
- * OpenShot Library (libopenshot) is distributed in the hope that it will be
- * useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with OpenShot Library. If not, see <http://www.gnu.org/licenses/>.
- */
+// Copyright (c) 2008-2021 OpenShot Studios, LLC
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
 
 #include <memory>
 

--- a/tests/Fraction.cpp
+++ b/tests/Fraction.cpp
@@ -12,13 +12,12 @@
 
 #include <catch2/catch.hpp>
 
-#include "Fraction.h"
-
 #include <map>
 #include <vector>
 #include <sstream>
 
-using namespace std;
+#include "Fraction.h"
+
 using namespace openshot;
 
 TEST_CASE( "Constructors", "[libopenshot][fraction]" )
@@ -133,6 +132,101 @@ TEST_CASE( "Reciprocal", "[libopenshot][fraction]" )
 	CHECK(f1.den == 720);
 	CHECK(f1.ToFloat() == Approx(1.77777f).margin(0.00001));
 	CHECK(f1.ToDouble() == Approx(1.77777f).margin(0.00001));
+}
+
+TEST_CASE( "Fraction operations", "[libopenshot][fraction]" ) {
+    openshot::Fraction f1(30, 1);
+    openshot::Fraction f2(3, 9);
+
+    // Multiply two Fractions
+    auto f3 = f1 * f2;
+    CHECK(f3.num == 90);
+    CHECK(f3.den == 9);
+
+    // Divide a Fraction by a Fraction
+    auto f4 = f1 / f2;
+    CHECK(f4.num == 270);
+    CHECK(f4.den == 3);
+}
+
+TEST_CASE( "Numeric multiplication", "[libopenshot][fraction]" )
+{
+    openshot::Fraction f1(30000, 1001);
+    const int64_t num1 = 12;
+    const double num2 = 13.6;
+    const float num3 = 14.1;
+    const int num4 = 15;
+
+    // operator* with Fraction on LHS
+    CHECK(f1 * num1 == static_cast<int64_t>(f1.ToDouble() * num1));
+    CHECK_FALSE(f1 * num1 == f1.ToDouble() * num1);
+    CHECK_FALSE(f1 * num1 == f1.ToInt() * num1);
+
+    CHECK(f1 * num2 == static_cast<double>(f1.ToDouble() * num2));
+    CHECK(f1 * num3 == static_cast<float>(f1.ToDouble() * num3));
+
+    CHECK(f1 * num4 == static_cast<int>(f1.ToDouble() * num4));
+    CHECK_FALSE(f1 * num4 == f1.ToDouble() * num4);
+    CHECK_FALSE(f1 * num4 == f1.ToInt() * num4);
+
+    // operator* with Fraction on RHS
+    CHECK(num1 * f1 == static_cast<int64_t>(f1.ToDouble() * num1));
+    CHECK_FALSE(num1 * f1 == num1 * f1.ToDouble());
+    CHECK_FALSE(num1 * f1 == num1 * f1.ToInt());
+
+    CHECK(num2 * f1 == static_cast<double>(f1.ToDouble() * num2));
+    CHECK(num3 * f1 == static_cast<float>(f1.ToDouble() * num3));
+
+    CHECK(num4 * f1 == static_cast<int>(f1.ToDouble() * num4));
+    CHECK_FALSE(num4 * f1 == num4 * f1.ToDouble());
+    CHECK_FALSE(num4 * f1 == num4 * f1.ToInt());
+
+    // Transposition
+    CHECK(num1 * f1 == f1 * num1);
+    CHECK(num2 * f1 == Approx(f1 * num2).margin(0.0001));
+    CHECK(num3 * f1 == Approx(f1 * num3).margin(0.0001));
+    CHECK(num4 * f1 == f1 * num4);
+}
+
+TEST_CASE( "Numeric division", "[libopenshot][fraction]" )
+{
+    openshot::Fraction f1(24000, 1001);
+    openshot::Fraction f2(1001, 30000);
+    const int64_t num1 = 2;
+    const double num2 = 3.5;
+    const float num3 = 4.99;
+    const int num4 = 5;
+
+
+    // operator* with Fraction on LHS
+    CHECK(f1 / num1 == static_cast<int64_t>(f1.ToDouble() / num1));
+    CHECK(f1 / num2 == Approx(static_cast<double>(f1.ToDouble() / num2))
+                       .margin(0.0001));
+    CHECK(f1 / num3 == Approx(static_cast<float>(f1.ToDouble() / num3))
+                       .margin(0.0001));
+    CHECK(f1 / num4 == static_cast<int>(f1.ToDouble() / num4));
+
+    CHECK(f2 / num1 == static_cast<int64_t>(f2.ToDouble() / num1));
+    CHECK(f2 / num2 == Approx(static_cast<double>(f2.ToDouble() / num2))
+                       .margin(0.0001));
+    CHECK(f2 / num3 == Approx(static_cast<float>(f2.ToDouble() / num3))
+                       .margin(0.0001));
+    CHECK(f2 / num4 == static_cast<int>(f2.ToDouble() / num4));
+
+    // operator* with Fraction on RHS
+    CHECK(num1 / f1 == static_cast<int64_t>(num1 / f1.ToDouble()));
+    CHECK(num2 / f1 == Approx(static_cast<double>(num2 / f1.ToDouble()))
+                       .margin(0.0001));
+    CHECK(num3 / f1 == Approx(static_cast<float>(num3 / f1.ToDouble()))
+                       .margin(0.0001));
+    CHECK(num4 / f1 == static_cast<int>(num4 / f1.ToDouble()));
+
+    CHECK(num1 / f2 == static_cast<int64_t>(num1 / f2.ToDouble()));
+    CHECK(num2 / f2 == Approx(static_cast<double>(num2 / f2.ToDouble()))
+                       .margin(0.0001));
+    CHECK(num3 / f2 == Approx(static_cast<float>(num3 / f2.ToDouble()))
+                       .margin(0.0001));
+    CHECK(num4 / f2 == static_cast<int>(num4 / f2.ToDouble()));
 }
 
 TEST_CASE( "Operator ostream", "[libopenshot][fraction]" )


### PR DESCRIPTION
The codebase contains a fair amount of code that looks like this:
```c++
double seconds = double(frame_number) / info.fps.ToDouble();
info.video_length = info.duration * info.fps.ToDouble();
int64_t clip_start_frame = (start * info.fps.ToDouble()) + 1;
```
These Fraction values are nice, but we sure do spend a lot of time converting them to (usually `double`) numeric types just to use them in arithmetic.

### C++ operator overloads
This PR adds three sets of `operator*()` and `operator/()` overloads, to make Fractions _directly_ usable in a numeric contexts.

1. Template functions in `openshot::Fraction` define `operator*` and `operator/` for any arithmetic that has an `openshot::Fraction` on the LHS.
2. Template functions outside of the class define `operator*` and `operator/` when an `openshot::Fraction` is on the RHS of an equation.
3. Specific `operator*()` and `operator/()` overloads in the class handle the case where an `openshot::Fraction` is multiplied or divided by another `openshot::Fraction`.

The return type of (3) is a new `openshot::Fraction`.

The return type of (1) and (2) is _always_ the type of the **other** operand. (This is one thing to watch out for — if you multiply or divide an `openshot::Fraction` by an integer, you will get an integer result, even if that means losing precision.)

The math, however, is **always** done using the `.ToDouble()`  value of the Fraction operand. This is primarily to ensure that e.g. `int x = openshot::Fraction(1, 3) * 10` doesn't set `x` to `0` (instead it's `3`), and so that `48000 / openshot::Fraction(1, 2)` isn't an illegal division by zero. After the `double`-precision result is calculated, it's `static_cast` to the type of the other operand and returned.

This allows all of the `.ToDouble()` calls above to be eliminated, as it's now legal to write simply:
```c++
auto seconds = double(frame_number) / info.fps;
info.video_length = info.duration * info.fps;
int64_t clip_start_frame = (start * info.fps) + 1;
```
As well as things like:
```c++
openshot::Fraction sample_rate(48000, 1);
openshot::Fraction fps(30000, 1001);
// samples/frame = (samples/sec) * (sec/frame == 1/fps)
auto samples_per_frame = sample_rate / fps;
```
At the end of this code `samples_per_frame` will be `openshot::Fraction(48048000, 30000)`. 

(The large components result because I wrote the `operator/` between two `openshot::Fraction`s to cheat — it returns the value of `lhs * rhs.Reciprocal()`. That calls the `operator*` overload for two fractions, which in turn returns `Fraction(lhs.num * rhs.num, lhs.den * rhs.den)`). That result can easily be converted to a more reasonable `openshot::Fraction(8008, 5)`, by calling `samples_per_frame.Reduce()`. Both before and after the call to `.Reduce()`, `samples_per_frame.ToDouble()` will remain `1601.6`.

### Unit tests
Comprehensive unit tests are provided for both Fraction-to-Fraction operators, as well as ad-hoc inline arithmetic which has a Fraction on either side of an `int`, `float`, `double`, or `int64_t` variable.

###  Python equivalency
To provide complementary features in the Python bindings, the `openshot.Fraction` wrapper class is extended with the dunder methods `__mul__`, `__rmul__`, `__truediv__`, and `__rtruediv__`, allowing `openshot.Fraction` to appear on either side of computations involving numeric values in Python too.

(The same conformity to the other operand's type is not implemented, as the Python norm is to produce floating-point values for all division and multiplication operations with decimal components. `int()` should be used around the result, if whole number values are required.)

```python3
>>> import openshot
>>> f1 = openshot.Fraction(30000, 1001)
>>> 5 * f1
149.85014985014985
>>> f1 * 2
59.94005994005994
>>> f1.Reciprocal() / 5
0.006673333333333334
>>> # The same Fraction-to-Fraction support is also implemented:
>>> f2 = openshot.Fraction(3, 10)
>>> f1 / f2
Fraction(300000, 3003)
>>> (f1 / f2).ToInt()
100
>>> int(f1 / f2)
100
>>> float(f1 / f2)
99.9000999000999
>>> f1 * f2
Fraction(90000, 10010)
>>> f1 / f2.Reciprocal()
Fraction(90000, 10010)
```

### Python `__format__` implementation
Additionally, an implementation of `__format__` is added to `openshot.Fraction`, allowing Fraction objects in Python to be directly referenced from formatting strings in either an integer or floating-point numeric context:
```python3
>>> # The default str() of a Fraction is "<num>:<den>"
>>> print(f"{f1}")
30000:1001
>>> # And it can still be treated implicitly as a dict:
>>> "{0} / {1}".format(f1["num"], f1["den"])
'30000 / 1001'
>>> # But now it can also be formatted freely as any numeric type...
>>> print(f"{f1:0.3f}")
29.970
>>> print(f"{f1:0.1f}")
30.0
>>> print(f"{f1:d}")
30
>>> "{:d}".format(f1)
'30'
>>> f"0x{f1:x}"
'0x1e'
>>> # Arbitrary precision and alignment are provided by format() directly:
>>> f"{f1:>10d}"
'        30'
>>> f"{f1:^10d}"
'    30    '
>>> f"{f1:^10.5f}"
' 29.97003 '
>>> f"{f1:^20.5f}"
'      29.97003      '
>>> f"{f1:^020.4f}"
'00000029.97000000000'
```
