### PR TITLE
Rename GetAudioSample to GetPeakSampleLevel, and fix... everything about it

### DIFF
--- a/src/Frame.cpp
+++ b/src/Frame.cpp
@@ -298,7 +298,7 @@ void Frame::DisplayWaveform()
 }
 
 // Get highest sample value in range
-float Frame::GetPeakLevel(int channel, int sample, int sample_count)
+float Frame::GetPeakSampleLevel(int channel, int sample, int sample_count)
 {
 	if (channel < 0) {
 		// Return magnitude across all channels
@@ -309,7 +309,7 @@ float Frame::GetPeakLevel(int channel, int sample, int sample_count)
 
 // Alias (Deprecated)
 float Frame::GetAudioSample(int channel, int sample, int sample_count) {
-    return GetPeakLevel(channel, sample, sample_count);
+    return GetPeakSampleLevel(channel, sample, sample_count);
 }
 
 // Get an array of sample data

--- a/src/Frame.cpp
+++ b/src/Frame.cpp
@@ -297,17 +297,19 @@ void Frame::DisplayWaveform()
 	ClearWaveform();
 }
 
-// Get magnitude of range of samples (if channel is -1, return average of all channels for that sample)
-float Frame::GetAudioSample(int channel, int sample, int magnitude_range)
+// Get highest sample value in range
+float Frame::GetPeakLevel(int channel, int sample, int sample_count)
 {
-	if (channel > 0) {
-		// return average magnitude for a specific channel/sample range
-		return audio->getMagnitude(channel, sample, magnitude_range);
-
-	} else {
-		// Return average magnitude for all channels
-		return audio->getMagnitude(sample, magnitude_range);
+	if (channel < 0) {
+		// Return magnitude across all channels
+		return audio->getMagnitude(sample, sample_count);
 	}
+	return audio->getMagnitude(channel, sample, sample_count);
+}
+
+// Alias (Deprecated)
+float Frame::GetAudioSample(int channel, int sample, int sample_count) {
+    return GetPeakLevel(channel, sample, sample_count);
 }
 
 // Get an array of sample data

--- a/src/Frame.h
+++ b/src/Frame.h
@@ -183,8 +183,17 @@ namespace openshot
 		/// Display the wave form
 		void DisplayWaveform();
 
-		/// Get magnitude of range of samples (if channel is -1, return average of all channels for that sample)
-		float GetAudioSample(int channel, int sample, int magnitude_range);
+		/// Get highest value within a range of samples
+		/// 
+		/// @param channel Channel number to scan, or -1 for all channels
+		/// @param sample The starting sample for the range
+		/// @param sample_count The length of the sample range
+		/// @returns The maximum sample value within the range of samples on
+		///          the specified channel, or all channels if channel == -1
+		float GetPeakLevel(int channel, int sample, int sample_count);
+
+		/// Deprecated alias for GetPeakLevel
+		float GetAudioSample(int channel, int sample, int sample_count);
 
 		/// Get an array of sample data
 		float* GetAudioSamples(int channel);

--- a/src/Frame.h
+++ b/src/Frame.h
@@ -184,15 +184,21 @@ namespace openshot
 		void DisplayWaveform();
 
 		/// Get highest value within a range of samples
-		/// 
-		/// @param channel Channel number to scan, or -1 for all channels
-		/// @param sample The starting sample for the range
-		/// @param sample_count The length of the sample range
-		/// @returns The maximum sample value within the range of samples on
-		///          the specified channel, or all channels if channel == -1
-		float GetPeakLevel(int channel, int sample, int sample_count);
+		//
+		/// @since 0.2.8
+		///
+		/// @returns The maximum sample value within the given range
+		///          of samples, on the channel(s) specified
+		float
+		GetPeakSampleLevel(
+			int channel, ///< channel number, or -1 for all channels
+			int sample, ///< starting sample for the range
+			int sample_count ///< length of the range
+		);
 
-		/// Deprecated alias for GetPeakLevel
+		/// Alias for GetSampleLevel()
+		///
+		/// @deprecated use Frame::GetPeakSampleLevel
 		float GetAudioSample(int channel, int sample, int sample_count);
 
 		/// Get an array of sample data

--- a/src/Frame.h
+++ b/src/Frame.h
@@ -164,11 +164,15 @@ namespace openshot
 		/// Apply gain ramp (i.e. fading volume)
 		void ApplyGainRamp(int destChannel, int destStartSample, int numSamples, float initial_gain, float final_gain);
 
-		/// Channel Layout of audio samples. A frame needs to keep track of this, since Writers do not always
-		/// know the original channel layout of a frame's audio samples (i.e. mono, stereo, 5 point surround, etc...)
+		/// Channel Layout for the Frame's audio samples.
+		///
+		/// A frame needs to keep track of this, since Writers
+		/// do not always know the original layout of a frame's
+		/// audio channels.
+		/// (i.e. mono, stereo, 5.1 surround, etc...)
 		openshot::ChannelLayout ChannelsLayout();
 
-		// Set the channel layout of audio samples (i.e. mono, stereo, 5 point surround, etc...)
+		/// Set the channel layout of audio samples (i.e. mono, stereo, 5 point surround, etc...)
 		void ChannelsLayout(openshot::ChannelLayout new_channel_layout) { channel_layout = new_channel_layout; };
 
 		/// Clear the waveform image (and deallocate its memory)
@@ -202,6 +206,8 @@ namespace openshot
 		float GetAudioSample(int channel, int sample, int sample_count);
 
 		/// Get an array of sample data
+		///
+		/// @returns A pointer to the first element in the array
 		float* GetAudioSamples(int channel);
 
 		/// Get an array of sample data (all channels interleaved together), using any sample rate
@@ -216,7 +222,9 @@ namespace openshot
 		/// Get number of audio samples
 		int GetAudioSamplesCount();
 
-	    juce::AudioBuffer<float> *GetAudioSampleBuffer();
+		/// Get the underlying storage buffer for the
+		/// frame's audio sample data
+		juce::AudioBuffer<float> *GetAudioSampleBuffer();
 
 		/// Get the size in bytes of this frame (rough estimate)
 		int64_t GetBytes();
@@ -224,10 +232,13 @@ namespace openshot
 		/// Get pointer to Qt QImage image object
 		std::shared_ptr<QImage> GetImage();
 
-		/// Set Pixel Aspect Ratio
+		/// Get Pixel Aspect Ratio
 		openshot::Fraction GetPixelRatio() { return pixel_ratio; };
 
-		/// Get pixel data (as packets)
+		/// Get pixel data
+		///
+		/// @returns A pointer to a two-dimensional array
+		///          of scanlines containing pixel values.
 		const unsigned char* GetPixels();
 
 		/// Get pixel data (for only a single scan-line)
@@ -248,7 +259,7 @@ namespace openshot
 		/// Get an audio waveform image
 		std::shared_ptr<QImage> GetWaveform(int width, int height, int Red, int Green, int Blue, int Alpha);
 
-		/// Get an audio waveform image pixels
+		/// Get the raw pixels of an audio waveform image
 		const unsigned char* GetWaveformPixels(int width, int height, int Red, int Green, int Blue, int Alpha);
 
 		/// Get height of image


### PR DESCRIPTION
While working on audio code updates for  JUCE 6, I discovered that `Frame::GetAudioSample`...

1. Was wildly misnamed, relative to its function
1. Was _confusingly_ named, since `Frame::GetAudioSamples` does something completely different
1. Had a confusingly-named set of largely-undocumented parameters. The behavior of `channel == -1` was mentioned, but no mention was made of what `magnitude_range` is or how to specify it. (I renamed it `sample_count`, which hopefully _does_ tell you what it actually signifies. But just in case, it's also got a `@param` line in the doc comment that explains in more detail.)
1. Was documented to do something completely different than what it _actually_ does (or, rather, what the JUCE function underlying it actually does).
1. Had a bug when passed a `channel` parameter of `0`, and would return the wrong values. (It was supposed to take `channel = -1` to mean all channels, but the test in the code was written `if (channel > 0) { <do channel-specific stuff> }`, meaning that when `channel == 0` it would take the other branch and act as if `channel == -1`.) <sup>1</sup>
1. Is never actually called anywhere in the libopenshot code. (It is used by OpenShot, to graph audio waveforms.) <sup>2</sup>

Details on the fixes for these issues forthcoming, as inline review comments.

#### Notes
1. The implication of this is that OpenShot's waveforms are currently incorrect for a lone/separated channel 0. Based on the existing code, they will always be identical to the combined `channel == -1` waveforms. The corrected code will OpenShot to correctly display the audio waveform for _only_ the first channel.

2. libopenshot's own waveform code is entirely unlike OpenShot's. libopenshot uses a completely different (and incredibly inefficient) method involving direct examination of the audio buffer's individual sample values. That should probably be improved.
