### PR TITLE
CI: Fix Resvg branch selection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
         with:
           repository: RazrFalcon/resvg
           path: resvg
-          branch: v0.11.0
+          ref: v0.19.0
 
       - uses: haya14busa/action-cond@v1
         id: generator

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,17 +123,19 @@ jobs:
               mingw-w64-x86_64-swig
 
       - uses: actions/cache@v2
+        name: Import OpenShotAudio cache
         id: cache-audio
         with:
           path: audio/build
-          key: audio-${{ runner.os }}-${{ matrix.compiler.cxx }}-${{ hashFiles('audio/CMakeLists.txt') }}
+          key: audio-${{ matrix.sys.os }}-${{ matrix.compiler.cxx }}-${{ hashFiles('audio/CMakeLists.txt') }}
 
       - uses: actions/cache@v2
+        name: Import Resvg cache
         if: ${{ steps.use-resvg.outputs.value }}
         id: cache-resvg
         with:
           path: resvg/target
-          key: resvg-${{ runner.os }}-${{ matrix.compiler.cxx }}-${{ hashFiles('resvg/Cargo.toml') }}
+          key: resvg-${{ matrix.sys.os }}-${{ matrix.compiler.cxx }}-${{ hashFiles('resvg/Cargo.toml') }}
 
       - name: Build OpenShotAudio (if not cached)
         if: steps.cache-audio.outputs.cache-hit != 'true'


### PR DESCRIPTION
Quick-fix because I used the wrong variable name for the `ref` selection, when checking out Resvg from RazrFalcon's upstream repo.