### PR TITLE
Resolve a build failure for missing <memory> include

### DIFF
--- a/src/WriterBase.cpp
+++ b/src/WriterBase.cpp
@@ -12,6 +12,7 @@
 
 #include <iostream>
 #include <iomanip>
+#include <memory>
 
 #include "WriterBase.h"
 #include "Exceptions.h"


### PR DESCRIPTION
Resolve a build failure for missing <memory> include. This is needed for `shared_ptr` to build on certain compilers. My local system was failing to build (including our Cloud API template servers).  No idea why this doesn't fail on our GitLab or GitHub builders though... so I'm assuming this is somehow related to the version of our compilers.

```
error: 'shared_ptr' was not declared in this scope
```