### PR TITLE
Adding a limit on video playback sleep

### DIFF
--- a/src/Qt/PlayerPrivate.h
+++ b/src/Qt/PlayerPrivate.h
@@ -39,6 +39,7 @@ namespace openshot
 	int speed; /// The speed and direction to playback a reader (1=normal, 2=fast, 3=faster, -1=rewind, etc...)
 	openshot::RendererBase *renderer;
 	int64_t last_video_position; /// The last frame actually displayed
+	int max_sleep_ms; /// The max milliseconds to sleep (when syncing audio and video)
 
 	/// Constructor
 	PlayerPrivate(openshot::RendererBase *rb);
@@ -52,7 +53,7 @@ namespace openshot
 	bool startPlayback();
 
 	/// Stop the video/audio playback
-	void stopPlayback(int timeOutMilliseconds = -1);
+	void stopPlayback();
 
 	/// Get the next frame (based on speed and direction)
 	std::shared_ptr<openshot::Frame> getFrame();

--- a/src/Timeline.cpp
+++ b/src/Timeline.cpp
@@ -897,7 +897,7 @@ std::shared_ptr<Frame> Timeline::GetFrame(int64_t requested_frame)
         final_cache->Add(new_frame);
 
 		// Return frame (or blank frame)
-		return final_cache->GetFrame(requested_frame);
+		return new_frame;
 	}
 }
 


### PR DESCRIPTION
Don't sleep forever! Also adding in a kill time when shutting down threads (so we don't wait indefinitely for them to stop). When shutting down OpenShot (especially if the video playback is running), as various threads are stopped and shutdown, our video player can calculate some really large differences between the audio and video position, and then sleep for a really long time before the loop calls `threadShouldExit()` again.

This code just limits that sleep calculation, and it seems to work really well in my testing.