### PR TITLE
CI: Try to avoid always recompiling Resvg

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,7 +161,7 @@ jobs:
           popd
 
       - name: Build Resvg (if enabled and not cached)
-        if: ${{ steps.use-resvg.outputs.value }} && (steps.cache-resvg.outputs.cache-hit != 'true')
+        if: steps.cache-resvg && (steps.cache-resvg.outputs.cache-hit != 'true')
         run: |
           if [ -d "resvg/c-api" ]; then
             pushd resvg/c-api


### PR DESCRIPTION
Currently the CI scripting is causing it to always recompile Resvg, when it's enabled. This PR attempts to fix that, so that Resvg won't be rebuilt on a cache hit.
