### PR TITLE
Simplify frame timing corrections

### DIFF
--- a/src/Qt/PlayerPrivate.cpp
+++ b/src/Qt/PlayerPrivate.cpp
@@ -105,6 +105,9 @@ namespace openshot
             const auto render_time = double_micro_sec(time2-time1);
             const auto sleep_time = duration_cast<micro_sec>(frame_duration - render_time) + (correction);
 
+            // Debug
+            ZmqLogger::Instance()->AppendDebugMethod("PlayerPrivate::run (determine sleep)", "video_frame_diff", video_frame_diff, "video_position", video_position, "audio_position", audio_position, "speed", speed, "render_time(ms)", render_time.count(), "sleep_time(ms)", sleep_time.count());
+
             if (sleep_time.count() > 0) {
                 if (sleep_time > max_sleep ) {
                     std::this_thread::sleep_for(max_sleep);

--- a/src/Qt/PlayerPrivate.cpp
+++ b/src/Qt/PlayerPrivate.cpp
@@ -109,15 +109,14 @@ namespace openshot
             const auto render_time = double_micro_sec(time2 - time1);
 
             // Calculate the amount of time to sleep (by subtracting the render time)
-//            auto sleep_time = duration_cast<micro_sec>( (frame_duration - render_time));
-            auto correction_factor = video_frame_diff * video_frame_diff * video_frame_diff * video_frame_diff * video_frame_diff;
-//            auto sleep_time_no_correction = duration_cast<micro_sec>((frame_duration - render_time));
+            auto correction_factor = video_frame_diff * video_frame_diff * video_frame_diff;
             auto sleep_micro_seconds = (frame_duration - render_time) + double_micro_sec (correction_factor);
             auto sleep_time = (sleep_micro_seconds.count() > 0) ? duration_cast<micro_sec>(double_micro_sec(sleep_micro_seconds)) : duration_cast<micro_sec>(double_micro_sec(0.0));
-            if (- (sleep_micro_seconds) > render_time) {
-                skipFrames = floor((-sleep_micro_seconds)/render_time);
-                if (skipFrames * 1.0 > reader->info.fps.ToDouble())
-                    skipFrames = floor(reader->info.fps.ToDouble());
+            if ( - (sleep_micro_seconds.count()) > frame_duration.count()) {
+                skipFrames = floor( (-sleep_micro_seconds.count()) / frame_duration.count());
+                skipFrames = (skipFrames / 2) + 1;
+                skipFrames = (float)skipFrames > reader->info.fps.ToDouble() ? reader->info.fps.ToDouble() : skipFrames;
+                continue;
             }
 
             // Debug


### PR DESCRIPTION
We've been getting a few issues regarding the video, and audio not matching up. (in one case the video paused, and then jumped forward several seconds)

@jonoomph Suggested this comes from our timing correction code, which had multiple levels of response depending on how out of sync the audio and video became. The goal is a single approach which "rubber-bands" the video playback to the audio. Speeding up when behind and slowing down when ahead.

My approach is this: have the video preview thread sleep for
![equation](https://render.githubusercontent.com/render/math?math=\large\text{error}^3)
additional seconds where
![equation](https://render.githubusercontent.com/render/math?math=\large\text{error}=\text{video_position}-\text{audio_position})

The reason I'm cubing the error, is so that the sign `+/-` is preserved. And Ideally, the correction is smaller the closer we are to synched.

For this to work, I believe I need to divide before cubing like this:
![equation](https://render.githubusercontent.com/render/math?math=\large(\frac{\text{error}}{\text{micro%20seconds%20per%20frame}})^3)

Which will take advantage of how cubing fractions should prevent us from over-correcting.

### Testing:
If you feel like testing it, I used this [video](https://www.youtube.com/watch?v=ucZl6vQ_8Uo) (via youtube-dl) to test audio-video synch.