### PR TITLE
Code changes to prepare for JUCE upgrade, speed up builds

### DIFF
--- a/bindings/python/openshot.i
+++ b/bindings/python/openshot.i
@@ -38,7 +38,7 @@
 #ifdef USE_IMAGEMAGICK
 	%shared_ptr(Magick::Image)
 #endif
-%shared_ptr(juce::AudioSampleBuffer)
+%shared_ptr(juce::AudioBuffer<float>)
 %shared_ptr(openshot::Frame)
 
 %{

--- a/bindings/ruby/openshot.i
+++ b/bindings/ruby/openshot.i
@@ -38,7 +38,7 @@
 #ifdef USE_IMAGEMAGICK
 	%shared_ptr(Magick::Image)
 #endif
-%shared_ptr(juce::AudioSampleBuffer)
+%shared_ptr(juce::AudioBuffer<float>)
 %shared_ptr(openshot::Frame)
 
 /* Template specializations */

--- a/src/AudioBufferSource.cpp
+++ b/src/AudioBufferSource.cpp
@@ -16,14 +16,14 @@ using namespace std;
 using namespace openshot;
 
 // Default constructor
-AudioBufferSource::AudioBufferSource(juce::AudioSampleBuffer *audio_buffer)
+AudioBufferSource::AudioBufferSource(juce::AudioBuffer<float> *audio_buffer)
 		: position(0), repeat(false), buffer(audio_buffer)
 { }
 
 // Destructor
 AudioBufferSource::~AudioBufferSource()
 {
-	// forget the AudioSampleBuffer. It still exists; we just don't know about it.
+	// forget the AudioBuffer<float>. It still exists; we just don't know about it.
 	buffer = NULL;
 }
 
@@ -115,8 +115,8 @@ void AudioBufferSource::setLooping (bool shouldLoop)
 	repeat = shouldLoop;
 }
 
-// Use a different AudioSampleBuffer for this source
-void AudioBufferSource::setBuffer (juce::AudioSampleBuffer *audio_buffer)
+// Use a different AudioBuffer<float> for this source
+void AudioBufferSource::setBuffer (juce::AudioBuffer<float> *audio_buffer)
 {
 	buffer = audio_buffer;
 	setNextReadPosition(0);

--- a/src/AudioBufferSource.h
+++ b/src/AudioBufferSource.h
@@ -13,30 +13,28 @@
 #ifndef OPENSHOT_AUDIOBUFFERSOURCE_H
 #define OPENSHOT_AUDIOBUFFERSOURCE_H
 
-#include <iomanip>
-#include <OpenShotAudio.h>
+#include <AppConfig.h>
+#include <juce_audio_basics/juce_audio_basics.h>
 
-/// This namespace is the default namespace for all code in the openshot library
 namespace openshot
 {
-
 	/**
-	 * @brief This class is used to expose an AudioSampleBuffer as an AudioSource in JUCE.
+	 * @brief This class is used to expose an AudioBuffer<float> as an AudioSource in JUCE.
 	 *
-	 * The <a href="http://www.juce.com/">JUCE</a> library cannot play audio directly from an AudioSampleBuffer, so this class exposes
-	 * an AudioSampleBuffer as a AudioSource, so that JUCE can play the audio.
+	 * The <a href="http://www.juce.com/">JUCE</a> library cannot play audio directly from an AudioBuffer<float>, so this class exposes
+	 * an AudioBuffer<float> as a AudioSource, so that JUCE can play the audio.
 	 */
 	class AudioBufferSource : public juce::PositionableAudioSource
 	{
 	private:
 		int position;
 		bool repeat;
-		juce::AudioSampleBuffer *buffer;
+		juce::AudioBuffer<float> *buffer;
 
 	public:
 		/// @brief Default constructor
 		/// @param audio_buffer This buffer contains the samples you want to play through JUCE.
-		AudioBufferSource(juce::AudioSampleBuffer *audio_buffer);
+		AudioBufferSource(juce::AudioBuffer<float> *audio_buffer);
 
 		/// Destructor
 		~AudioBufferSource();
@@ -69,7 +67,7 @@ namespace openshot
 		void setLooping (bool shouldLoop);
 
 		/// Update the internal buffer used by this source
-		void setBuffer (juce::AudioSampleBuffer *audio_buffer);
+		void setBuffer (juce::AudioBuffer<float> *audio_buffer);
 	};
 
 }

--- a/src/AudioReaderSource.cpp
+++ b/src/AudioReaderSource.cpp
@@ -15,8 +15,6 @@
 #include "Frame.h"
 #include "ZmqLogger.h"
 
-#include <OpenShotAudio.h>
-
 using namespace std;
 using namespace openshot;
 
@@ -26,7 +24,7 @@ AudioReaderSource::AudioReaderSource(
 ) :
     position(0),
     size(buffer_size),
-    buffer(new juce::AudioSampleBuffer(audio_reader->info.channels, buffer_size)),
+    buffer(new juce::AudioBuffer<float>(audio_reader->info.channels, buffer_size)),
     speed(1),
     reader(audio_reader),
     frame_number(starting_frame_number),
@@ -63,7 +61,7 @@ void AudioReaderSource::GetMoreSamplesFromReader()
 	estimated_frame = frame_number;
 
 	// Init new buffer
-	juce::AudioSampleBuffer *new_buffer = new juce::AudioSampleBuffer(reader->info.channels, size);
+	juce::AudioBuffer<float> *new_buffer = new juce::AudioSampleBuffer(reader->info.channels, size);
 	new_buffer->clear();
 
 	// Move the remaining samples into new buffer (if any)
@@ -132,7 +130,7 @@ void AudioReaderSource::GetMoreSamplesFromReader()
 }
 
 // Reverse an audio buffer
-juce::AudioSampleBuffer* AudioReaderSource::reverse_buffer(juce::AudioSampleBuffer* buffer)
+juce::AudioBuffer<float>* AudioReaderSource::reverse_buffer(juce::AudioSampleBuffer* buffer)
 {
 	int number_of_samples = buffer->getNumSamples();
 	int channels = buffer->getNumChannels();
@@ -141,7 +139,7 @@ juce::AudioSampleBuffer* AudioReaderSource::reverse_buffer(juce::AudioSampleBuff
 	ZmqLogger::Instance()->AppendDebugMethod("AudioReaderSource::reverse_buffer", "number_of_samples", number_of_samples, "channels", channels);
 
 	// Reverse array (create new buffer to hold the reversed version)
-	juce::AudioSampleBuffer *reversed = new juce::AudioSampleBuffer(channels, number_of_samples);
+	juce::AudioBuffer<float> *reversed = new juce::AudioSampleBuffer(channels, number_of_samples);
 	reversed->clear();
 
 	for (int channel = 0; channel < channels; channel++)
@@ -276,7 +274,7 @@ void AudioReaderSource::setLooping (bool shouldLoop)
 }
 
 // Update the internal buffer used by this source
-void AudioReaderSource::setBuffer (juce::AudioSampleBuffer *audio_buffer)
+void AudioReaderSource::setBuffer (juce::AudioBuffer<float> *audio_buffer)
 {
 	buffer = audio_buffer;
 	setNextReadPosition(0);

--- a/src/AudioReaderSource.h
+++ b/src/AudioReaderSource.h
@@ -15,12 +15,13 @@
 
 #include "ReaderBase.h"
 
-#include <OpenShotAudio.h>
+#include <AppConfig.h>
+#include <juce_audio_basics/juce_audio_basics.h>
 
 /// This namespace is the default namespace for all code in the openshot library
 namespace openshot
 {
-
+	class Frame;
 	/**
 	 * @brief This class is used to expose any ReaderBase derived class as an AudioSource in JUCE.
 	 *
@@ -32,7 +33,7 @@ namespace openshot
 		int position; /// The position of the audio source (index of buffer)
 		bool repeat; /// Repeat the audio source when finished
 		int size; /// The size of the internal buffer
-		juce::AudioSampleBuffer *buffer; /// The audio sample buffer
+		juce::AudioBuffer<float> *buffer; /// The audio sample buffer
 		int speed; /// The speed and direction to playback a reader (1=normal, 2=fast, 3=faster, -1=rewind, etc...)
 
 		ReaderBase *reader; /// The reader to pull samples from
@@ -46,7 +47,7 @@ namespace openshot
 		void GetMoreSamplesFromReader();
 
 		/// Reverse an audio buffer (for backwards audio)
-		juce::AudioSampleBuffer* reverse_buffer(juce::AudioSampleBuffer* buffer);
+		juce::AudioBuffer<float>* reverse_buffer(juce::AudioSampleBuffer* buffer);
 
 	public:
 
@@ -87,7 +88,7 @@ namespace openshot
 		void setLooping (bool shouldLoop);
 
 		/// Update the internal buffer used by this source
-		void setBuffer (juce::AudioSampleBuffer *audio_buffer);
+		void setBuffer (juce::AudioBuffer<float> *audio_buffer);
 
 	    const ReaderInfo & getReaderInfo() const { return reader->info; }
 

--- a/src/AudioResampler.cpp
+++ b/src/AudioResampler.cpp
@@ -34,7 +34,7 @@ AudioResampler::AudioResampler()
 	resample_source = new juce::ResamplingAudioSource(buffer_source, false, 2);
 
 	// Init resampled buffer
-	resampled_buffer = new juce::AudioSampleBuffer(2, 1);
+	resampled_buffer = new juce::AudioBuffer<float>(2, 1);
 	resampled_buffer->clear();
 
 	// Init callback buffer
@@ -56,7 +56,7 @@ AudioResampler::~AudioResampler()
 }
 
 // Sets the audio buffer and updates the key settings
-void AudioResampler::SetBuffer(juce::AudioSampleBuffer *new_buffer, double sample_rate, double new_sample_rate)
+void AudioResampler::SetBuffer(juce::AudioBuffer<float> *new_buffer, double sample_rate, double new_sample_rate)
 {
 	if (sample_rate <= 0)
 		sample_rate = 44100;
@@ -71,7 +71,7 @@ void AudioResampler::SetBuffer(juce::AudioSampleBuffer *new_buffer, double sampl
 }
 
 // Sets the audio buffer and key settings
-void AudioResampler::SetBuffer(juce::AudioSampleBuffer *new_buffer, double ratio)
+void AudioResampler::SetBuffer(juce::AudioBuffer<float> *new_buffer, double ratio)
 {
 	// Update buffer & buffer source
 	buffer = new_buffer;
@@ -102,7 +102,7 @@ void AudioResampler::SetBuffer(juce::AudioSampleBuffer *new_buffer, double ratio
 }
 
 // Get the resampled audio buffer
-juce::AudioSampleBuffer* AudioResampler::GetResampledBuffer()
+juce::AudioBuffer<float>* AudioResampler::GetResampledBuffer()
 {
 	// Resample the current frame's audio buffer (into the temp callback buffer)
 	resample_source->getNextAudioBlock(resample_callback_buffer);

--- a/src/AudioResampler.h
+++ b/src/AudioResampler.h
@@ -14,7 +14,10 @@
 #define OPENSHOT_RESAMPLER_H
 
 #include "AudioBufferSource.h"
-#include <OpenShotAudio.h>
+
+#include <AppConfig.h>
+#include <juce_audio_basics/juce_audio_basics.h>
+#include <juce_audio_devices/juce_audio_devices.h>
 
 namespace openshot {
 
@@ -26,8 +29,8 @@ namespace openshot {
 	 */
 	class AudioResampler {
 	private:
-		juce::AudioSampleBuffer *buffer;
-		juce::AudioSampleBuffer *resampled_buffer;
+		juce::AudioBuffer<float> *buffer;
+		juce::AudioBuffer<float> *resampled_buffer;
 		openshot::AudioBufferSource *buffer_source;
 		juce::ResamplingAudioSource *resample_source;
 		juce::AudioSourceChannelInfo resample_callback_buffer;
@@ -49,15 +52,15 @@ namespace openshot {
 		/// @param new_buffer The buffer of audio samples needing to be resampled
 		/// @param sample_rate The original sample rate of the buffered samples
 		/// @param new_sample_rate The requested sample rate you need
-		void SetBuffer(juce::AudioSampleBuffer *new_buffer, double sample_rate, double new_sample_rate);
+		void SetBuffer(juce::AudioBuffer<float> *new_buffer, double sample_rate, double new_sample_rate);
 
 		/// @brief Sets the audio buffer and key settings
 		/// @param new_buffer The buffer of audio samples needing to be resampled
 		/// @param ratio The multiplier that needs to be applied to the sample rate (this is how resampling happens)
-		void SetBuffer(juce::AudioSampleBuffer *new_buffer, double ratio);
+		void SetBuffer(juce::AudioBuffer<float> *new_buffer, double ratio);
 
 		/// Get the resampled audio buffer
-		juce::AudioSampleBuffer* GetResampledBuffer();
+		juce::AudioBuffer<float>* GetResampledBuffer();
 	};
 
 }

--- a/src/CVObjectDetection.cpp
+++ b/src/CVObjectDetection.cpp
@@ -16,8 +16,9 @@
 #include <iostream>
 
 #include "CVObjectDetection.h"
-#include "objdetectdata.pb.h"
+#include "Exceptions.h"
 
+#include "objdetectdata.pb.h"
 #include <google/protobuf/util/time_util.h>
 
 using namespace std;

--- a/src/CVStabilization.cpp
+++ b/src/CVStabilization.cpp
@@ -16,6 +16,7 @@
 #include <iostream>
 
 #include "CVStabilization.h"
+#include "Exceptions.h"
 
 #include "stabilizedata.pb.h"
 #include <google/protobuf/util/time_util.h>

--- a/src/CVTracker.cpp
+++ b/src/CVTracker.cpp
@@ -20,6 +20,7 @@
 #include "OpenCVUtilities.h"
 #include "CVTracker.h"
 #include "trackerdata.pb.h"
+#include "Exceptions.h"
 
 using namespace openshot;
 using google::protobuf::util::TimeUtil;

--- a/src/CacheBase.cpp
+++ b/src/CacheBase.cpp
@@ -16,15 +16,12 @@ using namespace std;
 using namespace openshot;
 
 // Default constructor, no max frames
-CacheBase::CacheBase() : max_bytes(0) {
-	// Init the critical section
-	cacheCriticalSection = new CriticalSection();
-}
+CacheBase::CacheBase() : CacheBase::CacheBase(0) { }
 
 // Constructor that sets the max frames to cache
 CacheBase::CacheBase(int64_t max_bytes) : max_bytes(max_bytes) {
-	// Init the critical section
-	cacheCriticalSection = new CriticalSection();
+	// Init the mutex
+	cacheMutex = new std::recursive_mutex();
 }
 
 // Set maximum bytes to a different amount based on a ReaderInfo struct

--- a/src/CacheBase.h
+++ b/src/CacheBase.h
@@ -14,10 +14,9 @@
 #define OPENSHOT_CACHE_BASE_H
 
 #include <memory>
+#include <mutex>
 
 #include "Json.h"
-
-#include <OpenShotAudio.h>
 
 namespace openshot {
 	class Frame;
@@ -35,8 +34,8 @@ namespace openshot {
 		std::string cache_type; ///< This is a friendly type name of the derived cache instance
 		int64_t max_bytes; ///< This is the max number of bytes to cache (0 = no limit)
 
-		/// Section lock for multiple threads
-	    juce::CriticalSection *cacheCriticalSection;
+		/// Mutex for multiple threads
+		std::recursive_mutex *cacheMutex;
 
 
 	public:

--- a/src/CacheDisk.cpp
+++ b/src/CacheDisk.cpp
@@ -81,7 +81,7 @@ void CacheDisk::CalculateRanges() {
 	if (needs_range_processing) {
 
 		// Create a scoped lock, to protect the cache from multiple threads
-		const GenericScopedLock<CriticalSection> lock(*cacheCriticalSection);
+                const std::lock_guard<std::recursive_mutex> lock(*cacheMutex);
 
 		// Sort ordered frame #s, and calculate JSON ranges
 		std::sort(ordered_frame_numbers.begin(), ordered_frame_numbers.end());
@@ -139,16 +139,15 @@ CacheDisk::~CacheDisk()
 	frame_numbers.clear();
 	ordered_frame_numbers.clear();
 
-	// remove critical section
-	delete cacheCriticalSection;
-	cacheCriticalSection = NULL;
+	// remove mutex
+	delete cacheMutex;
 }
 
 // Add a Frame to the cache
 void CacheDisk::Add(std::shared_ptr<Frame> frame)
 {
 	// Create a scoped lock, to protect the cache from multiple threads
-	const GenericScopedLock<CriticalSection> lock(*cacheCriticalSection);
+	const std::lock_guard<std::recursive_mutex> lock(*cacheMutex);
 	int64_t frame_number = frame->number;
 
 	// Freshen frame if it already exists
@@ -207,7 +206,7 @@ void CacheDisk::Add(std::shared_ptr<Frame> frame)
 std::shared_ptr<Frame> CacheDisk::GetFrame(int64_t frame_number)
 {
 	// Create a scoped lock, to protect the cache from multiple threads
-	const GenericScopedLock<CriticalSection> lock(*cacheCriticalSection);
+	const std::lock_guard<std::recursive_mutex> lock(*cacheMutex);
 
 	// Does frame exists in cache?
 	if (frames.count(frame_number)) {
@@ -277,7 +276,7 @@ std::shared_ptr<Frame> CacheDisk::GetFrame(int64_t frame_number)
 std::shared_ptr<Frame> CacheDisk::GetSmallestFrame()
 {
 	// Create a scoped lock, to protect the cache from multiple threads
-	const GenericScopedLock<CriticalSection> lock(*cacheCriticalSection);
+	const std::lock_guard<std::recursive_mutex> lock(*cacheMutex);
 
 	// Loop through frame numbers
 	std::deque<int64_t>::iterator itr;
@@ -300,7 +299,7 @@ std::shared_ptr<Frame> CacheDisk::GetSmallestFrame()
 int64_t CacheDisk::GetBytes()
 {
 	// Create a scoped lock, to protect the cache from multiple threads
-	const GenericScopedLock<CriticalSection> lock(*cacheCriticalSection);
+	const std::lock_guard<std::recursive_mutex> lock(*cacheMutex);
 
 	int64_t  total_bytes = 0;
 
@@ -322,7 +321,7 @@ void CacheDisk::Remove(int64_t frame_number)
 void CacheDisk::Remove(int64_t start_frame_number, int64_t end_frame_number)
 {
 	// Create a scoped lock, to protect the cache from multiple threads
-	const GenericScopedLock<CriticalSection> lock(*cacheCriticalSection);
+	const std::lock_guard<std::recursive_mutex> lock(*cacheMutex);
 
 	// Loop through frame numbers
 	std::deque<int64_t>::iterator itr;
@@ -374,7 +373,7 @@ void CacheDisk::MoveToFront(int64_t frame_number)
 	if (frames.count(frame_number))
 	{
 		// Create a scoped lock, to protect the cache from multiple threads
-		const GenericScopedLock<CriticalSection> lock(*cacheCriticalSection);
+		const std::lock_guard<std::recursive_mutex> lock(*cacheMutex);
 
 		// Loop through frame numbers
 		std::deque<int64_t>::iterator itr;
@@ -397,7 +396,7 @@ void CacheDisk::MoveToFront(int64_t frame_number)
 void CacheDisk::Clear()
 {
 	// Create a scoped lock, to protect the cache from multiple threads
-	const GenericScopedLock<CriticalSection> lock(*cacheCriticalSection);
+	const std::lock_guard<std::recursive_mutex> lock(*cacheMutex);
 
 	// Clear all containers
 	frames.clear();
@@ -418,7 +417,7 @@ void CacheDisk::Clear()
 int64_t CacheDisk::Count()
 {
 	// Create a scoped lock, to protect the cache from multiple threads
-	const GenericScopedLock<CriticalSection> lock(*cacheCriticalSection);
+	const std::lock_guard<std::recursive_mutex> lock(*cacheMutex);
 
 	// Return the number of frames in the cache
 	return frames.size();
@@ -431,7 +430,7 @@ void CacheDisk::CleanUp()
 	if (max_bytes > 0)
 	{
 		// Create a scoped lock, to protect the cache from multiple threads
-		const GenericScopedLock<CriticalSection> lock(*cacheCriticalSection);
+		const std::lock_guard<std::recursive_mutex> lock(*cacheMutex);
 
 		while (GetBytes() > max_bytes && frame_numbers.size() > 20)
 		{

--- a/src/ChannelLayouts.h
+++ b/src/ChannelLayouts.h
@@ -57,7 +57,6 @@ enum ChannelLayout
 };
 
 
-
 }
 
 #endif

--- a/src/ChunkReader.h
+++ b/src/ChunkReader.h
@@ -18,12 +18,11 @@
 
 #include "ReaderBase.h"
 #include "Json.h"
-#include "CacheMemory.h"
 
 namespace openshot
 {
+	class CacheBase;
 	class Frame;
-
 	/**
 	 * @brief This struct holds the location of a frame within a chunk.
 	 *
@@ -119,7 +118,7 @@ namespace openshot
 		void SetChunkSize(int64_t new_size) { chunk_size = new_size; };
 
 		/// Get the cache object used by this reader (always return NULL for this reader)
-		openshot::CacheMemory* GetCache() override { return nullptr; };
+		openshot::CacheBase* GetCache() override { return nullptr; };
 
 		/// @brief Get an openshot::Frame object for a specific frame number of this reader.
 		/// @returns				The requested frame (containing the image and audio)

--- a/src/ChunkWriter.cpp
+++ b/src/ChunkWriter.cpp
@@ -12,6 +12,7 @@
 
 #include "ChunkWriter.h"
 #include "Exceptions.h"
+#include "Frame.h"
 
 using namespace openshot;
 

--- a/src/Clip.h
+++ b/src/Clip.h
@@ -25,24 +25,23 @@
 
 #include <memory>
 #include <string>
-#include <QtGui/QImage>
 
-#include "AudioResampler.h"
 #include "ClipBase.h"
+#include "ReaderBase.h"
+
 #include "Color.h"
 #include "Enums.h"
 #include "EffectBase.h"
-#include "Effects.h"
 #include "EffectInfo.h"
-#include "Frame.h"
 #include "KeyFrame.h"
 #include "TrackedObjectBase.h"
-#include "ReaderBase.h"
-#include <OpenShotAudio.h>
 
+#include <QImage>
 
 namespace openshot {
+	class AudioResampler;
 	class EffectInfo;
+	class Frame;
 
 	/// Comparison method for sorting effect pointers (by Position, Layer, and Order). Effects are sorted
 	/// from lowest layer to top layer (since that is sequence clips are combined), and then by
@@ -90,8 +89,8 @@ namespace openshot {
 	 */
 	class Clip : public openshot::ClipBase, public openshot::ReaderBase {
 	protected:
-		/// Section lock for multiple threads
-	    juce::CriticalSection getFrameCriticalSection;
+		/// Mutex for multiple threads
+	    std::recursive_mutex getFrameMutex;
 
 		/// Init default settings for a clip
 		void init_settings();
@@ -149,7 +148,7 @@ namespace openshot {
 		void sort_effects();
 
 		/// Reverse an audio buffer
-		void reverse_buffer(juce::AudioSampleBuffer* buffer);
+		void reverse_buffer(juce::AudioBuffer<float>* buffer);
 
 
 	public:
@@ -201,7 +200,7 @@ namespace openshot {
 		std::shared_ptr<openshot::TrackedObjectBase> GetAttachedObject() const { return parentTrackedObject; };
 		/// Return a pointer to the clip this clip is attached to
 		Clip* GetAttachedClip() const { return parentClipObject; };
-		
+
 		/// Return the type name of the class
 		std::string Name() override { return "Clip"; };
 

--- a/src/CrashHandler.cpp
+++ b/src/CrashHandler.cpp
@@ -12,6 +12,10 @@
 
 #include "CrashHandler.h"
 
+#include <iostream>
+#include <iomanip>
+#include <sstream>
+
 using namespace std;
 using namespace openshot;
 

--- a/src/DummyReader.cpp
+++ b/src/DummyReader.cpp
@@ -113,7 +113,7 @@ std::shared_ptr<Frame> DummyReader::GetFrame(int64_t requested_frame)
 
 	if (dummy_cache_count == 0 && image_frame) {
 		// Create a scoped lock, allowing only a single thread to run the following code at one time
-		const GenericScopedLock<CriticalSection> lock(getFrameCriticalSection);
+		const std::lock_guard<std::recursive_mutex> lock(getFrameMutex);
 
 		// Always return same frame (regardless of which frame number was requested)
 		image_frame->number = requested_frame;
@@ -121,7 +121,7 @@ std::shared_ptr<Frame> DummyReader::GetFrame(int64_t requested_frame)
 
 	} else if (dummy_cache_count > 0) {
 		// Create a scoped lock, allowing only a single thread to run the following code at one time
-		const GenericScopedLock<CriticalSection> lock(getFrameCriticalSection);
+		const std::lock_guard<std::recursive_mutex> lock(getFrameMutex);
 
 		// Get a frame from the dummy cache
 		std::shared_ptr<openshot::Frame> f = dummy_cache->GetFrame(requested_frame);

--- a/src/EffectInfo.cpp
+++ b/src/EffectInfo.cpp
@@ -11,9 +11,9 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
 #include "EffectInfo.h"
+#include "Effects.h"
 
 using namespace openshot;
-
 
 // Generate JSON string of this object
 std::string EffectInfo::Json() {
@@ -103,7 +103,7 @@ EffectBase* EffectInfo::CreateEffect(std::string effect_type) {
 
 	else if(effect_type == "Tracker")
 		return new Tracker();
-		
+
 	else if(effect_type == "Object Detector")
 		return new ObjectDetection();
 	#endif

--- a/src/EffectInfo.h
+++ b/src/EffectInfo.h
@@ -13,13 +13,12 @@
 #ifndef OPENSHOT_EFFECT_INFO_H
 #define OPENSHOT_EFFECT_INFO_H
 
-#include "Effects.h"
-
-
+#include "Json.h"
 
 namespace openshot
 {
 	class Clip;
+	class EffectBase;
 	/**
 	 * @brief This class returns a listing of all effects supported by libopenshot
 	 *

--- a/src/Enums.h
+++ b/src/Enums.h
@@ -16,120 +16,123 @@
 
 namespace openshot
 {
-	/// This enumeration determines how clips are aligned to their parent container.
-	enum GravityType
-	{
-		GRAVITY_TOP_LEFT,		///< Align clip to the top left of its parent
-		GRAVITY_TOP,			///< Align clip to the top center of its parent
-		GRAVITY_TOP_RIGHT,		///< Align clip to the top right of its parent
-		GRAVITY_LEFT,			///< Align clip to the left of its parent (middle aligned)
-		GRAVITY_CENTER,			///< Align clip to the center of its parent (middle aligned)
-		GRAVITY_RIGHT,			///< Align clip to the right of its parent (middle aligned)
-		GRAVITY_BOTTOM_LEFT,	///< Align clip to the bottom left of its parent
-		GRAVITY_BOTTOM,			///< Align clip to the bottom center of its parent
-		GRAVITY_BOTTOM_RIGHT	///< Align clip to the bottom right of its parent
-	};
 
-	/// This enumeration determines how clips are scaled to fit their parent container.
-	enum ScaleType
-	{
-		SCALE_CROP,		///< Scale the clip until both height and width fill the canvas (cropping the overlap)
-		SCALE_FIT,		///< Scale the clip until either height or width fills the canvas (with no cropping)
-		SCALE_STRETCH,	///< Scale the clip until both height and width fill the canvas (distort to fit)
-		SCALE_NONE		///< Do not scale the clip
-	};
+/// This enumeration determines how clips are aligned to their parent container.
+enum GravityType
+{
+	GRAVITY_TOP_LEFT,		///< Align clip to the top left of its parent
+	GRAVITY_TOP,			///< Align clip to the top center of its parent
+	GRAVITY_TOP_RIGHT,		///< Align clip to the top right of its parent
+	GRAVITY_LEFT,			///< Align clip to the left of its parent (middle aligned)
+	GRAVITY_CENTER,			///< Align clip to the center of its parent (middle aligned)
+	GRAVITY_RIGHT,			///< Align clip to the right of its parent (middle aligned)
+	GRAVITY_BOTTOM_LEFT,	///< Align clip to the bottom left of its parent
+	GRAVITY_BOTTOM,			///< Align clip to the bottom center of its parent
+	GRAVITY_BOTTOM_RIGHT	///< Align clip to the bottom right of its parent
+};
 
-	/// This enumeration determines what parent a clip should be aligned to.
-	enum AnchorType
-	{
-		ANCHOR_CANVAS,	///< Anchor the clip to the canvas
-		ANCHOR_VIEWPORT	///< Anchor the clip to the viewport (which can be moved / animated around the canvas)
-	};
+/// This enumeration determines how clips are scaled to fit their parent container.
+enum ScaleType
+{
+	SCALE_CROP,		///< Scale the clip until both height and width fill the canvas (cropping the overlap)
+	SCALE_FIT,		///< Scale the clip until either height or width fills the canvas (with no cropping)
+	SCALE_STRETCH,	///< Scale the clip until both height and width fill the canvas (distort to fit)
+	SCALE_NONE		///< Do not scale the clip
+};
 
-	/// This enumeration determines the display format of the clip's frame number (if any). Useful for debugging.
-	enum FrameDisplayType
-	{
-		FRAME_DISPLAY_NONE,     ///< Do not display the frame number
-		FRAME_DISPLAY_CLIP,     ///< Display the clip's internal frame number
-		FRAME_DISPLAY_TIMELINE, ///< Display the timeline's frame number
-		FRAME_DISPLAY_BOTH      ///< Display both the clip's and timeline's frame number
-	};
+/// This enumeration determines what parent a clip should be aligned to.
+enum AnchorType
+{
+	ANCHOR_CANVAS,	///< Anchor the clip to the canvas
+	ANCHOR_VIEWPORT	///< Anchor the clip to the viewport (which can be moved / animated around the canvas)
+};
 
-	/// This enumeration determines the strategy when mixing audio with other clips.
-	enum VolumeMixType
-	{
-		VOLUME_MIX_NONE,   	///< Do not apply any volume mixing adjustments. Just add the samples together.
-		VOLUME_MIX_AVERAGE,	///< Evenly divide the overlapping clips volume keyframes, so that the sum does not exceed 100%
-		VOLUME_MIX_REDUCE 	///< Reduce volume by about %25, and then mix (louder, but could cause pops if the sum exceeds 100%)
-	};
+/// This enumeration determines the display format of the clip's frame number (if any). Useful for debugging.
+enum FrameDisplayType
+{
+	FRAME_DISPLAY_NONE,     ///< Do not display the frame number
+	FRAME_DISPLAY_CLIP,     ///< Display the clip's internal frame number
+	FRAME_DISPLAY_TIMELINE, ///< Display the timeline's frame number
+	FRAME_DISPLAY_BOTH      ///< Display both the clip's and timeline's frame number
+};
+
+/// This enumeration determines the strategy when mixing audio with other clips.
+enum VolumeMixType
+{
+	VOLUME_MIX_NONE,   	///< Do not apply any volume mixing adjustments. Just add the samples together.
+	VOLUME_MIX_AVERAGE,	///< Evenly divide the overlapping clips volume keyframes, so that the sum does not exceed 100%
+	VOLUME_MIX_REDUCE 	///< Reduce volume by about %25, and then mix (louder, but could cause pops if the sum exceeds 100%)
+};
 
 
-	/// This enumeration determines the distortion type of Distortion Effect.
-	enum DistortionType
-	{
-		HARD_CLIPPING,
-		SOFT_CLIPPING,
-		EXPONENTIAL,
-		FULL_WAVE_RECTIFIER,
-		HALF_WAVE_RECTIFIER,
-	};
+/// This enumeration determines the distortion type of Distortion Effect.
+enum DistortionType
+{
+	HARD_CLIPPING,
+	SOFT_CLIPPING,
+	EXPONENTIAL,
+	FULL_WAVE_RECTIFIER,
+	HALF_WAVE_RECTIFIER,
+};
 
-	/// This enumeration determines the filter type of ParametricEQ Effect.
-	enum FilterType
-	{
-		LOW_PASS,
-		HIGH_PASS,
-		LOW_SHELF,
-		HIGH_SHELF,
-		BAND_PASS,
-		BAND_STOP,
-		PEAKING_NOTCH,
-	};
+/// This enumeration determines the filter type of ParametricEQ Effect.
+enum FilterType
+{
+	LOW_PASS,
+	HIGH_PASS,
+	LOW_SHELF,
+	HIGH_SHELF,
+	BAND_PASS,
+	BAND_STOP,
+	PEAKING_NOTCH,
+};
 
-	/// This enumeration determines the FFT size.
-	enum FFTSize
-	{
-		FFT_SIZE_32,
-		FFT_SIZE_64,
-		FFT_SIZE_128,
-		FFT_SIZE_256,
-		FFT_SIZE_512,
-		FFT_SIZE_1024,
-		FFT_SIZE_2048,
-		FFT_SIZE_4096,
-		FFT_SIZE_8192,
-	};
+/// This enumeration determines the FFT size.
+enum FFTSize
+{
+	FFT_SIZE_32,
+	FFT_SIZE_64,
+	FFT_SIZE_128,
+	FFT_SIZE_256,
+	FFT_SIZE_512,
+	FFT_SIZE_1024,
+	FFT_SIZE_2048,
+	FFT_SIZE_4096,
+	FFT_SIZE_8192,
+};
 
-	/// This enumeration determines the hop size.
-	enum HopSize {
-        HOP_SIZE_2,
-        HOP_SIZE_4,
-        HOP_SIZE_8,
-    };
+/// This enumeration determines the hop size.
+enum HopSize {
+    HOP_SIZE_2,
+    HOP_SIZE_4,
+    HOP_SIZE_8,
+};
 
-	/// This enumeration determines the window type.
-	enum WindowType {
-        RECTANGULAR,
-        BART_LETT,
-        HANN,
-        HAMMING,
-    };
+/// This enumeration determines the window type.
+enum WindowType {
+    RECTANGULAR,
+    BART_LETT,
+    HANN,
+    HAMMING,
+};
 
-	/// This enumeration determines the algorithm used by the ChromaKey filter
-	enum ChromaKeyMethod
-	{
-		CHROMAKEY_BASIC,	///< Length of difference between RGB vectors
-		CHROMAKEY_HSVL_H,	///< Difference between HSV/HSL hues
-		CHROMAKEY_HSV_S,	///< Difference between HSV saturations
-		CHROMAKEY_HSL_S,	///< Difference between HSL saturations
-		CHROMAKEY_HSV_V,	///< Difference between HSV values
-		CHROMAKEY_HSL_L,	///< Difference between HSL luminances
-		CHROMAKEY_CIE_LCH_L,	///< Difference between CIE LCH(ab) luminousities
-		CHROMAKEY_CIE_LCH_C,	///< Difference between CIE LCH(ab) chromas
-		CHROMAKEY_CIE_LCH_H,	///< Difference between CIE LCH(ab) hues
-		CHROMAKEY_CIE_DISTANCE, ///< CIEDE2000 perceptual difference
-		CHROMAKEY_YCBCR,	///< YCbCr vector difference of CbCr
-		CHROMAKEY_LAST_METHOD = CHROMAKEY_YCBCR
-	};
-}
+/// This enumeration determines the algorithm used by the ChromaKey filter
+enum ChromaKeyMethod
+{
+    CHROMAKEY_BASIC,        ///< Length of difference between RGB vectors
+    CHROMAKEY_HSVL_H,       ///< Difference between HSV/HSL hues
+    CHROMAKEY_HSV_S,        ///< Difference between HSV saturations
+    CHROMAKEY_HSL_S,        ///< Difference between HSL saturations
+    CHROMAKEY_HSV_V,        ///< Difference between HSV values
+    CHROMAKEY_HSL_L,        ///< Difference between HSL luminances
+    CHROMAKEY_CIE_LCH_L,    ///< Difference between CIE LCH(ab) luminousities
+    CHROMAKEY_CIE_LCH_C,    ///< Difference between CIE LCH(ab) chromas
+    CHROMAKEY_CIE_LCH_H,    ///< Difference between CIE LCH(ab) hues
+    CHROMAKEY_CIE_DISTANCE, ///< CIEDE2000 perceptual difference
+    CHROMAKEY_YCBCR,        ///< YCbCr vector difference of CbCr
+    CHROMAKEY_LAST_METHOD = CHROMAKEY_YCBCR
+};
+
+}  // namespace openshot
+
 #endif

--- a/src/FFmpegReader.cpp
+++ b/src/FFmpegReader.cpp
@@ -13,15 +13,16 @@
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
+#include <thread>    // for std::this_thread::sleep_for
+#include <chrono>    // for std::chrono::milliseconds
+#include <unistd.h>
+
 #include "FFmpegUtilities.h"
 
 #include "FFmpegReader.h"
 #include "Exceptions.h"
 #include "Timeline.h"
 #include "ZmqLogger.h"
-
-#include <thread>    // for std::this_thread::sleep_for
-#include <chrono>    // for std::chrono::milliseconds
 
 #define ENABLE_VAAPI 0
 
@@ -583,7 +584,7 @@ void FFmpegReader::Close() {
 
 		// Clear processed lists
 		{
-			const GenericScopedLock <CriticalSection> lock(processingCriticalSection);
+			const std::lock_guard<std::recursive_mutex> lock(processingMutex);
 			processed_video_frames.clear();
 			processed_audio_frames.clear();
 			processing_video_frames.clear();
@@ -904,7 +905,7 @@ std::shared_ptr<Frame> FFmpegReader::ReadStream(int64_t requested_frame) {
 		int processing_video_frames_size = 0;
 		int processing_audio_frames_size = 0;
 		{
-			const GenericScopedLock <CriticalSection> lock(processingCriticalSection);
+			const std::lock_guard<std::recursive_mutex> lock(processingMutex);
 			processing_video_frames_size = processing_video_frames.size();
 			processing_audio_frames_size = processing_audio_frames.size();
 		}
@@ -912,7 +913,7 @@ std::shared_ptr<Frame> FFmpegReader::ReadStream(int64_t requested_frame) {
 		// Wait if too many frames are being processed
 		while (processing_video_frames_size + processing_audio_frames_size >= minimum_packets) {
 			std::this_thread::sleep_for(std::chrono::milliseconds(3));
-			const GenericScopedLock <CriticalSection> lock(processingCriticalSection);
+			const std::lock_guard<std::recursive_mutex> lock(processingMutex);
 			processing_video_frames_size = processing_video_frames.size();
 			processing_audio_frames_size = processing_audio_frames.size();
 		}
@@ -1236,7 +1237,7 @@ void FFmpegReader::ProcessVideoPacket(int64_t requested_frame) {
 	pFrame = NULL;
 
 	// Add video frame to list of processing video frames
-	const GenericScopedLock <CriticalSection> lock(processingCriticalSection);
+	const std::lock_guard<std::recursive_mutex> lock(processingMutex);
 	processing_video_frames[current_frame] = current_frame;
 
 	// Create variables for a RGB Frame (since most videos are not in RGB, we must convert it)
@@ -1368,7 +1369,7 @@ void FFmpegReader::ProcessVideoPacket(int64_t requested_frame) {
 
 	// Remove video frame from list of processing video frames
 	{
-		const GenericScopedLock <CriticalSection> lock(processingCriticalSection);
+		const std::lock_guard<std::recursive_mutex> lock(processingMutex);
 		processing_video_frames.erase(current_frame);
 		processed_video_frames[current_frame] = current_frame;
 	}
@@ -1467,7 +1468,7 @@ void FFmpegReader::ProcessAudioPacket(int64_t requested_frame, int64_t target_fr
 
 	// Add audio frame to list of processing audio frames
 	{
-		const GenericScopedLock <CriticalSection> lock(processingCriticalSection);
+		const std::lock_guard<std::recursive_mutex> lock(processingMutex);
 		processing_audio_frames.insert(std::pair<int, int>(previous_packet_location.frame, previous_packet_location.frame));
 	}
 
@@ -1490,7 +1491,7 @@ void FFmpegReader::ProcessAudioPacket(int64_t requested_frame, int64_t target_fr
 
 			// Add audio frame to list of processing audio frames
 			{
-				const GenericScopedLock <CriticalSection> lock(processingCriticalSection);
+				const std::lock_guard<std::recursive_mutex> lock(processingMutex);
 				processing_audio_frames.insert(std::pair<int, int>(previous_packet_location.frame, previous_packet_location.frame));
 			}
 
@@ -1645,7 +1646,7 @@ void FFmpegReader::ProcessAudioPacket(int64_t requested_frame, int64_t target_fr
 
 	// Remove audio frame from list of processing audio frames
 	{
-		const GenericScopedLock <CriticalSection> lock(processingCriticalSection);
+		const std::lock_guard<std::recursive_mutex> lock(processingMutex);
 		// Update all frames as completed
 		for (int64_t f = target_frame; f < starting_frame_number; f++) {
 			// Remove the frame # from the processing list. NOTE: If more than one thread is
@@ -1685,7 +1686,7 @@ void FFmpegReader::Seek(int64_t requested_frame) {
 	int processing_video_frames_size = 0;
 	int processing_audio_frames_size = 0;
 	{
-		const GenericScopedLock <CriticalSection> lock(processingCriticalSection);
+		const std::lock_guard<std::recursive_mutex> lock(processingMutex);
 		processing_video_frames_size = processing_video_frames.size();
 		processing_audio_frames_size = processing_audio_frames.size();
 	}
@@ -1696,7 +1697,7 @@ void FFmpegReader::Seek(int64_t requested_frame) {
 	// Wait for any processing frames to complete
 	while (processing_video_frames_size + processing_audio_frames_size > 0) {
 		std::this_thread::sleep_for(std::chrono::milliseconds(3));
-		const GenericScopedLock <CriticalSection> lock(processingCriticalSection);
+		const std::lock_guard<std::recursive_mutex> lock(processingMutex);
 		processing_video_frames_size = processing_video_frames.size();
 		processing_audio_frames_size = processing_audio_frames.size();
 	}
@@ -1707,7 +1708,7 @@ void FFmpegReader::Seek(int64_t requested_frame) {
 
 	// Clear processed lists
 	{
-		const GenericScopedLock <CriticalSection> lock(processingCriticalSection);
+		const std::lock_guard<std::recursive_mutex> lock(processingMutex);
 		processing_audio_frames.clear();
 		processing_video_frames.clear();
 		processed_video_frames.clear();
@@ -1930,7 +1931,7 @@ int64_t FFmpegReader::ConvertVideoPTStoFrame(int64_t pts) {
 
 		// Sometimes frames are missing due to varying timestamps, or they were dropped. Determine
 		// if we are missing a video frame.
-		const GenericScopedLock <CriticalSection> lock(processingCriticalSection);
+		const std::lock_guard<std::recursive_mutex> lock(processingMutex);
 		while (current_video_frame < frame) {
 			if (!missing_video_frames.count(current_video_frame)) {
 				ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::ConvertVideoPTStoFrame (tracking missing frame)", "current_video_frame", current_video_frame, "previous_video_frame", previous_video_frame);
@@ -2023,7 +2024,7 @@ AudioLocation FFmpegReader::GetAudioPTSLocation(int64_t pts) {
 			// Debug output
 			ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::GetAudioPTSLocation (Audio Gap Ignored - too big)", "Previous location frame", previous_packet_location.frame, "Target Frame", location.frame, "Target Audio Sample", location.sample_start, "pts", pts);
 
-			const GenericScopedLock <CriticalSection> lock(processingCriticalSection);
+			const std::lock_guard<std::recursive_mutex> lock(processingMutex);
 			for (int64_t audio_frame = previous_packet_location.frame; audio_frame < location.frame; audio_frame++) {
 				if (!missing_audio_frames.count(audio_frame)) {
 					ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::GetAudioPTSLocation (tracking missing frame)", "missing_audio_frame", audio_frame, "previous_audio_frame", previous_packet_location.frame, "new location frame", location.frame);
@@ -2047,7 +2048,7 @@ std::shared_ptr<Frame> FFmpegReader::CreateFrame(int64_t requested_frame) {
 
 	if (!output) {
 		// Lock
-		const GenericScopedLock <CriticalSection> lock(processingCriticalSection);
+		const std::lock_guard<std::recursive_mutex> lock(processingMutex);
 
 		// (re-)Check working cache
 		output = working_cache.GetFrame(requested_frame);
@@ -2089,7 +2090,7 @@ bool FFmpegReader::IsPartialFrame(int64_t requested_frame) {
 // Check if a frame is missing and attempt to replace its frame image (and
 bool FFmpegReader::CheckMissingFrame(int64_t requested_frame) {
 	// Lock
-	const GenericScopedLock <CriticalSection> lock(processingCriticalSection);
+	const std::lock_guard<std::recursive_mutex> lock(processingMutex);
 
 	// Increment check count for this frame (or init to 1)
 	++checked_frames[requested_frame];
@@ -2205,7 +2206,7 @@ void FFmpegReader::CheckWorkingFrames(bool end_of_stream, int64_t requested_fram
 		bool is_video_ready = false;
 		bool is_audio_ready = false;
 		{ // limit scope of next few lines
-			const GenericScopedLock <CriticalSection> lock(processingCriticalSection);
+			const std::lock_guard<std::recursive_mutex> lock(processingMutex);
 			is_video_ready = processed_video_frames.count(f->number);
 			is_audio_ready = processed_audio_frames.count(f->number);
 
@@ -2268,7 +2269,7 @@ void FFmpegReader::CheckWorkingFrames(bool end_of_stream, int64_t requested_fram
 
 				// Add to missing cache (if another frame depends on it)
 				{
-					const GenericScopedLock <CriticalSection> lock(processingCriticalSection);
+					const std::lock_guard<std::recursive_mutex> lock(processingMutex);
 					if (missing_video_frames_source.count(f->number)) {
 						// Debug output
 						ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::CheckWorkingFrames (add frame to missing cache)", "f->number", f->number, "is_seek_trash", is_seek_trash, "Missing Cache Count", missing_frames.Count(), "Working Cache Count", working_cache.Count(), "Final Cache Count", final_cache.Count());
@@ -2420,7 +2421,7 @@ int64_t FFmpegReader::GetSmallestVideoFrame() {
 	// Loop through frame numbers
 	std::map<int64_t, int64_t>::iterator itr;
 	int64_t smallest_frame = -1;
-	const GenericScopedLock <CriticalSection> lock(processingCriticalSection);
+	const std::lock_guard<std::recursive_mutex> lock(processingMutex);
 	for (itr = processing_video_frames.begin(); itr != processing_video_frames.end(); ++itr) {
 		if (itr->first < smallest_frame || smallest_frame == -1)
 			smallest_frame = itr->first;
@@ -2435,7 +2436,7 @@ int64_t FFmpegReader::GetSmallestAudioFrame() {
 	// Loop through frame numbers
 	std::map<int64_t, int64_t>::iterator itr;
 	int64_t smallest_frame = -1;
-	const GenericScopedLock <CriticalSection> lock(processingCriticalSection);
+	const std::lock_guard<std::recursive_mutex> lock(processingMutex);
 	for (itr = processing_audio_frames.begin(); itr != processing_audio_frames.end(); ++itr) {
 		if (itr->first < smallest_frame || smallest_frame == -1)
 			smallest_frame = itr->first;

--- a/src/FFmpegWriter.cpp
+++ b/src/FFmpegWriter.cpp
@@ -17,6 +17,7 @@
 
 #include "FFmpegWriter.h"
 #include "Exceptions.h"
+#include "Frame.h"
 
 #include <iostream>
 

--- a/src/Frame.cpp
+++ b/src/Frame.cpp
@@ -16,7 +16,13 @@
 #include <iomanip>
 
 #include "Frame.h"
-#include <OpenShotAudio.h>
+
+#include "AudioBufferSource.h"
+#include "AudioResampler.h"
+
+#include <AppConfig.h>
+#include <juce_audio_basics/juce_audio_basics.h>
+#include <juce_audio_devices/juce_audio_devices.h>
 
 #include <QApplication>
 #include <QImage>
@@ -41,7 +47,7 @@ using namespace openshot;
 
 // Constructor - image & audio
 Frame::Frame(int64_t number, int width, int height, std::string color, int samples, int channels)
-	: audio(std::make_shared<juce::AudioSampleBuffer>(channels, samples)),
+	: audio(std::make_shared<juce::AudioBuffer<float>>(channels, samples)),
 	  number(number), width(width), height(height),
 	  pixel_ratio(1,1), color(color), qbuffer(NULL),
 	  channels(channels), channel_layout(LAYOUT_STEREO),
@@ -99,7 +105,7 @@ void Frame::DeepCopy(const Frame& other)
 	if (other.image)
 		image = std::make_shared<QImage>(*(other.image));
 	if (other.audio)
-		audio = std::make_shared<juce::AudioSampleBuffer>(*(other.audio));
+		audio = std::make_shared<juce::AudioBuffer<float>>(*(other.audio));
 	if (other.wave_image)
 		wave_image = std::make_shared<QImage>(*(other.wave_image));
 }
@@ -319,7 +325,7 @@ float* Frame::GetAudioSamples(int channel)
 float* Frame::GetPlanarAudioSamples(int new_sample_rate, AudioResampler* resampler, int* sample_count)
 {
 	float *output = NULL;
-	juce::AudioSampleBuffer *buffer(audio.get());
+	juce::AudioBuffer<float> *buffer(audio.get());
 	int num_of_channels = audio->getNumChannels();
 	int num_of_samples = GetAudioSamplesCount();
 
@@ -365,7 +371,7 @@ float* Frame::GetPlanarAudioSamples(int new_sample_rate, AudioResampler* resampl
 float* Frame::GetInterleavedAudioSamples(int new_sample_rate, AudioResampler* resampler, int* sample_count)
 {
 	float *output = NULL;
-	juce::AudioSampleBuffer *buffer(audio.get());
+	juce::AudioBuffer<float> *buffer(audio.get());
 	int num_of_channels = audio->getNumChannels();
 	int num_of_samples = GetAudioSamplesCount();
 
@@ -409,7 +415,7 @@ float* Frame::GetInterleavedAudioSamples(int new_sample_rate, AudioResampler* re
 // Get number of audio channels
 int Frame::GetAudioChannelsCount()
 {
-    const juce::GenericScopedLock<juce::CriticalSection> lock(addingAudioSection);
+    const std::lock_guard<std::recursive_mutex> lock(addingAudioMutex);
 	if (audio)
 		return audio->getNumChannels();
 	else
@@ -419,11 +425,11 @@ int Frame::GetAudioChannelsCount()
 // Get number of audio samples
 int Frame::GetAudioSamplesCount()
 {
-    const juce::GenericScopedLock<juce::CriticalSection> lock(addingAudioSection);
+    const std::lock_guard<std::recursive_mutex> lock(addingAudioMutex);
 	return max_audio_sample;
 }
 
-juce::AudioSampleBuffer *Frame::GetAudioSampleBuffer()
+juce::AudioBuffer<float> *Frame::GetAudioSampleBuffer()
 {
     return audio.get();
 }
@@ -724,7 +730,7 @@ int Frame::constrain(int color_value)
 
 void Frame::AddColor(int new_width, int new_height, std::string new_color)
 {
-     const juce::GenericScopedLock<juce::CriticalSection> lock(addingImageSection);
+     const std::lock_guard<std::recursive_mutex> lock(addingImageMutex);
      // Update parameters
     width = new_width;
     height = new_height;
@@ -736,7 +742,7 @@ void Frame::AddColor(int new_width, int new_height, std::string new_color)
 void Frame::AddColor(const QColor& new_color)
 {
 	// Create new image object, and fill with pixel data
-	const juce::GenericScopedLock<juce::CriticalSection> lock(addingImageSection);
+	const std::lock_guard<std::recursive_mutex> lock(addingImageMutex);
 	image = std::make_shared<QImage>(width, height, QImage::Format_RGBA8888_Premultiplied);
 
 	// Fill with solid color
@@ -751,9 +757,9 @@ void Frame::AddImage(
 {
 	// Create new buffer
 	{
-		const juce::GenericScopedLock<juce::CriticalSection> lock(addingImageSection);
+		const std::lock_guard<std::recursive_mutex> lock(addingImageMutex);
 		qbuffer = pixels_;
-	}  // Release addingImageSection lock
+	}  // Release addingImageMutex lock
 
 	// Create new image object from pixel data
 	auto new_image = std::make_shared<QImage>(
@@ -775,7 +781,7 @@ void Frame::AddImage(std::shared_ptr<QImage> new_image)
 		return;
 
 	// assign image data
-	const juce::GenericScopedLock<juce::CriticalSection> lock(addingImageSection);
+	const std::lock_guard<std::recursive_mutex> lock(addingImageMutex);
 	image = new_image;
 
 	// Always convert to Format_RGBA8888_Premultiplied (if different)
@@ -815,7 +821,7 @@ void Frame::AddImage(std::shared_ptr<QImage> new_image, bool only_odd_lines)
 		}
 
 		// Get the frame's image
-		const juce::GenericScopedLock<juce::CriticalSection> lock(addingImageSection);
+		const std::lock_guard<std::recursive_mutex> lock(addingImageMutex);
 		unsigned char *pixels = image->bits();
 		const unsigned char *new_pixels = new_image->constBits();
 
@@ -840,7 +846,7 @@ void Frame::AddImage(std::shared_ptr<QImage> new_image, bool only_odd_lines)
 // Resize audio container to hold more (or less) samples and channels
 void Frame::ResizeAudio(int channels, int length, int rate, ChannelLayout layout)
 {
-    const juce::GenericScopedLock<juce::CriticalSection> lock(addingAudioSection);
+    const std::lock_guard<std::recursive_mutex> lock(addingAudioMutex);
 
     // Resize JUCE audio buffer
 	audio->setSize(channels, length, true, true, false);
@@ -853,7 +859,7 @@ void Frame::ResizeAudio(int channels, int length, int rate, ChannelLayout layout
 
 // Add audio samples to a specific channel
 void Frame::AddAudio(bool replaceSamples, int destChannel, int destStartSample, const float* source, int numSamples, float gainToApplyToSource = 1.0f) {
-	const juce::GenericScopedLock<juce::CriticalSection> lock(addingAudioSection);
+	const std::lock_guard<std::recursive_mutex> lock(addingAudioMutex);
 
 	// Clamp starting sample to 0
 	int destStartSampleAdjusted = max(destStartSample, 0);
@@ -882,7 +888,7 @@ void Frame::AddAudio(bool replaceSamples, int destChannel, int destStartSample, 
 // Apply gain ramp (i.e. fading volume)
 void Frame::ApplyGainRamp(int destChannel, int destStartSample, int numSamples, float initial_gain = 0.0f, float final_gain = 1.0f)
 {
-    const juce::GenericScopedLock<juce::CriticalSection> lock(addingAudioSection);
+    const std::lock_guard<std::recursive_mutex> lock(addingAudioMutex);
 
     // Apply gain ramp
 	audio->applyGainRamp(destChannel, destStartSample, numSamples, initial_gain, final_gain);
@@ -1087,7 +1093,7 @@ void Frame::cleanUpBuffer(void *info)
 // Add audio silence
 void Frame::AddAudioSilence(int numSamples)
 {
-    const juce::GenericScopedLock<juce::CriticalSection> lock(addingAudioSection);
+    const std::lock_guard<std::recursive_mutex> lock(addingAudioMutex);
 
     // Resize audio container
 	audio->setSize(channels, numSamples, false, true, false);

--- a/src/Frame.h
+++ b/src/Frame.h
@@ -21,15 +21,13 @@
 	#undef int64
 #endif
 
-#include <queue>
 #include <memory>
+#include <mutex>
+#include <sstream>
+#include <queue>
 
 #include "ChannelLayouts.h"
-#include "AudioBufferSource.h"
-#include "AudioResampler.h"
 #include "Fraction.h"
-
-#include <OpenShotAudio.h>
 
 #include <QColor>
 #include <QImage>
@@ -43,8 +41,14 @@ namespace Magick {
 
 class QApplication;
 
+namespace juce {
+    template <typename Type> class AudioBuffer;
+}
+
 namespace openshot
 {
+	class AudioBufferSource;
+	class AudioResampler;
 	/**
 	 * @brief This class represents a single frame of video (i.e. image & audio data)
 	 *
@@ -97,8 +101,8 @@ namespace openshot
 		std::shared_ptr<QImage> wave_image;
 
 		std::shared_ptr<QApplication> previewApp;
-		juce::CriticalSection addingImageSection;
-        juce::CriticalSection addingAudioSection;
+		std::recursive_mutex addingImageMutex;
+        std::recursive_mutex addingAudioMutex;
 		const unsigned char *qbuffer;
 		openshot::Fraction pixel_ratio;
 		int channels;
@@ -117,7 +121,7 @@ namespace openshot
 		int constrain(int color_value);
 
 	public:
-		std::shared_ptr<juce::AudioSampleBuffer> audio;
+		std::shared_ptr<juce::AudioBuffer<float>> audio;
 		int64_t number;	 ///< This is the frame number (starting at 1)
 		bool has_audio_data; ///< This frame has been loaded with audio data
 		bool has_image_data; ///< This frame has been loaded with pixel data
@@ -212,7 +216,7 @@ namespace openshot
 		/// Get number of audio samples
 		int GetAudioSamplesCount();
 
-	    juce::AudioSampleBuffer *GetAudioSampleBuffer();
+	    juce::AudioBuffer<float> *GetAudioSampleBuffer();
 
 		/// Get the size in bytes of this frame (rough estimate)
 		int64_t GetBytes();

--- a/src/FrameMapper.cpp
+++ b/src/FrameMapper.cpp
@@ -391,7 +391,7 @@ std::shared_ptr<Frame> FrameMapper::GetFrame(int64_t requested_frame)
 	if (final_frame) return final_frame;
 
 	// Create a scoped lock, allowing only a single thread to run the following code at one time
-	const GenericScopedLock<CriticalSection> lock(getFrameCriticalSection);
+	const std::lock_guard<std::recursive_mutex> lock(getFrameMutex);
 
     // Find parent properties (if any)
     Clip *parent = (Clip *) ParentClip();
@@ -649,7 +649,7 @@ void FrameMapper::Close()
 	if (reader)
 	{
 		// Create a scoped lock, allowing only a single thread to run the following code at one time
-		const GenericScopedLock<CriticalSection> lock(getFrameCriticalSection);
+		const std::lock_guard<std::recursive_mutex> lock(getFrameMutex);
 
 		ZmqLogger::Instance()->AppendDebugMethod("FrameMapper::Close");
 

--- a/src/ImageWriter.cpp
+++ b/src/ImageWriter.cpp
@@ -15,6 +15,8 @@
 
 #include "ImageWriter.h"
 #include "Exceptions.h"
+#include "Frame.h"
+#include "ZmqLogger.h"
 
 using namespace openshot;
 

--- a/src/Qt/AudioPlaybackThread.cpp
+++ b/src/Qt/AudioPlaybackThread.cpp
@@ -12,9 +12,12 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
 #include "AudioPlaybackThread.h"
+#include "Settings.h"
 
 #include <thread>    // for std::this_thread::sleep_for
 #include <chrono>    // for std::chrono::milliseconds
+
+using namespace juce;
 
 namespace openshot
 {

--- a/src/Qt/AudioPlaybackThread.h
+++ b/src/Qt/AudioPlaybackThread.h
@@ -14,11 +14,14 @@
 #ifndef OPENSHOT_AUDIO_PLAYBACK_THREAD_H
 #define OPENSHOT_AUDIO_PLAYBACK_THREAD_H
 
-#include "../ReaderBase.h"
-#include "../RendererBase.h"
-#include "../AudioReaderSource.h"
-#include "../AudioDeviceInfo.h"
-#include "../Settings.h"
+#include "ReaderBase.h"
+#include "RendererBase.h"
+#include "AudioReaderSource.h"
+#include "AudioDeviceInfo.h"
+
+#include <AppConfig.h>
+#include <juce_audio_basics/juce_audio_basics.h>
+#include <juce_audio_devices/juce_audio_devices.h>
 
 namespace openshot
 {

--- a/src/Qt/VideoCacheThread.cpp
+++ b/src/Qt/VideoCacheThread.cpp
@@ -11,7 +11,11 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
 #include "VideoCacheThread.h"
+
+#include "CacheBase.h"
 #include "Exceptions.h"
+#include "Frame.h"
+#include "OpenMPUtilities.h"
 #include "ZmqLogger.h"
 
 #include <algorithm>

--- a/src/Qt/VideoCacheThread.h
+++ b/src/Qt/VideoCacheThread.h
@@ -13,10 +13,10 @@
 #ifndef OPENSHOT_VIDEO_CACHE_THREAD_H
 #define OPENSHOT_VIDEO_CACHE_THREAD_H
 
-#include "../OpenMPUtilities.h"
-#include "../ReaderBase.h"
-#include "../RendererBase.h"
-#include "../CacheBase.h"
+#include "ReaderBase.h"
+
+#include <AppConfig.h>
+#include <juce_audio_basics/juce_audio_basics.h>
 
 namespace openshot
 {

--- a/src/Qt/VideoPlaybackThread.cpp
+++ b/src/Qt/VideoPlaybackThread.cpp
@@ -14,6 +14,10 @@
 #include "VideoPlaybackThread.h"
 #include "ZmqLogger.h"
 
+#include "Frame.h"
+#include "RendererBase.h"
+#include "ZmqLogger.h"
+
 namespace openshot
 {
 	// Constructor

--- a/src/Qt/VideoPlaybackThread.h
+++ b/src/Qt/VideoPlaybackThread.h
@@ -14,11 +14,13 @@
 #ifndef OPENSHOT_VIDEO_PLAYBACK_THREAD_H
 #define OPENSHOT_VIDEO_PLAYBACK_THREAD_H
 
-#include "../ReaderBase.h"
-#include "../RendererBase.h"
+#include <AppConfig.h>
+#include <juce_audio_basics/juce_audio_basics.h>
 
 namespace openshot
 {
+    class Frame;
+    class RendererBase;
     using juce::Thread;
     using juce::WaitableEvent;
 

--- a/src/QtImageReader.cpp
+++ b/src/QtImageReader.cpp
@@ -11,10 +11,10 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
 #include "QtImageReader.h"
-#include "Exceptions.h"
-#include "Settings.h"
+
 #include "Clip.h"
 #include "CacheMemory.h"
+#include "Exceptions.h"
 #include "Timeline.h"
 
 #include <QString>
@@ -147,8 +147,8 @@ std::shared_ptr<Frame> QtImageReader::GetFrame(int64_t requested_frame)
     if (!is_open)
         throw ReaderClosed("The Image is closed.  Call Open() before calling this method.", path.toStdString());
 
-    // Create a scoped lock, allowing only a single thread to run the following code at one time
-    const GenericScopedLock<CriticalSection> lock(getFrameCriticalSection);
+	// Create a scoped lock, allowing only a single thread to run the following code at one time
+	const std::lock_guard<std::recursive_mutex> lock(getFrameMutex);
 
     // Calculate max image size
     QSize current_max_size = calculate_max_size();

--- a/src/QtImageReader.h
+++ b/src/QtImageReader.h
@@ -41,6 +41,11 @@ class QImage;
 #include <QSize>
 #include <QString>
 
+#include <QSize>
+#include <QString>
+
+class QImage;
+
 namespace openshot
 {
     // Forward decl

--- a/src/QtTextReader.cpp
+++ b/src/QtTextReader.cpp
@@ -13,6 +13,7 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
 #include "QtTextReader.h"
+#include "CacheBase.h"
 #include "Exceptions.h"
 #include "Frame.h"
 

--- a/src/QtTextReader.h
+++ b/src/QtTextReader.h
@@ -19,7 +19,6 @@
 
 #include <memory>
 
-#include "CacheMemory.h"
 #include "Enums.h"
 
 #include <QFont>
@@ -30,6 +29,7 @@ namespace openshot
 {
 	// Forward decls
 	class CacheBase;
+	class Frame;
 
 	/**
 	 * @brief This class uses Qt libraries, to create frames with "Text", and return

--- a/src/ReaderBase.cpp
+++ b/src/ReaderBase.cpp
@@ -20,6 +20,7 @@
 
 #include "Json.h"
 
+
 using namespace openshot;
 
 /// Constructor for the base reader, where many things are initialized.

--- a/src/ReaderBase.h
+++ b/src/ReaderBase.h
@@ -15,6 +15,8 @@
 
 #include <map>
 #include <memory>
+#include <mutex>
+#include <iostream>
 #include <string>
 #include <vector>
 
@@ -22,14 +24,11 @@
 #include "Fraction.h"
 #include "Json.h"
 
-#include <OpenShotAudio.h>
-
 namespace openshot
 {
-	class ClipBase;
 	class CacheBase;
+	class ClipBase;
 	class Frame;
-
 	/**
 	 * @brief This struct contains info about a media file, such as height, width, frames per second, etc...
 	 *
@@ -76,9 +75,9 @@ namespace openshot
 	class ReaderBase
 	{
 	protected:
-		/// Section lock for multiple threads
-		juce::CriticalSection getFrameCriticalSection;
-		juce::CriticalSection processingCriticalSection;
+		/// Mutex for multiple threads
+		std::recursive_mutex getFrameMutex;
+		std::recursive_mutex processingMutex;
 		openshot::ClipBase* clip; ///< Pointer to the parent clip instance (if any)
 
 	public:

--- a/src/Timeline.cpp
+++ b/src/Timeline.cpp
@@ -468,7 +468,7 @@ int64_t Timeline::GetMaxFrame() {
 void Timeline::apply_mapper_to_clip(Clip* clip)
 {
     // Get lock (prevent getting frames while this happens)
-    const GenericScopedLock<CriticalSection> lock(getFrameCriticalSection);
+    const std::lock_guard<std::recursive_mutex> lock(getFrameMutex);
 
 	// Determine type of reader
 	ReaderBase* clip_reader = NULL;
@@ -773,7 +773,7 @@ std::shared_ptr<Frame> Timeline::GetFrame(int64_t requested_frame)
 	else
 	{
 		// Create a scoped lock, allowing only a single thread to run the following code at one time
-		const GenericScopedLock<CriticalSection> lock(getFrameCriticalSection);
+		const std::lock_guard<std::recursive_mutex> lock(getFrameMutex);
 
 		// Check for open reader (or throw exception)
 		if (!is_open)
@@ -1005,7 +1005,7 @@ Json::Value Timeline::JsonValue() const {
 void Timeline::SetJson(const std::string value) {
 
 	// Get lock (prevent getting frames while this happens)
-	const GenericScopedLock<CriticalSection> lock(getFrameCriticalSection);
+	const std::lock_guard<std::recursive_mutex> lock(getFrameMutex);
 
 	// Parse JSON string into JSON objects
 	try
@@ -1047,7 +1047,7 @@ void Timeline::SetJsonValue(const Json::Value root) {
 			// When a clip is attached to an object, it searches for the object
 			// on it's parent timeline. Setting the parent timeline of the clip here
 			// allows attaching it to an object when exporting the project (because)
-			// the exporter script initializes the clip and it's effects 
+			// the exporter script initializes the clip and it's effects
 			// before setting its parent timeline.
 			c->ParentTimeline(this);
 
@@ -1101,7 +1101,7 @@ void Timeline::SetJsonValue(const Json::Value root) {
 void Timeline::ApplyJsonDiff(std::string value) {
 
     // Get lock (prevent getting frames while this happens)
-    const GenericScopedLock<CriticalSection> lock(getFrameCriticalSection);
+    const std::lock_guard<std::recursive_mutex> lock(getFrameMutex);
 
 	// Parse JSON string into JSON objects
 	try
@@ -1480,7 +1480,7 @@ void Timeline::apply_json_to_timeline(Json::Value change) {
 void Timeline::ClearAllCache() {
 
     // Get lock (prevent getting frames while this happens)
-    const GenericScopedLock<CriticalSection> lock(getFrameCriticalSection);
+    const std::lock_guard<std::recursive_mutex> lock(getFrameMutex);
 
     // Clear primary cache
     final_cache->Clear();

--- a/src/WriterBase.cpp
+++ b/src/WriterBase.cpp
@@ -15,6 +15,8 @@
 
 #include "WriterBase.h"
 #include "Exceptions.h"
+#include "Frame.h"
+#include "ReaderBase.h"
 
 using namespace openshot;
 

--- a/src/WriterBase.h
+++ b/src/WriterBase.h
@@ -17,12 +17,12 @@
 
 #include "ChannelLayouts.h"
 #include "Fraction.h"
-#include "Frame.h"
-#include "ReaderBase.h"
-#include "ZmqLogger.h"
+#include "Json.h"
 
 namespace openshot
 {
+	class ReaderBase;
+	class Frame;
 	/**
 	 * @brief This struct contains info about encoding a media file, such as height, width, frames per second, etc...
 	 *

--- a/src/ZmqLogger.cpp
+++ b/src/ZmqLogger.cpp
@@ -12,6 +12,7 @@
 
 #include "ZmqLogger.h"
 #include "Exceptions.h"
+#include "Settings.h"
 
 #if USE_RESVG == 1
 	#include "ResvgQt.h"
@@ -62,7 +63,7 @@ ZmqLogger *ZmqLogger::Instance()
 void ZmqLogger::Connection(std::string new_connection)
 {
 	// Create a scoped lock, allowing only a single thread to run the following code at one time
-	const juce::GenericScopedLock<juce::CriticalSection> lock(loggerCriticalSection);
+	const std::lock_guard<std::recursive_mutex> lock(loggerMutex);
 
 	// Does anything need to happen?
 	if (new_connection == connection)
@@ -106,7 +107,7 @@ void ZmqLogger::Log(std::string message)
 		return;
 
 	// Create a scoped lock, allowing only a single thread to run the following code at one time
-	const juce::GenericScopedLock<juce::CriticalSection> lock(loggerCriticalSection);
+	const std::lock_guard<std::recursive_mutex> lock(loggerMutex);
 
 	// Send message over socket (ZeroMQ)
 	zmq::message_t reply (message.length());
@@ -183,7 +184,7 @@ void ZmqLogger::AppendDebugMethod(std::string method_name,
 
 	{
 		// Create a scoped lock, allowing only a single thread to run the following code at one time
-		const juce::GenericScopedLock<juce::CriticalSection> lock(loggerCriticalSection);
+		const std::lock_guard<std::recursive_mutex> lock(loggerMutex);
 
 		std::stringstream message;
 		message << std::fixed << std::setprecision(4);

--- a/src/ZmqLogger.h
+++ b/src/ZmqLogger.h
@@ -14,19 +14,12 @@
 #define OPENSHOT_LOGGER_H
 
 
-#include <iostream>
-#include <iomanip>
 #include <fstream>
-#include <cstdlib>
+#include <memory>
+#include <mutex>
 #include <string>
-#include <sstream>
-#include <cstdio>
-#include <ctime>
-#include <zmq.hpp>
-#include <unistd.h>
-#include <OpenShotAudio.h>
-#include "Settings.h"
 
+#include <zmq.hpp>
 
 namespace openshot {
 
@@ -38,7 +31,7 @@ namespace openshot {
 	 */
 	class ZmqLogger {
 	private:
-		juce::CriticalSection loggerCriticalSection;
+		std::recursive_mutex loggerMutex;
 		std::string connection;
 
 		// Logfile related vars

--- a/src/audio_effects/Compressor.h
+++ b/src/audio_effects/Compressor.h
@@ -1,7 +1,7 @@
 /**
  * @file
  * @brief Header file for Compressor audio effect class
- * @author 
+ * @author
  *
  * @ref License
  */
@@ -13,21 +13,21 @@
 #ifndef OPENSHOT_COMPRESSOR_AUDIO_EFFECT_H
 #define OPENSHOT_COMPRESSOR_AUDIO_EFFECT_H
 
-#include "../EffectBase.h"
+#include "EffectBase.h"
 
-#include "../Frame.h"
-#include "../Json.h"
-#include "../KeyFrame.h"
-#include "../Enums.h"
+#include "Json.h"
+#include "KeyFrame.h"
+#include "Enums.h"
 
 #include <memory>
 #include <string>
-#include <math.h>
 
+#include <AppConfig.h>
+#include <juce_audio_basics/juce_audio_basics.h>
 
 namespace openshot
 {
-
+	class Frame;
 	/**
 	 * @brief This class adds a compressor into the audio
 	 *
@@ -37,7 +37,7 @@ namespace openshot
 	private:
 		/// Init effect settings
 		void init_effect_details();
-		
+
 
 	public:
 		Keyframe threshold;
@@ -47,7 +47,7 @@ namespace openshot
 		Keyframe makeup_gain;
 		Keyframe bypass;
 
-		juce::AudioSampleBuffer mixed_down_input;
+		juce::AudioBuffer<float> mixed_down_input;
 		float xl;
 		float yl;
 		float xg;
@@ -76,8 +76,8 @@ namespace openshot
 		///
 		/// @returns A new openshot::Frame object
 		/// @param frame_number The frame number (starting at 1) of the clip or effect on the timeline.
-		std::shared_ptr<openshot::Frame> GetFrame(int64_t frame_number) override { 
-			return GetFrame(std::make_shared<openshot::Frame>(), frame_number); 
+		std::shared_ptr<openshot::Frame> GetFrame(int64_t frame_number) override {
+			return GetFrame(std::make_shared<openshot::Frame>(), frame_number);
 		}
 
 		/// @brief This method is required for all derived classes of ClipBase, and returns a

--- a/src/audio_effects/Delay.cpp
+++ b/src/audio_effects/Delay.cpp
@@ -1,7 +1,7 @@
 /**
  * @file
  * @brief Source file for Delay audio effect class
- * @author 
+ * @author
  *
  * @ref License
  */
@@ -12,6 +12,7 @@
 
 #include "Delay.h"
 #include "Exceptions.h"
+#include "Frame.h"
 
 using namespace openshot;
 
@@ -84,7 +85,7 @@ std::shared_ptr<openshot::Frame> Delay::GetFrame(std::shared_ptr<openshot::Frame
             float read_position = fmodf((float)local_write_position - delay_time_value + (float)delay_buffer_samples, delay_buffer_samples);
             int local_read_position = floorf(read_position);
 
-            if (local_read_position != local_write_position) 
+            if (local_read_position != local_write_position)
 			{
                 float fraction = read_position - (float)local_read_position;
                 float delayed1 = delay_data[(local_read_position + 0)];

--- a/src/audio_effects/Delay.h
+++ b/src/audio_effects/Delay.h
@@ -1,7 +1,7 @@
 /**
  * @file
  * @brief Header file for Delay audio effect class
- * @author 
+ * @author
  *
  * @ref License
  */
@@ -13,20 +13,20 @@
 #ifndef OPENSHOT_DELAY_AUDIO_EFFECT_H
 #define OPENSHOT_DELAY_AUDIO_EFFECT_H
 
-#include "../EffectBase.h"
+#include "EffectBase.h"
 
-#include "../Frame.h"
-#include "../Json.h"
-#include "../KeyFrame.h"
+#include "Json.h"
+#include "KeyFrame.h"
 
 #include <memory>
 #include <string>
-#include <random>
-#include <math.h>
 
+#include <AppConfig.h>
+#include <juce_audio_basics/juce_audio_basics.h>
 
 namespace openshot
 {
+	class Frame;
 
 	/**
 	 * @brief This class adds a delay into the audio
@@ -39,9 +39,9 @@ namespace openshot
 		void init_effect_details();
 
 	public:
-		Keyframe delay_time;	
+		Keyframe delay_time;
 
-		juce::AudioSampleBuffer delay_buffer;
+		juce::AudioBuffer<float> delay_buffer;
 		int delay_buffer_samples;
 		int delay_buffer_channels;
 		int delay_write_position;
@@ -59,8 +59,8 @@ namespace openshot
 		///
 		/// @returns A new openshot::Frame object
 		/// @param frame_number The frame number (starting at 1) of the clip or effect on the timeline.
-		std::shared_ptr<openshot::Frame> GetFrame(int64_t frame_number) override { 
-			return GetFrame(std::make_shared<openshot::Frame>(), frame_number); 
+		std::shared_ptr<openshot::Frame> GetFrame(int64_t frame_number) override {
+			return GetFrame(std::make_shared<openshot::Frame>(), frame_number);
 		}
 
 		void setup(std::shared_ptr<openshot::Frame> frame);

--- a/src/audio_effects/Distortion.h
+++ b/src/audio_effects/Distortion.h
@@ -1,7 +1,7 @@
 /**
  * @file
  * @brief Header file for Distortion audio effect class
- * @author 
+ * @author
  *
  * @ref License
  */
@@ -14,22 +14,22 @@
 #define OPENSHOT_DISTORTION_AUDIO_EFFECT_H
 #define _USE_MATH_DEFINES
 
-#include "../EffectBase.h"
+#include "EffectBase.h"
 
-#include "../Frame.h"
-#include "../Json.h"
-#include "../KeyFrame.h"
-#include "../Enums.h"
+#include "Json.h"
+#include "KeyFrame.h"
+#include "Enums.h"
 
 #include <memory>
 #include <string>
-#include <math.h>
-// #include <OpenShotAudio.h>
 
+#include <AppConfig.h>
+#include <juce_audio_basics/juce_audio_basics.h>
+#include <juce_dsp/juce_dsp.h>
 
 namespace openshot
 {
-
+	class Frame;
 	/**
 	 * @brief This class adds a distortion into the audio
 	 *
@@ -42,8 +42,8 @@ namespace openshot
 
 	public:
 		openshot::DistortionType distortion_type;
-		Keyframe input_gain;	
-		Keyframe output_gain;	
+		Keyframe input_gain;
+		Keyframe output_gain;
 		Keyframe tone;
 
 		/// Blank constructor, useful when using Json to load the effect properties
@@ -60,8 +60,8 @@ namespace openshot
 		///
 		/// @returns A new openshot::Frame object
 		/// @param frame_number The frame number (starting at 1) of the clip or effect on the timeline.
-		std::shared_ptr<openshot::Frame> GetFrame(int64_t frame_number) override { 
-			return GetFrame(std::make_shared<openshot::Frame>(), frame_number); 
+		std::shared_ptr<openshot::Frame> GetFrame(int64_t frame_number) override {
+			return GetFrame(std::make_shared<openshot::Frame>(), frame_number);
 		}
 
 		/// @brief This method is required for all derived classes of ClipBase, and returns a

--- a/src/audio_effects/Echo.cpp
+++ b/src/audio_effects/Echo.cpp
@@ -1,7 +1,7 @@
 /**
  * @file
  * @brief Source file for Echo audio effect class
- * @author 
+ * @author
  *
  * @ref License
  */
@@ -12,17 +12,13 @@
 
 #include "Echo.h"
 #include "Exceptions.h"
+#include "Frame.h"
 
 using namespace openshot;
 
-/// Blank constructor, useful when using Json to load the effect properties
-Echo::Echo() : echo_time(0.1), feedback(0.5), mix(0.5) {
-	// Init effect properties
-	init_effect_details();
-}
+Echo::Echo() : Echo::Echo(0.1, 0.5, 0.5) { }
 
-// Default constructor
-Echo::Echo(Keyframe new_echo_time, Keyframe new_feedback, Keyframe new_mix) : 
+Echo::Echo(Keyframe new_echo_time, Keyframe new_feedback, Keyframe new_mix) :
 			 echo_time(new_echo_time), feedback(new_feedback), mix(new_mix)
 {
 	// Init effect properties
@@ -87,7 +83,7 @@ std::shared_ptr<openshot::Frame> Echo::GetFrame(std::shared_ptr<openshot::Frame>
             float read_position = fmodf((float)local_write_position - echo_time_value + (float)echo_buffer_samples, echo_buffer_samples);
             int local_read_position = floorf(read_position);
 
-            if (local_read_position != local_write_position) 
+            if (local_read_position != local_write_position)
 			{
                 float fraction = read_position - (float)local_read_position;
                 float echoed1 = echo_data[(local_read_position + 0)];

--- a/src/audio_effects/Echo.h
+++ b/src/audio_effects/Echo.h
@@ -1,7 +1,7 @@
 /**
  * @file
  * @brief Header file for Echo audio effect class
- * @author 
+ * @author
  *
  * @ref License
  */
@@ -13,20 +13,20 @@
 #ifndef OPENSHOT_ECHO_AUDIO_EFFECT_H
 #define OPENSHOT_ECHO_AUDIO_EFFECT_H
 
-#include "../EffectBase.h"
+#include "EffectBase.h"
 
-#include "../Frame.h"
-#include "../Json.h"
-#include "../KeyFrame.h"
+#include "Json.h"
+#include "KeyFrame.h"
 
 #include <memory>
 #include <string>
-#include <random>
-#include <math.h>
 
+#include <AppConfig.h>
+#include <juce_audio_basics/juce_audio_basics.h>
 
 namespace openshot
 {
+	class Frame;
 
 	/**
 	 * @brief This class adds a echo into the audio
@@ -39,11 +39,11 @@ namespace openshot
 		void init_effect_details();
 
 	public:
-		Keyframe echo_time;	
-		Keyframe feedback;	
+		Keyframe echo_time;
+		Keyframe feedback;
 		Keyframe mix;
 
-		juce::AudioSampleBuffer echo_buffer;
+		juce::AudioBuffer<float> echo_buffer;
 		int echo_buffer_samples;
 		int echo_buffer_channels;
 		int echo_write_position;
@@ -61,8 +61,8 @@ namespace openshot
 		///
 		/// @returns A new openshot::Frame object
 		/// @param frame_number The frame number (starting at 1) of the clip or effect on the timeline.
-		std::shared_ptr<openshot::Frame> GetFrame(int64_t frame_number) override { 
-			return GetFrame(std::make_shared<openshot::Frame>(), frame_number); 
+		std::shared_ptr<openshot::Frame> GetFrame(int64_t frame_number) override {
+			return GetFrame(std::make_shared<openshot::Frame>(), frame_number);
 		}
 
 		void setup(std::shared_ptr<openshot::Frame> frame);

--- a/src/audio_effects/Expander.cpp
+++ b/src/audio_effects/Expander.cpp
@@ -1,7 +1,7 @@
 /**
  * @file
  * @brief Source file for Expander audio effect class
- * @author 
+ * @author
  *
  * @ref License
  */
@@ -12,6 +12,7 @@
 
 #include "Expander.h"
 #include "Exceptions.h"
+#include "Frame.h"
 
 using namespace openshot;
 
@@ -22,7 +23,7 @@ Expander::Expander() : threshold(-10), ratio(1), attack(1), release(1), makeup_g
 }
 
 // Default constructor
-Expander::Expander(Keyframe new_threshold, Keyframe new_ratio, Keyframe new_attack, Keyframe new_release, Keyframe new_makeup_gain, Keyframe new_bypass) : 
+Expander::Expander(Keyframe new_threshold, Keyframe new_ratio, Keyframe new_attack, Keyframe new_release, Keyframe new_makeup_gain, Keyframe new_bypass) :
 				   threshold(new_threshold), ratio(new_ratio), attack(new_attack), release(new_release), makeup_gain(new_makeup_gain), bypass(new_bypass)
 {
 	// Init effect properties
@@ -60,7 +61,7 @@ std::shared_ptr<openshot::Frame> Expander::GetFrame(std::shared_ptr<openshot::Fr
     mixed_down_input.setSize(1, num_samples);
 	inverse_sample_rate = 1.0f / frame->SampleRate();
     inverseE = 1.0f / M_E;
-	
+
 	if ((bool)bypass.GetValue(frame_number))
         return frame;
 
@@ -76,12 +77,12 @@ std::shared_ptr<openshot::Frame> Expander::GetFrame(std::shared_ptr<openshot::Fr
         float alphaR = calculateAttackOrRelease(release.GetValue(frame_number));
         float gain = makeup_gain.GetValue(frame_number);
 		float input_squared = powf(mixed_down_input.getSample(0, sample), 2.0f);
-        
+
 		const float average_factor = 0.9999f;
 		input_level = average_factor * input_level + (1.0f - average_factor) * input_squared;
 
         xg = (input_level <= 1e-6f) ? -60.0f : 10.0f * log10f(input_level);
-		
+
 		if (xg > T)
 			yg = xg;
 		else

--- a/src/audio_effects/Expander.h
+++ b/src/audio_effects/Expander.h
@@ -1,7 +1,7 @@
 /**
  * @file
  * @brief Header file for Expander audio effect class
- * @author 
+ * @author
  *
  * @ref License
  */
@@ -13,20 +13,21 @@
 #ifndef OPENSHOT_EXPANDER_AUDIO_EFFECT_H
 #define OPENSHOT_EXPANDER_AUDIO_EFFECT_H
 
-#include "../EffectBase.h"
+#include "EffectBase.h"
 
-#include "../Frame.h"
-#include "../Json.h"
-#include "../KeyFrame.h"
-#include "../Enums.h"
+#include "Json.h"
+#include "KeyFrame.h"
+#include "Enums.h"
 
 #include <memory>
 #include <string>
-#include <math.h>
 
+#include <AppConfig.h>
+#include <juce_audio_basics/juce_audio_basics.h>
 
 namespace openshot
 {
+	class Frame;
 
 	/**
 	 * @brief This class adds a expander (or noise gate) into the audio
@@ -37,7 +38,7 @@ namespace openshot
 	private:
 		/// Init effect settings
 		void init_effect_details();
-		
+
 
 	public:
 		Keyframe threshold;
@@ -47,7 +48,7 @@ namespace openshot
 		Keyframe makeup_gain;
 		Keyframe bypass;
 
-		juce::AudioSampleBuffer mixed_down_input;
+		juce::AudioBuffer<float> mixed_down_input;
 		float xl;
 		float yl;
 		float xg;
@@ -76,8 +77,8 @@ namespace openshot
 		///
 		/// @returns A new openshot::Frame object
 		/// @param frame_number The frame number (starting at 1) of the clip or effect on the timeline.
-		std::shared_ptr<openshot::Frame> GetFrame(int64_t frame_number) override { 
-			return GetFrame(std::make_shared<openshot::Frame>(), frame_number); 
+		std::shared_ptr<openshot::Frame> GetFrame(int64_t frame_number) override {
+			return GetFrame(std::make_shared<openshot::Frame>(), frame_number);
 		}
 
 		/// @brief This method is required for all derived classes of ClipBase, and returns a

--- a/src/audio_effects/Noise.cpp
+++ b/src/audio_effects/Noise.cpp
@@ -1,7 +1,7 @@
 /**
  * @file
  * @brief Source file for Noise audio effect class
- * @author 
+ * @author
  *
  * @ref License
  */
@@ -12,6 +12,10 @@
 
 #include "Noise.h"
 #include "Exceptions.h"
+#include "Frame.h"
+
+#include <AppConfig.h>
+#include <juce_audio_basics/juce_audio_basics.h>
 
 using namespace openshot;
 
@@ -59,7 +63,7 @@ std::shared_ptr<openshot::Frame> Noise::GetFrame(std::shared_ptr<openshot::Frame
 			buffer[sample] = buffer[sample]*(1 - (1+(float)noise)/100) + buffer[sample]*0.0001*(rand()%100+1)*noise;
 		}
 	}
-	
+
 
 	// return the modified frame
 	return frame;

--- a/src/audio_effects/ParametricEQ.cpp
+++ b/src/audio_effects/ParametricEQ.cpp
@@ -14,6 +14,7 @@
 #include "Exceptions.h"
 
 using namespace openshot;
+using namespace juce;
 
 /// Blank constructor, useful when using Json to load the effect properties
 ParametricEQ::ParametricEQ() : filter_type(LOW_PASS), frequency(500), gain(0), q_factor(0) {

--- a/src/audio_effects/ParametricEQ.h
+++ b/src/audio_effects/ParametricEQ.h
@@ -1,7 +1,7 @@
 /**
  * @file
  * @brief Header file for Parametric EQ audio effect class
- * @author 
+ * @author
  *
  * @ref License
  */
@@ -14,21 +14,21 @@
 #define OPENSHOT_PARAMETRIC_EQ_AUDIO_EFFECT_H
 #define _USE_MATH_DEFINES
 
-#include "../EffectBase.h"
+#include "EffectBase.h"
 
-#include "../Frame.h"
-#include "../Json.h"
-#include "../KeyFrame.h"
-#include "../Enums.h"
+#include "Json.h"
+#include "KeyFrame.h"
+#include "Enums.h"
 
 #include <memory>
 #include <string>
-#include <math.h>
-// #include <OpenShotAudio.h>
 
+#include <AppConfig.h>
+#include <juce_audio_basics/juce_audio_basics.h>
 
 namespace openshot
 {
+	class Frame;
 
 	/**
 	 * @brief This class adds a equalization into the audio
@@ -41,8 +41,8 @@ namespace openshot
 		void init_effect_details();
 
 	public:
-		openshot::FilterType filter_type;	
-		Keyframe frequency;	
+		openshot::FilterType filter_type;
+		Keyframe frequency;
 		Keyframe q_factor;
 		Keyframe gain;
 		bool initialized;
@@ -52,7 +52,7 @@ namespace openshot
 
 		/// Default constructor
 		///
-		/// @param new_level 
+		/// @param new_level
 		ParametricEQ(openshot::FilterType new_filter_type, Keyframe new_frequency, Keyframe new_gain, Keyframe new_q_factor);
 
 		/// @brief This method is required for all derived classes of ClipBase, and returns a
@@ -61,8 +61,8 @@ namespace openshot
 		///
 		/// @returns A new openshot::Frame object
 		/// @param frame_number The frame number (starting at 1) of the clip or effect on the timeline.
-		std::shared_ptr<openshot::Frame> GetFrame(int64_t frame_number) override { 
-			return GetFrame(std::make_shared<openshot::Frame>(), frame_number); 
+		std::shared_ptr<openshot::Frame> GetFrame(int64_t frame_number) override {
+			return GetFrame(std::make_shared<openshot::Frame>(), frame_number);
 		}
 
 		/// @brief This method is required for all derived classes of ClipBase, and returns a
@@ -86,7 +86,7 @@ namespace openshot
 		/// of all properties at any time)
 		std::string PropertiesJSON(int64_t requested_frame) const override;
 
-		class Filter : public IIRFilter
+		class Filter : public juce::IIRFilter
 		{
 		public:
 			void updateCoefficients (const double discrete_frequency,

--- a/src/audio_effects/Robotization.cpp
+++ b/src/audio_effects/Robotization.cpp
@@ -1,7 +1,7 @@
 /**
  * @file
  * @brief Source file for Robotization audio effect class
- * @author 
+ * @author
  *
  * @ref License
  */
@@ -12,9 +12,10 @@
 
 #include "Robotization.h"
 #include "Exceptions.h"
+#include "Frame.h"
 
 using namespace openshot;
-
+using namespace juce;
 
 /// Blank constructor, useful when using Json to load the effect properties
 Robotization::Robotization() : fft_size(FFT_SIZE_512), hop_size(HOP_SIZE_2), window_type(RECTANGULAR), stft(*this) {
@@ -23,7 +24,7 @@ Robotization::Robotization() : fft_size(FFT_SIZE_512), hop_size(HOP_SIZE_2), win
 }
 
 // Default constructor
-Robotization::Robotization(openshot::FFTSize new_fft_size, openshot::HopSize new_hop_size, openshot::WindowType new_window_type) : 
+Robotization::Robotization(openshot::FFTSize new_fft_size, openshot::HopSize new_hop_size, openshot::WindowType new_window_type) :
 			 fft_size(new_fft_size), hop_size(new_hop_size), window_type(new_window_type), stft(*this)
 {
 	// Init effect properties
@@ -48,14 +49,14 @@ void Robotization::init_effect_details()
 // modified openshot::Frame object
 std::shared_ptr<openshot::Frame> Robotization::GetFrame(std::shared_ptr<openshot::Frame> frame, int64_t frame_number)
 {
-	const ScopedLock sl (lock);
+	const std::lock_guard<std::recursive_mutex> lock(mutex);
     ScopedNoDenormals noDenormals;
 
     const int num_input_channels = frame->audio->getNumChannels();
     const int num_output_channels = frame->audio->getNumChannels();
     const int num_samples = frame->audio->getNumSamples();
-    const int hop_size_value = 1 << ((int)hop_size + 1); 
-	const int fft_size_value = 1 << ((int)fft_size + 5); 
+    const int hop_size_value = 1 << ((int)hop_size + 1);
+	const int fft_size_value = 1 << ((int)fft_size + 5);
 
     stft.setup(num_output_channels);
     stft.updateParameters((int)fft_size_value,
@@ -157,7 +158,7 @@ std::string Robotization::PropertiesJSON(int64_t requested_frame) const {
 	root["fft_size"]["choices"].append(add_property_choice_json("512", FFT_SIZE_512, fft_size));
 	root["fft_size"]["choices"].append(add_property_choice_json("1024", FFT_SIZE_1024, fft_size));
 	root["fft_size"]["choices"].append(add_property_choice_json("2048", FFT_SIZE_2048, fft_size));
-	
+
 	// Add hop_size choices (dropdown style)
 	root["hop_size"]["choices"].append(add_property_choice_json("1/2", HOP_SIZE_2, hop_size));
 	root["hop_size"]["choices"].append(add_property_choice_json("1/4", HOP_SIZE_4, hop_size));
@@ -168,7 +169,7 @@ std::string Robotization::PropertiesJSON(int64_t requested_frame) const {
 	root["window_type"]["choices"].append(add_property_choice_json("Bart Lett", BART_LETT, window_type));
 	root["window_type"]["choices"].append(add_property_choice_json("Hann", HANN, window_type));
 	root["window_type"]["choices"].append(add_property_choice_json("Hamming", HAMMING, window_type));
-	
+
 	// Return formatted string
 	return root.toStyledString();
 }

--- a/src/audio_effects/Robotization.h
+++ b/src/audio_effects/Robotization.h
@@ -1,7 +1,7 @@
 /**
  * @file
  * @brief Header file for Robotization audio effect class
- * @author 
+ * @author
  *
  * @ref License
  */
@@ -14,22 +14,26 @@
 #define OPENSHOT_ROBOTIZATION_AUDIO_EFFECT_H
 #define _USE_MATH_DEFINES
 
-#include "../EffectBase.h"
+#include <memory>
+#include <mutex>
+#include <string>
 
-#include "../Frame.h"
-#include "../Json.h"
-#include "../KeyFrame.h"
-#include "../Enums.h"
+#include "EffectBase.h"
+
 #include "STFT.h"
 
-#include <memory>
-#include <string>
-#include <math.h>
-#include <cmath>
+#include "Json.h"
+#include "KeyFrame.h"
+#include "Enums.h"
 
-
+namespace juce {
+    namespace dsp {
+        class FFT;
+    }
+}
 namespace openshot
 {
+	class Frame;
 
 	/**
 	 * @brief This class adds a robotization effect into the audio
@@ -60,8 +64,8 @@ namespace openshot
 		///
 		/// @returns A new openshot::Frame object
 		/// @param frame_number The frame number (starting at 1) of the clip or effect on the timeline.
-		std::shared_ptr<openshot::Frame> GetFrame(int64_t frame_number) override { 
-			return GetFrame(std::make_shared<openshot::Frame>(), frame_number); 
+		std::shared_ptr<openshot::Frame> GetFrame(int64_t frame_number) override {
+			return GetFrame(std::make_shared<openshot::Frame>(), frame_number);
 		}
 
 		/// @brief This method is required for all derived classes of ClipBase, and returns a
@@ -97,11 +101,11 @@ namespace openshot
 			Robotization &parent;
 		};
 
-		juce::CriticalSection lock;
+		std::recursive_mutex mutex;
     	RobotizationEffect stft;
 		std::unique_ptr<juce::dsp::FFT> fft;
 	};
 
-}
+}  // namespace
 
-#endif
+#endif  // OPENSHOT_ROBOTIZATION_AUDIO_EFFECT_H

--- a/src/audio_effects/STFT.cpp
+++ b/src/audio_effects/STFT.cpp
@@ -18,7 +18,7 @@ void STFT::updateParameters(const int new_fft_size, const int new_overlap, const
     updateWindow(new_window_type);
 }
 
-void STFT::process(juce::AudioSampleBuffer &block)
+void STFT::process(juce::AudioBuffer<float> &block)
 {
     num_samples = block.getNumSamples();
 

--- a/src/audio_effects/STFT.h
+++ b/src/audio_effects/STFT.h
@@ -8,8 +8,12 @@
 #define OPENSHOT_STFT_AUDIO_EFFECT_H
 #define _USE_MATH_DEFINES
 
-#include "../EffectBase.h"
-#include "../Enums.h"
+#include "EffectBase.h"
+#include "Enums.h"
+
+#include <AppConfig.h>
+#include <juce_audio_basics/juce_audio_basics.h>
+#include <juce_dsp/juce_dsp.h>
 
 namespace openshot
 {
@@ -18,23 +22,23 @@ namespace openshot
     {
     public:
         STFT() : num_channels (1) { }
-        
+
         virtual ~STFT() { }
 
         void setup(const int num_input_channels);
 
-        void process(juce::AudioSampleBuffer &block);
+        void process(juce::AudioBuffer<float> &block);
 
         void updateParameters(const int new_fft_size, const int new_overlap, const int new_window_type);
 
         virtual void updateFftSize(const int new_fft_size);
-  
+
         virtual void updateHopSize(const int new_overlap);
 
         virtual void updateWindow(const int new_window_type);
-    
+
     private:
- 
+
         virtual void modification(const int channel);
 
         virtual void analysis(const int channel);
@@ -49,10 +53,10 @@ namespace openshot
         std::unique_ptr<juce::dsp::FFT> fft;
 
         int input_buffer_length;
-        juce::AudioSampleBuffer input_buffer;
+        juce::AudioBuffer<float> input_buffer;
 
         int output_buffer_length;
-        juce::AudioSampleBuffer output_buffer;
+        juce::AudioBuffer<float> output_buffer;
 
         juce::HeapBlock<float> fft_window;
         juce::HeapBlock<juce::dsp::Complex<float>> time_domain_buffer;

--- a/src/audio_effects/Whisperization.h
+++ b/src/audio_effects/Whisperization.h
@@ -1,7 +1,7 @@
 /**
  * @file
  * @brief Header file for whisperization audio effect class
- * @author 
+ * @author
  *
  * @ref License
  */
@@ -14,23 +14,26 @@
 #define OPENSHOT_WHISPERIZATION_AUDIO_EFFECT_H
 #define _USE_MATH_DEFINES
 
+#include <memory>
+#include <mutex>
+#include <string>
+
 #include "../EffectBase.h"
 
-#include "../Frame.h"
 #include "../Json.h"
 #include "../KeyFrame.h"
 #include "../Enums.h"
 #include "STFT.h"
 
-#include <memory>
-#include <string>
-#include <math.h>
-#include <cmath>
-
+namespace juce {
+    namespace dsp {
+        class FFT;
+    }
+}
 
 namespace openshot
 {
-
+    class Frame;
 	/**
 	 * @brief This class adds a whisperization effect into the audio
 	 *
@@ -60,8 +63,8 @@ namespace openshot
 		///
 		/// @returns A new openshot::Frame object
 		/// @param frame_number The frame number (starting at 1) of the clip or effect on the timeline.
-		std::shared_ptr<openshot::Frame> GetFrame(int64_t frame_number) override { 
-			return GetFrame(std::make_shared<openshot::Frame>(), frame_number); 
+		std::shared_ptr<openshot::Frame> GetFrame(int64_t frame_number) override {
+			return GetFrame(std::make_shared<openshot::Frame>(), frame_number);
 		}
 
 		/// @brief This method is required for all derived classes of ClipBase, and returns a
@@ -97,7 +100,7 @@ namespace openshot
 			Whisperization &parent;
 		};
 
-		juce::CriticalSection lock;
+		std::recursive_mutex mutex;
     	WhisperizationEffect stft;
 		std::unique_ptr<juce::dsp::FFT> fft;
 	};

--- a/src/effects/ChromaKey.cpp
+++ b/src/effects/ChromaKey.cpp
@@ -17,6 +17,7 @@
 #include <babl/babl.h>
 #endif
 #include <vector>
+#include <cmath>
 
 using namespace openshot;
 
@@ -390,12 +391,12 @@ std::shared_ptr<openshot::Frame> ChromaKey::GetFrame(std::shared_ptr<openshot::F
 					float KL = 1.0;
 					float KC = 1.0;
 					float KH = 1.0;
-					float pi = 4 * atan(1);
+					float pi = 4 * std::atan(1);
 
 					float L1 = ((float) mask.u[0]) / 2.55;
 					float a1 = mask.u[1] - 127;
 					float b1 = mask.u[2] - 127;
-					float C1 = sqrt(a1 * a1 + b1 * b1);
+					float C1 = std::sqrt(a1 * a1 + b1 * b1);
 
 					for (int y = 0; y < height; ++y)
 					{
@@ -406,23 +407,23 @@ std::shared_ptr<openshot::Frame> ChromaKey::GetFrame(std::shared_ptr<openshot::F
 							float L2 = ((float) pc[0]) / 2.55;
 							int   a2 = pc[1] - 127;
 							int   b2 = pc[2] - 127;
-							float C2 = sqrt(a2 * a2 + b2 * b2);
+							float C2 = std::sqrt(a2 * a2 + b2 * b2);
 
 							float delta_L_prime = L2 - L1;
 							float L_bar = (L1 + L2) / 2;
 							float C_bar = (C1 + C2) / 2;
 
-							float a_prime_multiplier = 1 + 0.5 * (1 - sqrt(C_bar / (C_bar + 25)));
+							float a_prime_multiplier = 1 + 0.5 * (1 - std::sqrt(C_bar / (C_bar + 25)));
 							float a1_prime = a1 * a_prime_multiplier;
 							float a2_prime = a2 * a_prime_multiplier;
 
-							float C1_prime = sqrt(a1_prime * a1_prime + b1 * b1);
-							float C2_prime = sqrt(a2_prime * a2_prime + b2 * b2);
+							float C1_prime = std::sqrt(a1_prime * a1_prime + b1 * b1);
+							float C2_prime = std::sqrt(a2_prime * a2_prime + b2 * b2);
 							float C_prime_bar = (C1_prime + C2_prime) / 2;
 							float delta_C_prime = C2_prime - C1_prime;
 
-							float h1_prime = atan2(b1, a1_prime) * 180 / pi;
-							float h2_prime = atan2(b2, a2_prime) * 180 / pi;
+							float h1_prime = std::atan2(b1, a1_prime) * 180 / pi;
+							float h2_prime = std::atan2(b2, a2_prime) * 180 / pi;
 
 							float delta_h_prime = h2_prime - h1_prime;
 							double H_prime_bar = (C1_prime != 0 && C2_prime != 0) ? (h1_prime + h2_prime) / 2 : (h1_prime + h2_prime);
@@ -444,21 +445,21 @@ std::shared_ptr<openshot::Frame> ChromaKey::GetFrame(std::shared_ptr<openshot::F
 									H_prime_bar -= 180;
 							}
 
-							float delta_H_prime = 2 * sqrt(C1_prime * C2_prime) * sin(delta_h_prime * pi / 360);
+							float delta_H_prime = 2 * std::sqrt(C1_prime * C2_prime) * std::sin(delta_h_prime * pi / 360);
 
 							float T = 1
-								- 0.17 * cos((H_prime_bar - 30) * pi / 180)
-								+ 0.24 * cos(H_prime_bar * pi / 90)
-								+ 0.32 * cos((3 * H_prime_bar + 6) * pi / 180)
-								- 0.20 * cos((4 * H_prime_bar - 64) * pi / 180);
+								- 0.17 * std::cos((H_prime_bar - 30) * pi / 180)
+								+ 0.24 * std::cos(H_prime_bar * pi / 90)
+								+ 0.32 * std::cos((3 * H_prime_bar + 6) * pi / 180)
+								- 0.20 * std::cos((4 * H_prime_bar - 64) * pi / 180);
 
-							float SL = 1 + 0.015 * square(L_bar - 50) / sqrt(20 + square(L_bar - 50));
+							float SL = 1 + 0.015 * std::pow(L_bar - 50, 2) / std::sqrt(20 + std::pow(L_bar - 50, 2));
 							float SC = 1 + 0.045 * C_prime_bar;
 							float SH = 1 + 0.015 * C_prime_bar * T;
-							float RT = -2 * sqrt(C_prime_bar / (C_prime_bar + 25)) * sin(pi / 3 * exp(-square((H_prime_bar - 275) / 25)));
-							float delta_E = sqrt(square(delta_L_prime / KL / SL)
-										+ square(delta_C_prime / KC / SC)
-										+ square(delta_h_prime / KH / SH)
+							float RT = -2 * std::sqrt(C_prime_bar / (C_prime_bar + 25)) * std::sin(pi / 3 * std::exp(-std::pow((H_prime_bar - 275) / 25, 2)));
+							float delta_E = std::sqrt(std::pow(delta_L_prime / KL / SL, 2)
+										+ std::pow(delta_C_prime / KC / SC, 2)
+										+ std::pow(delta_h_prime / KH / SH, 2)
 										+ RT * delta_C_prime / KC / SC * delta_H_prime / KH / SH);
 							if (delta_E <= threshold)
 							{

--- a/src/effects/Mask.cpp
+++ b/src/effects/Mask.cpp
@@ -11,12 +11,17 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
 #include "Mask.h"
+
 #include "Exceptions.h"
+
+#include "ReaderBase.h"
+#include "ChunkReader.h"
 #include "FFmpegReader.h"
+#include "QtImageReader.h"
+
 #ifdef USE_IMAGEMAGICK
 	#include "ImageReader.h"
 #endif
-#include "ReaderBase.h"
 
 using namespace openshot;
 

--- a/src/effects/ObjectDetection.h
+++ b/src/effects/ObjectDetection.h
@@ -18,7 +18,7 @@
 
 #include <memory>
 
-#include <opencv2/opencv.hpp>
+#include "OpenCVUtilities.h"
 
 #include "Json.h"
 #include "KeyFrame.h"

--- a/tests/CVTracker.cpp
+++ b/tests/CVTracker.cpp
@@ -19,6 +19,7 @@
 #include "Clip.h"
 #include "CVTracker.h"  // for FrameData, CVTracker
 #include "ProcessingController.h"
+#include "Exceptions.h"
 
 using namespace openshot;
 

--- a/tests/Clip.cpp
+++ b/tests/Clip.cpp
@@ -21,10 +21,12 @@
 
 #include "Clip.h"
 #include "Enums.h"
+#include "Exceptions.h"
 #include "Frame.h"
 #include "Fraction.h"
 #include "Timeline.h"
 #include "Json.h"
+#include "effects/Negate.h"
 
 using namespace openshot;
 

--- a/tests/FrameMapper.cpp
+++ b/tests/FrameMapper.cpp
@@ -15,6 +15,7 @@
 #include "CacheMemory.h"
 #include "Clip.h"
 #include "DummyReader.h"
+#include "Exceptions.h"
 #include "FFmpegReader.h"
 #include "Fraction.h"
 #include "Frame.h"

--- a/tests/KeyFrame.cpp
+++ b/tests/KeyFrame.cpp
@@ -16,16 +16,18 @@
 #include <memory>
 
 #include "KeyFrame.h"
-#include "Exceptions.h"
 #include "Coordinate.h"
-#include "Fraction.h"
 #include "Clip.h"
+#include "Exceptions.h"
+#include "FFmpegReader.h"
+#include "Fraction.h"
+#include "Point.h"
 #include "Timeline.h"
+
 #ifdef USE_OPENCV
 #include "effects/Tracker.h"
 #include "TrackedObjectBBox.h"
 #endif
-#include "Point.h"
 
 using namespace openshot;
 

--- a/tests/QtImageReader.cpp
+++ b/tests/QtImageReader.cpp
@@ -15,8 +15,9 @@
 #include <QGuiApplication>
 
 #include "QtImageReader.h"
-#include "Frame.h"
 #include "Clip.h"
+#include "Exceptions.h"
+#include "Frame.h"
 #include "Timeline.h"
 
 using namespace openshot;


### PR DESCRIPTION
This PR makes changes to the way libopenshot uses JUCE that prepare the codebase for the forthcoming upgrade to JUCE 6.1.2. Many of these are not strictly _necessary_, but they eliminate long-standing bad/outdated practices and/or inefficiencies that have become ingrained in how we use the various JUCE modules.

### Major changes

1. Replace all references to `juce::AudioSampleBuffer` with `juce::AudioBuffer<float>`. `juce::AudioSampleBuffer` has been a legacy typedef for `AudioBuffer<float>` for several years now.
2. Eliminate all use of `juce::CriticalSection` and `juce::GenericScopedLock`, replacing all `CriticalSections` with `std::recursive_mutex` and locking in the standard fashion (using `std::lock_guard`). Unlike `std::mutex` (which becomes a deadlock factory if it's used the way we use `CriticalSection`), `std::recursive_mutex` is explicitly designed (as was `CriticalSection`) to support multiple locks from the same thread  when code that uses it calls other code that uses it. Jules has even mentioned at times that he's considered deprecating `CriticalSection` in favor of `std::recursive_mutex` now that the latter exists, as they have identical semantics. 
    The primary benefit of this change is that it allows us to remove uses of the JUCE headers in classes that have no business including them, like `ZmqLogger`. The only reason `#include <OpenShotAudio.h>` appeared in `ZmqLogger.cpp` was for `juce::CriticalSection`, now it's been replaced with a much lighter-weight `#include <mutex>`.
3. Speaking of `OpenShotAudio.h`, all uses of `#include <OpenShotAudio.h>` have been eliminated from the code. Now, code that makes use of e.g. `juce::AudioBuffer<float>` will instead do the following:
    ```c++
    #include <AppConfig.h>
    #include <juce_audio_basics/juce_audio_basics.h>
    ```
    This avoids pulling in the _entirety_ of JUCE into every class that needs even just a simple audio buffer.
4. Class declarations that only make use of JUCE classes via pointers have further had the includes replaced with forward declarations, to lighten the compilation weight of those headers. (The same has also been increasingly done for `openshot::` classes as well, where appropriate. A _lot_ of `#include "Frame.h"` in headers is now `namespace openshot { class Frame; }`, for a significant reduction in header size and complexity.)

### Compilation time savings
Taken all together, the changes in this PR — even compiling with JUCE 5.4.7 — had a consistent impact on my local machine's runtime for the command `time cmake --build build_noccache --target pyopenshot` (from a cold `cmake -B build_noccache -S .`, into a formerly-empty directory and with `ccache` disabled). 

| branch          | CPU cycles                              | total runtime      |  speedup   |
|-----------------|---------------------------------------|----------------------|---------------|
| develop        | `641.65s user`<br/>`21.18s system` | `11:14.93 total` |                   |
| pre-juce612 | `437.21s user`<br/>`11.17s system` | `7:32.07 total`    | **33%**     |

### Other changes

In addition to the preceding, this PR contains (as separate commits):
1. An un-indenting of the entire `Enums.h` header by one level, to avoid wasting an indent on the namespace.
2. A fix for the new `ChromaKey.cpp` code so that it uses `std::`-prefixed `<cmath>` classes for math functions like `std::sin`, `std::cos`, `std::sqrt`, etc. 
     Turns out, the existing code was accidentally making use of the JUCE math functions. (Most obviously `juce::square()`, which has no corresponding STL version. The closest equivalent is `std::pow()`, which takes two arguments.) With the header changes, ChromaKey's namespace is no longer polluted with the JUCE classes,