### PR TITLE
Disable FFmpeg hwaccel when APPIMAGE_BUILD is set

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -359,7 +359,10 @@ add_feature_info("FFmpeg ${resample_lib}" TRUE "Audio resampling uses ${resample
 set(FFMPEG_USE_SWRESAMPLE ${USE_SW} CACHE BOOL "libswresample used for audio resampling" FORCE)
 mark_as_advanced(FFMPEG_USE_SWRESAMPLE)
 
-# Version check for hardware-acceleration code
+# Version check / enablement for hardware-acceleration code
+if(APPIMAGE_BUILD)
+  set(USE_HW_ACCEL FALSE)
+endif()
 if(USE_HW_ACCEL AND FFmpeg_avcodec_VERSION)
   if(${FFmpeg_avcodec_VERSION} VERSION_GREATER "57.106")
     set(HAVE_HW_ACCEL TRUE)


### PR DESCRIPTION
As discussed in OpenShot/openshot-qt#4538, the hwaccel code in FFmpegReader/Writer should be completely disabled, when building for the Linux AppImages. This PR respects the CMake option 'APPIMAGE_BUILD', which we are already setting in the project server builds, and defines the symbol `USE_HW_ACCEL=0` for the build. The `#ifdef`s around the hwaccel code will cause it to be omitted from the compiled classes entirely.

Fixes OpenShot/openshot-qt#4538