### PR TITLE
Reformat ZmqLogger calls

### DIFF
--- a/src/Clip.cpp
+++ b/src/Clip.cpp
@@ -699,7 +699,9 @@ std::shared_ptr<Frame> Clip::GetOrCreateFrame(int64_t number)
 {
 	try {
 		// Debug output
-		ZmqLogger::Instance()->AppendDebugMethod("Clip::GetOrCreateFrame (from reader)", "number", number);
+		ZmqLogger::Instance()->AppendDebugMethod(
+			"Clip::GetOrCreateFrame (from reader)",
+			"number", number);
 
 		// Attempt to get a frame (but this could fail if a reader has just been closed)
 		auto reader_frame = reader->GetFrame(number);
@@ -727,7 +729,10 @@ std::shared_ptr<Frame> Clip::GetOrCreateFrame(int64_t number)
 	int estimated_samples_in_frame = Frame::GetSamplesPerFrame(number, reader->info.fps, reader->info.sample_rate, reader->info.channels);
 
 	// Debug output
-	ZmqLogger::Instance()->AppendDebugMethod("Clip::GetOrCreateFrame (create blank)", "number", number, "estimated_samples_in_frame", estimated_samples_in_frame);
+	ZmqLogger::Instance()->AppendDebugMethod(
+		"Clip::GetOrCreateFrame (create blank)",
+		"number", number,
+		"estimated_samples_in_frame", estimated_samples_in_frame);
 
 	// Create blank frame
 	auto new_frame = std::make_shared<Frame>(
@@ -1242,7 +1247,12 @@ void Clip::apply_keyframes(std::shared_ptr<Frame> frame, std::shared_ptr<QImage>
     if (Waveform())
     {
         // Debug output
-        ZmqLogger::Instance()->AppendDebugMethod("Clip::get_transform (Generate Waveform Image)", "frame->number", frame->number, "Waveform()", Waveform(), "background_canvas->width()", background_canvas->width(), "background_canvas->height()", background_canvas->height());
+        ZmqLogger::Instance()->AppendDebugMethod(
+            "Clip::get_transform (Generate Waveform Image)",
+            "frame->number", frame->number,
+            "Waveform()", Waveform(),
+            "background_canvas->width()", background_canvas->width(),
+            "background_canvas->height()", background_canvas->height());
 
         // Get the color of the waveform
         int red = wave_color.red.GetInt(frame->number);
@@ -1259,7 +1269,11 @@ void Clip::apply_keyframes(std::shared_ptr<Frame> frame, std::shared_ptr<QImage>
     QTransform transform = get_transform(frame, background_canvas->width(), background_canvas->height());
 
     // Debug output
-    ZmqLogger::Instance()->AppendDebugMethod("Clip::ApplyKeyframes (Transform: Composite Image Layer: Prepare)", "frame->number", frame->number, "background_canvas->width()", background_canvas->width(), "background_canvas->height()", background_canvas->height());
+    ZmqLogger::Instance()->AppendDebugMethod(
+        "Clip::ApplyKeyframes (Transform: Composite Image Layer: Prepare)",
+        "frame->number", frame->number,
+        "background_canvas->width()", background_canvas->width(),
+        "background_canvas->height()", background_canvas->height());
 
     // Load timeline's new frame image into a QPainter
     QPainter painter(background_canvas.get());
@@ -1333,7 +1347,10 @@ QTransform Clip::get_transform(std::shared_ptr<Frame> frame, int width, int heig
 		}
 
 		// Debug output
-		ZmqLogger::Instance()->AppendDebugMethod("Clip::get_transform (Set Alpha & Opacity)", "alpha_value", alpha_value, "frame->number", frame->number);
+		ZmqLogger::Instance()->AppendDebugMethod(
+			"Clip::get_transform (Set Alpha & Opacity)",
+			"alpha_value", alpha_value,
+			"frame->number", frame->number);
 	}
 
 	/* RESIZE SOURCE IMAGE - based on scale type */
@@ -1350,29 +1367,45 @@ QTransform Clip::get_transform(std::shared_ptr<Frame> frame, int width, int heig
 			source_size.scale(width, height, Qt::KeepAspectRatio);
 
 			// Debug output
-			ZmqLogger::Instance()->AppendDebugMethod("Clip::get_transform (Scale: SCALE_FIT)", "frame->number", frame->number, "source_width", source_size.width(), "source_height", source_size.height());
+			ZmqLogger::Instance()->AppendDebugMethod(
+				"Clip::get_transform (Scale: SCALE_FIT)",
+				"frame->number", frame->number,
+				"source_width", source_size.width(),
+				"source_height", source_size.height());
 			break;
 		}
 		case (SCALE_STRETCH): {
 			source_size.scale(width, height, Qt::IgnoreAspectRatio);
 
 			// Debug output
-			ZmqLogger::Instance()->AppendDebugMethod("Clip::get_transform (Scale: SCALE_STRETCH)", "frame->number", frame->number, "source_width", source_size.width(), "source_height", source_size.height());
+			ZmqLogger::Instance()->AppendDebugMethod(
+				"Clip::get_transform (Scale: SCALE_STRETCH)",
+				"frame->number", frame->number,
+				"source_width", source_size.width(),
+				"source_height", source_size.height());
 			break;
 		}
 		case (SCALE_CROP): {
 			source_size.scale(width, height, Qt::KeepAspectRatioByExpanding);
 
 			// Debug output
-			ZmqLogger::Instance()->AppendDebugMethod("Clip::get_transform (Scale: SCALE_CROP)", "frame->number", frame->number, "source_width", source_size.width(), "source_height", source_size.height());
+			ZmqLogger::Instance()->AppendDebugMethod(
+				"Clip::get_transform (Scale: SCALE_CROP)",
+				"frame->number", frame->number,
+				"source_width", source_size.width(),
+				"source_height", source_size.height());
 			break;
 		}
 		case (SCALE_NONE): {
-		    // Image is already the original size (i.e. no scaling mode) relative
-		    // to the preview window size (i.e. timeline / preview ratio). No further
-		    // scaling is needed here.
+			// Image is already the original size (i.e. no scaling mode) relative
+			// to the preview window size (i.e. timeline / preview ratio). No further
+			// scaling is needed here.
 			// Debug output
-			ZmqLogger::Instance()->AppendDebugMethod("Clip::get_transform (Scale: SCALE_NONE)", "frame->number", frame->number, "source_width", source_size.width(), "source_height", source_size.height());
+			ZmqLogger::Instance()->AppendDebugMethod(
+				"Clip::get_transform (Scale: SCALE_NONE)",
+				"frame->number", frame->number,
+				"source_width", source_size.width(),
+				"source_height", source_size.height());
 			break;
 		}
 	}
@@ -1498,7 +1531,12 @@ QTransform Clip::get_transform(std::shared_ptr<Frame> frame, int width, int heig
 	}
 
 	// Debug output
-	ZmqLogger::Instance()->AppendDebugMethod("Clip::get_transform (Gravity)", "frame->number", frame->number, "source_clip->gravity", gravity, "scaled_source_width", scaled_source_width, "scaled_source_height", scaled_source_height);
+	ZmqLogger::Instance()->AppendDebugMethod(
+		"Clip::get_transform (Gravity)",
+		"frame->number", frame->number,
+		"source_clip->gravity", gravity,
+		"scaled_source_width", scaled_source_width,
+		"scaled_source_height", scaled_source_height);
 
 	QTransform transform;
 
@@ -1512,7 +1550,12 @@ QTransform Clip::get_transform(std::shared_ptr<Frame> frame, int width, int heig
 	float origin_y_value = origin_y.GetValue(frame->number);
 
 	// Transform source image (if needed)
-	ZmqLogger::Instance()->AppendDebugMethod("Clip::get_transform (Build QTransform - if needed)", "frame->number", frame->number, "x", x, "y", y, "r", r, "sx", sx, "sy", sy);
+	ZmqLogger::Instance()->AppendDebugMethod(
+		"Clip::get_transform (Build QTransform - if needed)",
+		"frame->number", frame->number,
+		"x", x, "y", y,
+		"r", r,
+		"sx", sx, "sy", sy);
 
 	if (!isEqual(x, 0) || !isEqual(y, 0)) {
 		// TRANSLATE/MOVE CLIP

--- a/src/FFmpegWriter.h
+++ b/src/FFmpegWriter.h
@@ -22,15 +22,6 @@
 // Include FFmpeg headers and macros
 #include "FFmpegUtilities.h"
 
-#include <cmath>
-#include <ctime>
-#include <unistd.h>
-#include "CacheMemory.h"
-#include "OpenMPUtilities.h"
-#include "ZmqLogger.h"
-#include "Settings.h"
-
-
 namespace openshot {
 
 	/// This enumeration designates the type of stream when encoding (video or audio)

--- a/src/FrameMapper.cpp
+++ b/src/FrameMapper.cpp
@@ -342,7 +342,12 @@ MappedFrame FrameMapper::GetMappedFrame(int64_t TargetFrameNumber)
 		TargetFrameNumber = frames.size();
 
 	// Debug output
-	ZmqLogger::Instance()->AppendDebugMethod("FrameMapper::GetMappedFrame", "TargetFrameNumber", TargetFrameNumber, "frames.size()", frames.size(), "frames[...].Odd", frames[TargetFrameNumber - 1].Odd.Frame, "frames[...].Even", frames[TargetFrameNumber - 1].Even.Frame);
+	ZmqLogger::Instance()->AppendDebugMethod(
+		"FrameMapper::GetMappedFrame",
+		"TargetFrameNumber", TargetFrameNumber,
+		"frames.size()", frames.size(),
+		"frames[...].Odd", frames[TargetFrameNumber - 1].Odd.Frame,
+		"frames[...].Even", frames[TargetFrameNumber - 1].Even.Frame);
 
 	// Return frame
 	return frames[TargetFrameNumber - 1];
@@ -358,7 +363,10 @@ std::shared_ptr<Frame> FrameMapper::GetOrCreateFrame(int64_t number)
 
 	try {
 		// Debug output
-		ZmqLogger::Instance()->AppendDebugMethod("FrameMapper::GetOrCreateFrame (from reader)", "number", number, "samples_in_frame", samples_in_frame);
+		ZmqLogger::Instance()->AppendDebugMethod(
+			"FrameMapper::GetOrCreateFrame (from reader)",
+			"number", number,
+			"samples_in_frame", samples_in_frame);
 
 		// Attempt to get a frame (but this could fail if a reader has just been closed)
 		new_frame = reader->GetFrame(number);
@@ -373,7 +381,10 @@ std::shared_ptr<Frame> FrameMapper::GetOrCreateFrame(int64_t number)
 	}
 
 	// Debug output
-	ZmqLogger::Instance()->AppendDebugMethod("FrameMapper::GetOrCreateFrame (create blank)", "number", number, "samples_in_frame", samples_in_frame);
+	ZmqLogger::Instance()->AppendDebugMethod(
+		"FrameMapper::GetOrCreateFrame (create blank)",
+		"number", number,
+		"samples_in_frame", samples_in_frame);
 
 	// Create blank frame
 	new_frame = std::make_shared<Frame>(number, info.width, info.height, "#000000", samples_in_frame, reader->info.channels);
@@ -418,14 +429,21 @@ std::shared_ptr<Frame> FrameMapper::GetFrame(int64_t requested_frame)
 	int minimum_frames = 1;
 
 	// Debug output
-	ZmqLogger::Instance()->AppendDebugMethod("FrameMapper::GetFrame (Loop through frames)", "requested_frame", requested_frame, "minimum_frames", minimum_frames);
+	ZmqLogger::Instance()->AppendDebugMethod(
+		"FrameMapper::GetFrame (Loop through frames)",
+		"requested_frame", requested_frame,
+		"minimum_frames", minimum_frames);
 
 	// Loop through all requested frames
 	for (int64_t frame_number = requested_frame; frame_number < requested_frame + minimum_frames; frame_number++)
 	{
 
 		// Debug output
-		ZmqLogger::Instance()->AppendDebugMethod("FrameMapper::GetFrame (inside omp for loop)", "frame_number", frame_number, "minimum_frames", minimum_frames, "requested_frame", requested_frame);
+		ZmqLogger::Instance()->AppendDebugMethod(
+			"FrameMapper::GetFrame (inside omp for loop)",
+			"frame_number", frame_number,
+			"minimum_frames", minimum_frames,
+			"requested_frame", requested_frame);
 
 		// Get the mapped frame
 		MappedFrame mapped = GetMappedFrame(frame_number);

--- a/src/Qt/PlayerPrivate.cpp
+++ b/src/Qt/PlayerPrivate.cpp
@@ -107,7 +107,14 @@ namespace openshot
             auto sleep_time = duration_cast<micro_sec>(frame_duration - render_time);
 
             // Debug
-            ZmqLogger::Instance()->AppendDebugMethod("PlayerPrivate::run (determine sleep)", "video_frame_diff", video_frame_diff, "video_position", video_position, "audio_position", audio_position, "speed", speed, "render_time(ms)", render_time.count(), "sleep_time(ms)", sleep_time.count());
+            ZmqLogger::Instance()->AppendDebugMethod(
+                "PlayerPrivate::run (determine sleep)",
+                "video_frame_diff", video_frame_diff,
+                "video_position", video_position,
+                "audio_position", audio_position,
+                "speed", speed,
+                "render_time(ms)", render_time.count(),
+                "sleep_time(ms)", sleep_time.count());
 
             // Adjust drift (if more than a few frames off between audio and video)
             if (video_frame_diff > 6 && reader->info.has_audio && reader->info.has_video) {

--- a/src/Qt/VideoPlaybackThread.cpp
+++ b/src/Qt/VideoPlaybackThread.cpp
@@ -51,7 +51,10 @@ namespace openshot
 		if (need_render && frame)
 		{
 			// Debug
-			ZmqLogger::Instance()->AppendDebugMethod("VideoPlaybackThread::run (before render)", "frame->number", frame->number, "need_render", need_render);
+			ZmqLogger::Instance()->AppendDebugMethod(
+				"VideoPlaybackThread::run (before render)",
+				"frame->number", frame->number,
+				"need_render", need_render);
 
 			// Render the frame to the screen
 			renderer->paint(frame);

--- a/src/Timeline.cpp
+++ b/src/Timeline.cpp
@@ -521,7 +521,11 @@ double Timeline::calculate_time(int64_t number, Fraction rate)
 std::shared_ptr<Frame> Timeline::apply_effects(std::shared_ptr<Frame> frame, int64_t timeline_frame_number, int layer)
 {
 	// Debug output
-	ZmqLogger::Instance()->AppendDebugMethod("Timeline::apply_effects", "frame->number", frame->number, "timeline_frame_number", timeline_frame_number, "layer", layer);
+	ZmqLogger::Instance()->AppendDebugMethod(
+		"Timeline::apply_effects",
+		"frame->number", frame->number,
+		"timeline_frame_number", timeline_frame_number,
+		"layer", layer);
 
 	// Find Effects at this position and layer
 	for (auto effect : effects)
@@ -533,7 +537,12 @@ std::shared_ptr<Frame> Timeline::apply_effects(std::shared_ptr<Frame> frame, int
 		bool does_effect_intersect = (effect_start_position <= timeline_frame_number && effect_end_position >= timeline_frame_number && effect->Layer() == layer);
 
 		// Debug output
-		ZmqLogger::Instance()->AppendDebugMethod("Timeline::apply_effects (Does effect intersect)", "effect->Position()", effect->Position(), "does_effect_intersect", does_effect_intersect, "timeline_frame_number", timeline_frame_number, "layer", layer);
+		ZmqLogger::Instance()->AppendDebugMethod(
+			"Timeline::apply_effects (Does effect intersect)",
+			"effect->Position()", effect->Position(),
+			"does_effect_intersect", does_effect_intersect,
+			"timeline_frame_number", timeline_frame_number,
+			"layer", layer);
 
 		// Clip is visible
 		if (does_effect_intersect)
@@ -543,7 +552,10 @@ std::shared_ptr<Frame> Timeline::apply_effects(std::shared_ptr<Frame> frame, int
 			long effect_frame_number = timeline_frame_number - effect_start_position + effect_start_frame;
 
 			// Debug output
-			ZmqLogger::Instance()->AppendDebugMethod("Timeline::apply_effects (Process Effect)", "effect_frame_number", effect_frame_number, "does_effect_intersect", does_effect_intersect);
+			ZmqLogger::Instance()->AppendDebugMethod(
+				"Timeline::apply_effects (Process Effect)",
+				"effect_frame_number", effect_frame_number,
+				"does_effect_intersect", does_effect_intersect);
 
 			// Apply the effect to this frame
 			frame = effect->GetFrame(frame, effect_frame_number);
@@ -565,7 +577,10 @@ std::shared_ptr<Frame> Timeline::GetOrCreateFrame(std::shared_ptr<Frame> backgro
 
 	try {
 		// Debug output
-		ZmqLogger::Instance()->AppendDebugMethod("Timeline::GetOrCreateFrame (from reader)", "number", number, "samples_in_frame", samples_in_frame);
+		ZmqLogger::Instance()->AppendDebugMethod(
+			"Timeline::GetOrCreateFrame (from reader)",
+			"number", number,
+			"samples_in_frame", samples_in_frame);
 
 		// Attempt to get a frame (but this could fail if a reader has just been closed)
 		new_frame = std::shared_ptr<Frame>(clip->GetFrame(background_frame, number, options));
@@ -580,7 +595,10 @@ std::shared_ptr<Frame> Timeline::GetOrCreateFrame(std::shared_ptr<Frame> backgro
 	}
 
 	// Debug output
-	ZmqLogger::Instance()->AppendDebugMethod("Timeline::GetOrCreateFrame (create blank)", "number", number, "samples_in_frame", samples_in_frame);
+	ZmqLogger::Instance()->AppendDebugMethod(
+		"Timeline::GetOrCreateFrame (create blank)",
+		"number", number,
+		"samples_in_frame", samples_in_frame);
 
 	// Create blank frame
 	return new_frame;
@@ -603,12 +621,20 @@ void Timeline::add_layer(std::shared_ptr<Frame> new_frame, Clip* source_clip, in
 		return;
 
 	// Debug output
-	ZmqLogger::Instance()->AppendDebugMethod("Timeline::add_layer", "new_frame->number", new_frame->number, "clip_frame_number", clip_frame_number);
+	ZmqLogger::Instance()->AppendDebugMethod(
+		"Timeline::add_layer",
+		"new_frame->number", new_frame->number,
+		"clip_frame_number", clip_frame_number);
 
 	/* COPY AUDIO - with correct volume */
 	if (source_clip->Reader()->info.has_audio) {
 		// Debug output
-		ZmqLogger::Instance()->AppendDebugMethod("Timeline::add_layer (Copy Audio)", "source_clip->Reader()->info.has_audio", source_clip->Reader()->info.has_audio, "source_frame->GetAudioChannelsCount()", source_frame->GetAudioChannelsCount(), "info.channels", info.channels, "clip_frame_number", clip_frame_number);
+		ZmqLogger::Instance()->AppendDebugMethod(
+			"Timeline::add_layer (Copy Audio)",
+			"source_clip->Reader()->info.has_audio", source_clip->Reader()->info.has_audio,
+			"source_frame->GetAudioChannelsCount()", source_frame->GetAudioChannelsCount(),
+			"info.channels", info.channels,
+			"clip_frame_number", clip_frame_number);
 
 		if (source_frame->GetAudioChannelsCount() == info.channels && source_clip->has_audio.GetInt(clip_frame_number) != 0)
 			for (int channel = 0; channel < source_frame->GetAudioChannelsCount(); channel++)
@@ -661,17 +687,32 @@ void Timeline::add_layer(std::shared_ptr<Frame> new_frame, Clip* source_clip, in
 			}
 		else
 			// Debug output
-			ZmqLogger::Instance()->AppendDebugMethod("Timeline::add_layer (No Audio Copied - Wrong # of Channels)", "source_clip->Reader()->info.has_audio", source_clip->Reader()->info.has_audio, "source_frame->GetAudioChannelsCount()", source_frame->GetAudioChannelsCount(), "info.channels", info.channels, "clip_frame_number", clip_frame_number);
+			ZmqLogger::Instance()->AppendDebugMethod(
+				"Timeline::add_layer (No Audio Copied - Wrong # of Channels)",
+				"source_clip->Reader()->info.has_audio",
+					source_clip->Reader()->info.has_audio,
+				"source_frame->GetAudioChannelsCount()",
+					source_frame->GetAudioChannelsCount(),
+				"info.channels", info.channels,
+				"clip_frame_number", clip_frame_number);
 	}
 
 	// Debug output
-	ZmqLogger::Instance()->AppendDebugMethod("Timeline::add_layer (Transform: Composite Image Layer: Completed)", "source_frame->number", source_frame->number, "new_frame->GetImage()->width()", new_frame->GetImage()->width(), "new_frame->GetImage()->height()", new_frame->GetImage()->height());
+	ZmqLogger::Instance()->AppendDebugMethod(
+		"Timeline::add_layer (Transform: Composite Image Layer: Completed)",
+		"source_frame->number", source_frame->number,
+		"new_frame->GetImage()->width()", new_frame->GetImage()->width(),
+		"new_frame->GetImage()->height()", new_frame->GetImage()->height());
 }
 
 // Update the list of 'opened' clips
 void Timeline::update_open_clips(Clip *clip, bool does_clip_intersect)
 {
-	ZmqLogger::Instance()->AppendDebugMethod("Timeline::update_open_clips (before)", "does_clip_intersect", does_clip_intersect, "closing_clips.size()", closing_clips.size(), "open_clips.size()", open_clips.size());
+	ZmqLogger::Instance()->AppendDebugMethod(
+		"Timeline::update_open_clips (before)",
+		"does_clip_intersect", does_clip_intersect,
+		"closing_clips.size()", closing_clips.size(),
+		"open_clips.size()", open_clips.size());
 
 	// is clip already in list?
 	bool clip_found = open_clips.count(clip);
@@ -699,14 +740,21 @@ void Timeline::update_open_clips(Clip *clip, bool does_clip_intersect)
 	}
 
 	// Debug output
-	ZmqLogger::Instance()->AppendDebugMethod("Timeline::update_open_clips (after)", "does_clip_intersect", does_clip_intersect, "clip_found", clip_found, "closing_clips.size()", closing_clips.size(), "open_clips.size()", open_clips.size());
+	ZmqLogger::Instance()->AppendDebugMethod(
+		"Timeline::update_open_clips (after)",
+		"does_clip_intersect", does_clip_intersect,
+		"clip_found", clip_found,
+		"closing_clips.size()", closing_clips.size(),
+		"open_clips.size()", open_clips.size());
 }
 
 // Sort clips by position on the timeline
 void Timeline::sort_clips()
 {
 	// Debug output
-	ZmqLogger::Instance()->AppendDebugMethod("Timeline::SortClips", "clips.size()", clips.size());
+	ZmqLogger::Instance()->AppendDebugMethod(
+		"Timeline::SortClips",
+		"clips.size()", clips.size());
 
 	// sort clips
 	clips.sort(CompareClips());
@@ -765,49 +813,56 @@ std::shared_ptr<Frame> Timeline::GetFrame(int64_t requested_frame)
 	frame = final_cache->GetFrame(requested_frame);
 	if (frame) {
 		// Debug output
-		ZmqLogger::Instance()->AppendDebugMethod("Timeline::GetFrame (Cached frame found)", "requested_frame", requested_frame);
+		ZmqLogger::Instance()->AppendDebugMethod(
+			"Timeline::GetFrame (Cached frame found)",
+			"requested_frame", requested_frame);
 
 		// Return cached frame
 		return frame;
 	}
 	else
 	{
-		// Create a scoped lock, allowing only a single thread to run the following code at one time
-		const std::lock_guard<std::recursive_mutex> lock(getFrameMutex);
+        // Create a scoped lock, allowing only a single thread to run the following code at one time
+        const std::lock_guard<std::recursive_mutex> lock(getFrameMutex);
 
-		// Check for open reader (or throw exception)
-		if (!is_open)
-			throw ReaderClosed("The Timeline is closed.  Call Open() before calling this method.");
+        // Check for open reader (or throw exception)
+        if (!is_open)
+            throw ReaderClosed("The Timeline is closed.  Call Open() before calling this method.");
 
-		// Check cache again (due to locking)
-		frame = final_cache->GetFrame(requested_frame);
-		if (frame) {
-			// Debug output
-			ZmqLogger::Instance()->AppendDebugMethod("Timeline::GetFrame (Cached frame found on 2nd look)", "requested_frame", requested_frame);
+        // Check cache again (due to locking)
+        frame = final_cache->GetFrame(requested_frame);
+        if (frame) {
+            // Debug output
+            ZmqLogger::Instance()->AppendDebugMethod(
+                "Timeline::GetFrame (Cached frame found on 2nd look)",
+                "requested_frame", requested_frame);
 
-			// Return cached frame
-			return frame;
-		}
+            // Return cached frame
+            return frame;
+        }
 
-		// Check if previous frame was cached? (if not, assume we are seeking somewhere else on the Timeline, and need
-		// to clear all cache (for continuity sake). For example, jumping back to a previous spot can cause issues with audio
-		// data where the new jump location doesn't match up with the previously cached audio data.
-		std::shared_ptr<Frame> previous_frame = final_cache->GetFrame(requested_frame - 1);
-		if (!previous_frame) {
-			// Seeking to new place on timeline (destroy cache)
-			ClearAllCache();
-		}
+        // Check if previous frame was cached? (if not, assume we are seeking somewhere else on the Timeline, and need
+        // to clear all cache (for continuity sake). For example, jumping back to a previous spot can cause issues with audio
+        // data where the new jump location doesn't match up with the previously cached audio data.
+        std::shared_ptr<Frame> previous_frame = final_cache->GetFrame(requested_frame - 1);
+        if (!previous_frame) {
+            // Seeking to new place on timeline (destroy cache)
+            ClearAllCache();
+        }
 
-		// Minimum number of frames to process (for performance reasons)
-		int minimum_frames = OPEN_MP_NUM_PROCESSORS;
+        // Minimum number of frames to process (for performance reasons)
+        int minimum_frames = OPEN_MP_NUM_PROCESSORS;
 
-		// Get a list of clips that intersect with the requested section of timeline
-		// This also opens the readers for intersecting clips, and marks non-intersecting clips as 'needs closing'
-		std::vector<Clip*> nearby_clips;
-		nearby_clips = find_intersecting_clips(requested_frame, 1, true);
+        // Get a list of clips that intersect with the requested section of timeline
+        // This also opens the readers for intersecting clips, and marks non-intersecting clips as 'needs closing'
+        std::vector<Clip*> nearby_clips;
+        nearby_clips = find_intersecting_clips(requested_frame, 1, true);
 
         // Debug output
-        ZmqLogger::Instance()->AppendDebugMethod("Timeline::GetFrame (processing frame)", "requested_frame", requested_frame, "omp_get_thread_num()", omp_get_thread_num());
+        ZmqLogger::Instance()->AppendDebugMethod(
+            "Timeline::GetFrame (processing frame)",
+            "requested_frame", requested_frame,
+            "omp_get_thread_num()", omp_get_thread_num());
 
         // Init some basic properties about this frame
         int samples_in_frame = Frame::GetSamplesPerFrame(requested_frame, info.fps, info.sample_rate, info.channels);
@@ -819,7 +874,11 @@ std::shared_ptr<Frame> Timeline::GetFrame(int64_t requested_frame)
         new_frame->ChannelsLayout(info.channel_layout);
 
         // Debug output
-        ZmqLogger::Instance()->AppendDebugMethod("Timeline::GetFrame (Adding solid color)", "requested_frame", requested_frame, "info.width", info.width, "info.height", info.height);
+        ZmqLogger::Instance()->AppendDebugMethod(
+            "Timeline::GetFrame (Adding solid color)",
+            "requested_frame", requested_frame,
+            "info.width", info.width,
+            "info.height", info.height);
 
         // Add Background Color to 1st layer (if animated or not black)
         if ((color.red.GetCount() > 1 || color.green.GetCount() > 1 || color.blue.GetCount() > 1) ||
@@ -827,7 +886,11 @@ std::shared_ptr<Frame> Timeline::GetFrame(int64_t requested_frame)
         new_frame->AddColor(preview_width, preview_height, color.GetColorHex(requested_frame));
 
         // Debug output
-        ZmqLogger::Instance()->AppendDebugMethod("Timeline::GetFrame (Loop through clips)", "requested_frame", requested_frame, "clips.size()", clips.size(), "nearby_clips.size()", nearby_clips.size());
+        ZmqLogger::Instance()->AppendDebugMethod(
+            "Timeline::GetFrame (Loop through clips)",
+            "requested_frame", requested_frame,
+            "clips.size()", clips.size(),
+            "nearby_clips.size()", nearby_clips.size());
 
         // Find Clips near this time
         for (auto clip : nearby_clips)
@@ -838,7 +901,12 @@ std::shared_ptr<Frame> Timeline::GetFrame(int64_t requested_frame)
             bool does_clip_intersect = (clip_start_position <= requested_frame && clip_end_position >= requested_frame);
 
             // Debug output
-            ZmqLogger::Instance()->AppendDebugMethod("Timeline::GetFrame (Does clip intersect)", "requested_frame", requested_frame, "clip->Position()", clip->Position(), "clip->Duration()", clip->Duration(), "does_clip_intersect", does_clip_intersect);
+            ZmqLogger::Instance()->AppendDebugMethod(
+                "Timeline::GetFrame (Does clip intersect)",
+                "requested_frame", requested_frame,
+                "clip->Position()", clip->Position(),
+                "clip->Duration()", clip->Duration(),
+                "does_clip_intersect", does_clip_intersect);
 
             // Clip is visible
             if (does_clip_intersect)
@@ -873,22 +941,32 @@ std::shared_ptr<Frame> Timeline::GetFrame(int64_t requested_frame)
                 long clip_frame_number = requested_frame - clip_start_position + clip_start_frame;
 
                 // Debug output
-                ZmqLogger::Instance()->AppendDebugMethod("Timeline::GetFrame (Calculate clip's frame #)", "clip->Position()", clip->Position(), "clip->Start()", clip->Start(), "info.fps.ToFloat()", info.fps.ToFloat(), "clip_frame_number", clip_frame_number);
+                ZmqLogger::Instance()->AppendDebugMethod(
+                    "Timeline::GetFrame (Calculate clip's frame #)",
+                    "clip->Position()", clip->Position(),
+                    "clip->Start()", clip->Start(),
+                    "info.fps.ToFloat()", info.fps.ToFloat(),
+                    "clip_frame_number", clip_frame_number);
 
                 // Add clip's frame as layer
                 add_layer(new_frame, clip, clip_frame_number, is_top_clip, max_volume);
 
             } else {
                 // Debug output
-                ZmqLogger::Instance()->AppendDebugMethod("Timeline::GetFrame (clip does not intersect)",
-                                                         "requested_frame", requested_frame, "does_clip_intersect",
-                                                         does_clip_intersect);
+                ZmqLogger::Instance()->AppendDebugMethod(
+                    "Timeline::GetFrame (clip does not intersect)",
+                    "requested_frame", requested_frame,
+                    "does_clip_intersect", does_clip_intersect);
             }
 
         } // end clip loop
 
         // Debug output
-        ZmqLogger::Instance()->AppendDebugMethod("Timeline::GetFrame (Add frame to cache)", "requested_frame", requested_frame, "info.width", info.width, "info.height", info.height);
+        ZmqLogger::Instance()->AppendDebugMethod(
+            "Timeline::GetFrame (Add frame to cache)",
+            "requested_frame", requested_frame,
+            "info.width", info.width,
+            "info.height", info.height);
 
         // Set frame # on mapped frame
         new_frame->SetFrameNumber(requested_frame);
@@ -927,7 +1005,13 @@ std::vector<Clip*> Timeline::find_intersecting_clips(int64_t requested_frame, in
                 (clip_end_position >= min_requested_frame || clip_end_position >= max_requested_frame);
 
 		// Debug output
-		ZmqLogger::Instance()->AppendDebugMethod("Timeline::find_intersecting_clips (Is clip near or intersecting)", "requested_frame", requested_frame, "min_requested_frame", min_requested_frame, "max_requested_frame", max_requested_frame, "clip->Position()", clip->Position(), "does_clip_intersect", does_clip_intersect);
+		ZmqLogger::Instance()->AppendDebugMethod(
+            "Timeline::find_intersecting_clips (Is clip near or intersecting)",
+            "requested_frame", requested_frame,
+            "min_requested_frame", min_requested_frame,
+            "max_requested_frame", max_requested_frame,
+            "clip->Position()", clip->Position(),
+            "does_clip_intersect", does_clip_intersect);
 
 		// Open (or schedule for closing) this clip, based on if it's intersecting or not
 		update_open_clips(clip, does_clip_intersect);


### PR DESCRIPTION
I have submitted _parts_ of this in more PRs than I care to count, but most of them ended up abandoned or not merged. So, I have learned my lesson.

This PR does ONE THING<sup>1</sup> only.

It reformats nearly all of the `ZmqLogger` calls throughout the codebase — many, single lines of code in excess of 300, 400 characters long (!!) — to follow a consistent, well-defined, multi-line format.

```c++
// Except for all but the shortest of log calls, which I left alone...
ZmqLogger::Instance()->AppendDebugMethod("Short message");

// And with only one or two other, well-considered exceptions
// (which I'll get to), the standard format is this:
ZmqLogger::Instance()->AppendDebugMethod(
    "Initial message",
    "label", variable,
    "label", variable,
    "label", variable,
    "label", variable);

// The only two exceptions are:
// (1): Calls with especially long labels/variables, which became this...
ZmqLogger::Instance()->AppendDebugMethod(
    "Initial message",
    "label", variable,
    "Unnecessarily expository label that's just going to clutter the logs",
         usually_an_insanely_long->variable_name + math + to_go_with_it,
    "label", variable,
    "label", variable);
// (2): Intrinsically paired variables, like (direct from Clip.cpp):
ZmqLogger::Instance()->AppendDebugMethod(
    "Clip::get_transform (Build QTransform - if needed)",
    "frame->number", frame->number,
    "x", x, "y", y,
    "r", r,
    "sx", sx, "sy", sy);
```

I have tried to match the prevailing indentation of the surrounding function as much as possible.
* Where it was spaces, I used (four) spaces. 
* Where it was tabs, I closed my eyes, thought of England, and used tabs. 
* Where it was a complete disaster _**already**_, I reformatted the entire function to 4-space indents and never looked back.
* Where it was **wrong** (like, some misleading tabs or spaces thrown in that didn't line up unless your editor settings matched the author's), I fixed it. (But only if there was a logging call there I was changing anyway.)

And that's all<sup>1</sup>.

#### Notes
1. Only a very slight exaggeration, It also moves around the FFmpegWriter includes so that the `#include "ZmqLogger.h"` call (and any other source-only includes) happens in the implementation file, instead of the header. I thought I'd already done that for all of the classes, but I guess I missed that one.
