### PR TITLE
Revert "fix cmake instructions using '-d' argument in MacOs"

### DIFF
--- a/doc/INSTALL-MAC.md
+++ b/doc/INSTALL-MAC.md
@@ -158,25 +158,24 @@ brew install babl
 Since libopenshot-audio is not available in a Homebrew or MacPorts package, we need to go through a 
 few additional steps to manually build and install it. Launch a terminal and enter:
 
-```zsh
+```
 cd [libopenshot-audio repo folder]
 mkdir build
 cd build
-# (CLang must be used due to GNU incompatible Objective-C code in some of the Apple frameworks)
-cmake --debug-output -G "Unix Makefiles" -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang ../
+cmake -d -G "Unix Makefiles" -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang ../   (CLang must be used due to GNU incompatible Objective-C code in some of the Apple frameworks)
 make
 make install
-./src/openshot-audio-demo  (This should play a test sound)
+./src/openshot-audio-test-sound  (This should play a test sound)
 ```
 
 ## Mac Build Instructions (libopenshot)
 Run the following commands to build libopenshot:
 
-```zsh
-cd [libopenshot repo folder]
-mkdir build
-cd build
-cmake -G "Unix Makefiles" -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang -DCMAKE_PREFIX_PATH="$(brew --cellar qt5)/<version>" -DPython_FRAMEWORKS="$(brew --cellar python3)/<version>/Frameworks/Python.framework/" ../ -D"CMAKE_BUILD_TYPE:STRING=Debug"
+```
+$ cd [libopenshot repo folder]
+$ mkdir build
+$ cd build
+$ cmake -G "Unix Makefiles"  -DCMAKE_CXX_COMPILER=/usr/local/opt/gcc48/bin/g++-4.8 -DCMAKE_C_COMPILER=/usr/local/opt/gcc48/bin/gcc-4.8 -DCMAKE_PREFIX_PATH=/usr/local/Cellar/qt5/5.4.2/ -DPYTHON_INCLUDE_DIR=/usr/local/Cellar/python3/3.3.2/Frameworks/Python.framework/Versions/3.3/include/python3.3m/ -DPYTHON_LIBRARY=/usr/local/Cellar/python3/3.3.2/Frameworks/Python.framework/Versions/3.3/lib/libpython3.3.dylib -DPython_FRAMEWORKS=/usr/local/Cellar/python3/3.3.2/Frameworks/Python.framework/ ../ -D"CMAKE_BUILD_TYPE:STRING=Debug"
 ```
 
 The extra arguments on the cmake command make sure the compiler will be gcc4.8 and that cmake 


### PR DESCRIPTION
Reverts OpenShot/libopenshot#673

The following error was generated on our Linux build server:
```
$ make doc
/snap/cmake/955/bin/cmake -S/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot -B/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/build --check-build-system CMakeFiles/Makefile.cmake 0
make  -f CMakeFiles/Makefile2 doc
make[1]: Entering directory '/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/build'
/snap/cmake/955/bin/cmake -S/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot -B/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/build --check-build-system CMakeFiles/Makefile.cmake 0
/snap/cmake/955/bin/cmake -E cmake_progress_start /home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/build/CMakeFiles 1
make  -f CMakeFiles/Makefile2 CMakeFiles/doc.dir/all
make[2]: Entering directory '/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/build'
make  -f CMakeFiles/libopenshot-doc.dir/build.make CMakeFiles/libopenshot-doc.dir/depend
make[3]: Entering directory '/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/build'
cd /home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/build && /snap/cmake/955/bin/cmake -E cmake_depends "Unix Makefiles" /home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot /home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot /home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/build /home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/build /home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/build/CMakeFiles/libopenshot-doc.dir/DependInfo.cmake --color=
make[3]: Leaving directory '/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/build'
make  -f CMakeFiles/libopenshot-doc.dir/build.make CMakeFiles/libopenshot-doc.dir/build
make[3]: Entering directory '/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/build'
[100%] Generate libopenshot documentation
/snap/cmake/955/bin/cmake -E make_directory /home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/build/docs
/usr/bin/doxygen /home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/build/Doxyfile.libopenshot-doc
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/Exceptions.h:368: warning: Found ';' while parsing initializer list! (doxygen could be confused by a macro call without semicolon)
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/effects/Pixelate.cpp:54: warning: no uniquely matching class member found for 
  std::shared_ptr< Frame > Pixelate::GetFrame(std::shared_ptr< openshot::Frame > frame, int64_t frame_number)
Possible candidates:
  std::shared_ptr< openshot::Frame > openshot::Pixelate::GetFrame(int64_t frame_number) override' at line 66 of file /home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/effects/Pixelate.h
  std::shared_ptr< openshot::Frame > openshot::Pixelate::GetFrame(std::shared_ptr< openshot::Frame > frame, int64_t frame_number) override' at line 77 of file /home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/effects/Pixelate.h

/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/build/src/OpenShotVersion.h:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/audio_effects/Compressor.cpp:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/audio_effects/Compressor.h:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/audio_effects/Delay.cpp:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/audio_effects/Delay.h:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/audio_effects/Distortion.cpp:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/audio_effects/Distortion.h:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/audio_effects/Echo.cpp:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/audio_effects/Echo.h:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/audio_effects/Expander.cpp:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/audio_effects/Expander.h:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/audio_effects/Noise.cpp:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/audio_effects/Noise.h:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/audio_effects/ParametricEQ.cpp:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/audio_effects/ParametricEQ.h:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/audio_effects/Robotization.cpp:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/audio_effects/Robotization.h:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/audio_effects/Whisperization.cpp:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/audio_effects/Whisperization.h:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/AudioBufferSource.cpp:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/AudioBufferSource.h:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/AudioDeviceInfo.h:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/AudioReaderSource.cpp:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/AudioReaderSource.h:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/AudioResampler.cpp:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/AudioResampler.h:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/CacheBase.cpp:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/CacheBase.h:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/CacheDisk.cpp:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/CacheDisk.h:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/CacheMemory.cpp:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/CacheMemory.h:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/ChannelLayouts.h:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/ChunkReader.cpp:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/ChunkReader.h:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/ChunkWriter.cpp:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/ChunkWriter.h:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/Clip.cpp:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/Clip.h:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/ClipBase.cpp:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/ClipBase.h:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/ClipProcessingJobs.cpp:6: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/ClipProcessingJobs.h:6: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/Color.cpp:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/Color.h:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/Coordinate.cpp:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/Coordinate.h:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/CrashHandler.cpp:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/CrashHandler.h:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/CVObjectDetection.cpp:6: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/CVObjectDetection.h:6: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/CVStabilization.cpp:6: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/CVStabilization.h:6: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/CVTracker.cpp:6: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/CVTracker.h:6: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/DummyReader.cpp:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/DummyReader.h:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/EffectBase.cpp:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/EffectBase.h:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/EffectInfo.cpp:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/EffectInfo.h:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/effects/Bars.cpp:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/effects/Bars.h:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/effects/Blur.cpp:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/effects/Blur.h:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/effects/Brightness.cpp:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/effects/Brightness.h:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/effects/Caption.cpp:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/effects/Caption.h:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/effects/ChromaKey.cpp:6: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/effects/ChromaKey.h:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/effects/ColorShift.cpp:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/effects/ColorShift.h:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/effects/Crop.cpp:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/effects/Crop.h:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/effects/Deinterlace.cpp:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/effects/Deinterlace.h:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/effects/Hue.cpp:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/effects/Hue.h:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/effects/Mask.cpp:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/effects/Mask.h:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/effects/Negate.cpp:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/effects/Negate.h:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/effects/ObjectDetection.cpp:6: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/effects/ObjectDetection.h:6: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/effects/Pixelate.cpp:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/effects/Pixelate.h:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/effects/Saturation.cpp:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/effects/Saturation.h:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/effects/Shift.cpp:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/effects/Shift.h:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/effects/Stabilizer.cpp:6: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/effects/Stabilizer.h:6: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/effects/Tracker.cpp:6: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/effects/Tracker.h:6: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/effects/Wave.cpp:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/effects/Wave.h:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/Enums.h:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/Exceptions.h:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/FFmpegReader.cpp:8: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/FFmpegReader.h:8: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/FFmpegUtilities.h:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/FFmpegWriter.cpp:8: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/FFmpegWriter.h:8: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/Fraction.cpp:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/Fraction.h:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/Frame.cpp:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/Frame.h:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/FrameMapper.cpp:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/FrameMapper.h:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/ImageReader.cpp:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/ImageReader.h:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/ImageWriter.cpp:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/ImageWriter.h:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/Json.cpp:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/Json.h:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/KeyFrame.cpp:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/KeyFrame.h:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/OpenCVUtilities.h:6: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/OpenMPUtilities.h:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/OpenShotVersion.cpp:6: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/PlayerBase.cpp:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/PlayerBase.h:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/Point.cpp:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/Point.h:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/ProcessingController.h:6: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/Profiles.cpp:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/Profiles.h:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/Qt/AudioPlaybackThread.cpp:6: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/Qt/AudioPlaybackThread.h:6: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/Qt/PlayerDemo.cpp:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/Qt/PlayerDemo.h:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/Qt/PlayerPrivate.cpp:6: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/Qt/PlayerPrivate.h:6: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/Qt/VideoCacheThread.cpp:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/Qt/VideoCacheThread.h:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/Qt/VideoPlaybackThread.cpp:6: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/Qt/VideoPlaybackThread.h:6: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/Qt/VideoRenderer.cpp:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/Qt/VideoRenderer.h:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/Qt/VideoRenderWidget.cpp:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/Qt/VideoRenderWidget.h:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/QtHtmlReader.cpp:7: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/QtHtmlReader.h:7: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/QtImageReader.cpp:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/QtImageReader.h:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/QtPlayer.cpp:6: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/QtPlayer.h:6: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/QtTextReader.cpp:7: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/QtTextReader.h:7: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/ReaderBase.cpp:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/ReaderBase.h:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/RendererBase.cpp:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/RendererBase.h:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/Settings.cpp:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/Settings.h:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/TextReader.cpp:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/TextReader.h:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/Timeline.cpp:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/Timeline.h:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/TimelineBase.cpp:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/TimelineBase.h:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/TrackedObjectBase.cpp:6: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/TrackedObjectBase.h:6: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/TrackedObjectBBox.cpp:6: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/TrackedObjectBBox.h:6: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/WriterBase.cpp:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/WriterBase.h:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/ZmqLogger.cpp:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/ZmqLogger.h:5: warning: unable to resolve reference to `License' for \ref command
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/audio_effects/Compressor.h:66: warning: argument 'new_level' of command @param is not found in the argument list of openshot::Compressor::Compressor(Keyframe new_threshold, Keyframe new_ratio, Keyframe new_attack, Keyframe new_release, Keyframe new_makeup_gain, Keyframe new_bypass)
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/audio_effects/Compressor.h:69: warning: The following parameters of openshot::Compressor::Compressor(Keyframe new_threshold, Keyframe new_ratio, Keyframe new_attack, Keyframe new_release, Keyframe new_makeup_gain, Keyframe new_bypass) are not documented:
  parameter 'new_threshold'
  parameter 'new_ratio'
  parameter 'new_attack'
  parameter 'new_release'
  parameter 'new_makeup_gain'
  parameter 'new_bypass'
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/audio_effects/Distortion.h:52: warning: argument 'new_level' of command @param is not found in the argument list of openshot::Distortion::Distortion(openshot::DistortionType new_distortion_type, Keyframe new_input_gain, Keyframe new_output_gain, Keyframe new_tone)
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/audio_effects/Distortion.h:55: warning: The following parameters of openshot::Distortion::Distortion(openshot::DistortionType new_distortion_type, Keyframe new_input_gain, Keyframe new_output_gain, Keyframe new_tone) are not documented:
  parameter 'new_distortion_type'
  parameter 'new_input_gain'
  parameter 'new_output_gain'
  parameter 'new_tone'
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/audio_effects/Expander.h:67: warning: argument 'new_level' of command @param is not found in the argument list of openshot::Expander::Expander(Keyframe new_threshold, Keyframe new_ratio, Keyframe new_attack, Keyframe new_release, Keyframe new_makeup_gain, Keyframe new_bypass)
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/audio_effects/Expander.h:70: warning: The following parameters of openshot::Expander::Expander(Keyframe new_threshold, Keyframe new_ratio, Keyframe new_attack, Keyframe new_release, Keyframe new_makeup_gain, Keyframe new_bypass) are not documented:
  parameter 'new_threshold'
  parameter 'new_ratio'
  parameter 'new_attack'
  parameter 'new_release'
  parameter 'new_makeup_gain'
  parameter 'new_bypass'
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/audio_effects/ParametricEQ.h:53: warning: argument 'new_level' of command @param is not found in the argument list of openshot::ParametricEQ::ParametricEQ(openshot::FilterType new_filter_type, Keyframe new_frequency, Keyframe new_gain, Keyframe new_q_factor)
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/audio_effects/ParametricEQ.h:56: warning: The following parameters of openshot::ParametricEQ::ParametricEQ(openshot::FilterType new_filter_type, Keyframe new_frequency, Keyframe new_gain, Keyframe new_q_factor) are not documented:
  parameter 'new_filter_type'
  parameter 'new_frequency'
  parameter 'new_gain'
  parameter 'new_q_factor'
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/audio_effects/Robotization.h:56: warning: argument 'new_level' of command @param is not found in the argument list of openshot::Robotization::Robotization(openshot::FFTSize new_fft_size, openshot::HopSize new_hop_size, openshot::WindowType new_window_type)
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/audio_effects/Robotization.h:59: warning: The following parameters of openshot::Robotization::Robotization(openshot::FFTSize new_fft_size, openshot::HopSize new_hop_size, openshot::WindowType new_window_type) are not documented:
  parameter 'new_fft_size'
  parameter 'new_hop_size'
  parameter 'new_window_type'
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/audio_effects/Whisperization.h:55: warning: argument 'new_level' of command @param is not found in the argument list of openshot::Whisperization::Whisperization(openshot::FFTSize new_fft_size, openshot::HopSize new_hop_size, openshot::WindowType new_window_type)
/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/src/audio_effects/Whisperization.h:58: warning: The following parameters of openshot::Whisperization::Whisperization(openshot::FFTSize new_fft_size, openshot::HopSize new_hop_size, openshot::WindowType new_window_type) are not documented:
  parameter 'new_fft_size'
  parameter 'new_hop_size'
  parameter 'new_window_type'
make[3]: Leaving directory '/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/build'
[100%] Built target libopenshot-doc
make  -f CMakeFiles/doc.dir/build.make CMakeFiles/doc.dir/depend
make[3]: Entering directory '/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/build'
cd /home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/build && /snap/cmake/955/bin/cmake -E cmake_depends "Unix Makefiles" /home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot /home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot /home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/build /home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/build /home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/build/CMakeFiles/doc.dir/DependInfo.cmake --color=
make[3]: Leaving directory '/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/build'
make  -f CMakeFiles/doc.dir/build.make CMakeFiles/doc.dir/build
make[3]: Entering directory '/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/build'
make[3]: Nothing to be done for 'CMakeFiles/doc.dir/build'.
make[3]: Leaving directory '/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/build'
[100%] Built target doc
make[2]: Leaving directory '/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/build'
/snap/cmake/955/bin/cmake -E cmake_progress_start /home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/build/CMakeFiles 0
make[1]: Leaving directory '/home/gitlab-runner/builds/d0022447/0/OpenShot/libopenshot/build'
```