### PR TITLE
Add QtImageReader(QImage) constructor, setters, and a convenience header for unit tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -253,6 +253,7 @@ if (ENABLE_COVERAGE AND DEFINED UNIT_TEST_TARGETS)
     "${CMAKE_CURRENT_BINARY_DIR}/src/*_autogen/*"
     "${CMAKE_CURRENT_BINARY_DIR}/src/protobuf_messages/*"
     "audio/*"
+    "tests/test_utils.h"
   )
   setup_target_for_coverage_lcov(
     NAME coverage

--- a/src/QtImageReader.cpp
+++ b/src/QtImageReader.cpp
@@ -60,15 +60,14 @@ void QtImageReader::Open()
 
     if (path.isEmpty() && image && !image->isNull()) {
         // We already have an image
-        loaded = true;
         image_size = image->size();
     } else {
+	bool loaded = false;
         // Check for SVG files and rasterizing them to QImages
-        if (path.toLower().endsWith(".svg") || path.toLower().endsWith(".svgz")) {
+        const auto path_check = path.toLower();
+        if (path_check.endsWith(".svg") || path_check.endsWith(".svgz")) {
             image_size = load_svg_path(path);
-            if (!image_size.isEmpty()) {
-                loaded = true;
-            }
+	    loaded = !image_size.isEmpty();
         }
 
         if (!loaded) {
@@ -91,12 +90,12 @@ void QtImageReader::Open()
     info.has_audio = false;
     info.has_video = true;
     info.has_single_image = true;
-    #if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
-        // byteCount() is deprecated from Qt 5.10
-        info.file_size = image->sizeInBytes();
-    #else
-        info.file_size = image->byteCount();
-    #endif
+#if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
+    // byteCount() is deprecated from Qt 5.10
+    info.file_size = image->sizeInBytes();
+#else
+    info.file_size = image->byteCount();
+#endif
     info.vcodec = "QImage";
 
     if (!image_size.isEmpty()) {

--- a/src/QtImageReader.h
+++ b/src/QtImageReader.h
@@ -38,110 +38,112 @@
 
 namespace openshot
 {
-    // Forward decl
-    class CacheBase;
-    class Frame;
 
-	/**
-	 * @brief This class uses the Qt library, to open image files, and return
-	 * openshot::Frame objects containing the image.
-	 *
-	 * @code
-	 * // Create a reader for a video
-	 * QtImageReader r("MyAwesomeImage.jpeg");
-	 * r.Open(); // Open the reader
-	 *
-	 * // Get frame number 1 from the video
-	 * std::shared_ptr<Frame> f = r.GetFrame(1);
-	 *
-	 * // Now that we have an openshot::Frame object, lets have some fun!
-	 * f->Display(); // Display the frame on the screen
-	 *
-	 * // Close the reader
-	 * r.Close();
-	 * @endcode
-	 */
-	class QtImageReader : public ReaderBase
-	{
-	private:
-		QString path;
-		std::shared_ptr<QImage> image;			///> Original image (full quality)
-		std::shared_ptr<QImage> cached_image;	///> Scaled for performance
-		bool is_open;	///> Is Reader opened
-		QSize max_size;	///> Current max_size as calculated with Clip properties
+// Forward decl
+class CacheBase;
+class Frame;
+
+/**
+ * @brief This class uses the Qt library, to open image files, and return
+ * openshot::Frame objects containing the image.
+ *
+ * @code
+ * // Create a reader for a video
+ * QtImageReader r("MyAwesomeImage.jpeg");
+ * r.Open(); // Open the reader
+ *
+ * // Get frame number 1 from the video
+ * std::shared_ptr<Frame> f = r.GetFrame(1);
+ *
+ * // Now that we have an openshot::Frame object, lets have some fun!
+ * f->Display(); // Display the frame on the screen
+ *
+ * // Close the reader
+ * r.Close();
+ * @endcode
+ */
+class QtImageReader : public ReaderBase
+{
+
+private:
+	QString path;
+	std::shared_ptr<QImage> image;			///> Original image (full quality)
+	std::shared_ptr<QImage> cached_image;	///> Scaled for performance
+	bool is_open;	///> Is Reader opened
+	QSize max_size;	///> Current max_size as calculated with Clip properties
 
 #if RESVG_VERSION_MIN(0, 11)
-        ResvgOptions resvg_options;
+	ResvgOptions resvg_options;
 #endif
 
-		/// Load an SVG file with Resvg or fallback with Qt
-        ///
-        /// @returns Success as a boolean
-        /// @param path The file path of the SVG file
-        QSize load_svg_path(QString path);
+	/// Load an SVG file with Resvg or fallback with Qt
+	///
+	/// @returns Success as a boolean
+	/// @param path The file path of the SVG file
+	QSize load_svg_path(QString path);
 
-		/// Calculate the max_size QSize, based on parent timeline and parent clip settings
-		QSize calculate_max_size();
+	/// Calculate the max_size QSize, based on parent timeline and parent clip settings
+	QSize calculate_max_size();
 
-		/// Cycle the reader through the open/closed states
-		///
-		/// This will cause it to re-read the image file from disk
-		/// (if a \a path was set), and re-compute metadata properties
-        ///
-        /// @param leave_open Whether the final state should be open or closed
-		void Reload(bool leave_open);
+	/// Cycle the reader through the open/closed states
+	///
+	/// This will cause it to re-read the image file from disk
+	/// (if a \a path was set), and re-compute metadata properties
+	///
+	/// @param leave_open Whether the final state should be open or closed
+	void Reload(bool leave_open);
 
-	public:
-		/// @brief Constructor for QtImageReader.
-		///
-		/// Opens the media file to inspect its properties and loads frame 1,
-		/// iff \a inspect_reader == true (the default). Pass a false value in
-		/// the optional parameter to defer this initial Open()/Close() cycle.
-		///
-		/// When not inspecting the media file, it's much faster, and useful
-		/// when you are inflating the object using JSON after instantiation.
-		QtImageReader(std::string path, bool inspect_reader=true);
+public:
+	/// @brief Constructor for QtImageReader.
+	///
+	/// Opens the media file to inspect its properties and loads frame 1,
+	/// iff \a inspect_reader == true (the default). Pass a false value in
+	/// the optional parameter to defer this initial Open()/Close() cycle.
+	///
+	/// When not inspecting the media file, it's much faster, and useful
+	/// when you are inflating the object using JSON after instantiation.
+	QtImageReader(std::string path, bool inspect_reader=true);
 
-		/// Constructor which takes an existing QImage
-		explicit QtImageReader(const QImage&, bool inspect=true);
+	/// Constructor which takes an existing QImage
+	explicit QtImageReader(const QImage&, bool inspect=true);
 
-		virtual ~QtImageReader() = default;
+	virtual ~QtImageReader() = default;
 
-		/// Close File
-		void Close() override;
+	/// Close File
+	void Close() override;
 
-		/// Get the cache object used by this reader (always returns NULL for this object)
-		CacheBase* GetCache() override { return NULL; };
+	/// Get the cache object used by this reader (always returns NULL for this object)
+	CacheBase* GetCache() override { return NULL; };
 
-		/// Get an openshot::Frame object for a specific frame number of this reader.  All numbers
-		/// return the same Frame, since they all share the same image data.
-		///
-		/// @returns The requested frame (containing the image)
-		/// @param requested_frame The frame number that is requested.
-		std::shared_ptr<Frame> GetFrame(int64_t requested_frame) override;
+	/// Get an openshot::Frame object for a specific frame number of this reader.  All numbers
+	/// return the same Frame, since they all share the same image data.
+	///
+	/// @returns The requested frame (containing the image)
+	/// @param requested_frame The frame number that is requested.
+	std::shared_ptr<Frame> GetFrame(int64_t requested_frame) override;
 
-		/// Provide a new image file path to the Reader
-		void SetPath(const std::string& new_path);
+	/// Provide a new image file path to the Reader
+	void SetPath(const std::string& new_path);
 
-		/// Supply (or replace) the QImage used as the image source
-		void SetQImage(const QImage& new_image);
+	/// Supply (or replace) the QImage used as the image source
+	void SetQImage(const QImage& new_image);
 
-		/// Determine if reader is open or closed
-		bool IsOpen() override { return is_open; };
+	/// Determine if reader is open or closed
+	bool IsOpen() override { return is_open; };
 
-		/// Return the type name of the class
-		std::string Name() override { return "QtImageReader"; };
+	/// Return the type name of the class
+	std::string Name() override { return "QtImageReader"; };
 
-		// Get and Set JSON methods
-		std::string Json() const override; ///< Generate JSON string of this object
-		void SetJson(const std::string value) override; ///< Load JSON string into this object
-		Json::Value JsonValue() const override; ///< Generate Json::Value for this object
-		void SetJsonValue(const Json::Value root) override; ///< Load Json::Value into this object
+	// Get and Set JSON methods
+	std::string Json() const override; ///< Generate JSON string of this object
+	void SetJson(const std::string value) override; ///< Load JSON string into this object
+	Json::Value JsonValue() const override; ///< Generate Json::Value for this object
+	void SetJsonValue(const Json::Value root) override; ///< Load Json::Value into this object
 
-		/// Open File - which is called by the constructor automatically
-		void Open() override;
-	};
+	/// Open File - which is called by the constructor automatically
+	void Open() override;
+};
 
-}
+}  // namespace openshot
 
-#endif
+#endif  // OPENSHOT_QTIMAGE_READER_H

--- a/src/QtImageReader.h
+++ b/src/QtImageReader.h
@@ -16,6 +16,7 @@
 #include <memory>
 #include <string>
 
+#include <QImage>
 #include <QString>
 #include <QSize>
 
@@ -34,17 +35,6 @@
 #else
     #define RESVG_VERSION_MIN(a, b) 0
 #endif
-
-class QImage;
-
-#include <QImage>
-#include <QSize>
-#include <QString>
-
-#include <QSize>
-#include <QString>
-
-class QImage;
 
 namespace openshot
 {
@@ -91,20 +81,31 @@ namespace openshot
         QSize load_svg_path(QString path);
 
 		/// Calculate the max_size QSize, based on parent timeline and parent clip settings
-        QSize calculate_max_size();
+		QSize calculate_max_size();
+
+		/// Cycle the reader through the open/closed states
+		///
+		/// This will cause it to re-read the image file from disk
+		/// (if a \a path was set), and re-compute metadata properties
+        ///
+        /// @param leave_open Whether the final state should be open or closed
+		void Reload(bool leave_open);
 
 	public:
 		/// @brief Constructor for QtImageReader.
 		///
 		/// Opens the media file to inspect its properties and loads frame 1,
-		/// iff inspect_reader == true (the default). Pass a false value in
+		/// iff \a inspect_reader == true (the default). Pass a false value in
 		/// the optional parameter to defer this initial Open()/Close() cycle.
 		///
 		/// When not inspecting the media file, it's much faster, and useful
 		/// when you are inflating the object using JSON after instantiation.
 		QtImageReader(std::string path, bool inspect_reader=true);
 
-		virtual ~QtImageReader();
+		/// Constructor which takes an existing QImage
+		explicit QtImageReader(const QImage&, bool inspect=true);
+
+		virtual ~QtImageReader() = default;
 
 		/// Close File
 		void Close() override;
@@ -118,6 +119,12 @@ namespace openshot
 		/// @returns The requested frame (containing the image)
 		/// @param requested_frame The frame number that is requested.
 		std::shared_ptr<Frame> GetFrame(int64_t requested_frame) override;
+
+		/// Provide a new image file path to the Reader
+		void SetPath(const std::string& new_path);
+
+		/// Supply (or replace) the QImage used as the image source
+		void SetQImage(const QImage& new_image);
 
 		/// Determine if reader is open or closed
 		bool IsOpen() override { return is_open; };

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -81,6 +81,9 @@ foreach(tname ${OPENSHOT_TESTS})
   target_compile_definitions(openshot-${tname}-test PRIVATE
     TEST_MEDIA_PATH="${TEST_MEDIA_PATH}"
   )
+  target_include_directories(openshot-${tname}-test PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}
+  )
   target_link_libraries(openshot-${tname}-test Catch2::Catch2 openshot)
 
   # Automatically configure CTest targets from Catch2 test cases

--- a/tests/ChromaKey.cpp
+++ b/tests/ChromaKey.cpp
@@ -17,16 +17,10 @@
 #include "Frame.h"
 #include "effects/ChromaKey.h"
 
+#include "test_utils.h"
+
 #include <QColor>
 #include <QImage>
-
-// Stream output formatter for QColor, needed so Catch2 can display
-// values when CHECK(qcolor1 == qcolor2) comparisons fail
-std::ostream& operator << ( std::ostream& os, QColor const& value ) {
-    os << "QColor(" << value.red() << ", " << value.green() << ", "
-       << value.blue() << ", " << value.alpha() << ")";
-    return os;
-}
 
 #include <catch2/catch.hpp>
 

--- a/tests/QtImageReader.cpp
+++ b/tests/QtImageReader.cpp
@@ -105,13 +105,21 @@ TEST_CASE( "Set path or image", "[libopenshot][qtimagereader]" )
     QImage imgB(QString::fromStdString(pathB.str()));
     openshot::QtImageReader r(pathB.str());
     r.Open();
+#if QT_VERSION > QT_VERSION_CHECK(5, 10, 0)
     CHECK(r.info.file_size == imgB.sizeInBytes());
+#else
+    CHECK(r.info.file_size == imgB.byteCount());
+#endif
     CHECK(imgB.size() == QSize(r.info.width, r.info.height));
 
     // Ignored update with bad input
     r.SetPath("");
     CHECK(r.IsOpen());
+#if QT_VERSION > QT_VERSION_CHECK(5, 10, 0)
     CHECK(r.info.file_size == imgB.sizeInBytes());
+#else
+    CHECK(r.info.file_size == imgB.byteCount());
+#endif
 
     // Update with new path
     r.SetPath(pathA.str());

--- a/tests/QtImageReader.cpp
+++ b/tests/QtImageReader.cpp
@@ -12,6 +12,7 @@
 
 #include <catch2/catch.hpp>
 
+#include "test_utils.h"
 #include <QGuiApplication>
 
 #include "QtImageReader.h"

--- a/tests/test_utils.h
+++ b/tests/test_utils.h
@@ -1,0 +1,38 @@
+/**
+ * @file
+ * @brief Utility templates useful when writing tests
+ * @author FeRD (Frank Dana) <ferdnyc@gmail.com>
+ *
+ * @ref License
+ */
+
+// Copyright (c) 2008-2022 OpenShot Studios, LLC
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include <ostream>
+#include <iomanip>
+
+#include <QColor>
+#include <QSize>
+
+// Stream output formatter for QColor.
+//
+// This allows Catch2 to display values when
+// CHECK(qcolor1 == qcolor2) comparisons fail.
+// No setup is required, just include this header.
+std::ostream& operator<<(std::ostream& os, const QColor& value)
+{
+    os << std::unitbuf;  // Don't auto-flush on destruction
+    os << "QColor(" << value.red() << ", " << value.green() << ", "
+       << value.blue() << ", " << value.alpha() << ")";
+    return os;
+}
+
+// Same for QSize
+std::ostream& operator<<(std::ostream& os, const QSize& size)
+{
+    os << std::unitbuf;
+    os << "QSize(" << size.width() << ", " << size.height() << ")";
+    return os;
+}


### PR DESCRIPTION
Stemming from conversations over at #791, this PR adds a few things to make writing unit tests for libopenshot more convenient/developer-friendly:

1. **A new constructor overload `QtImageReader(const QImage&, bool inspect=true)`**, which allows QtImageReader to be supplied directly with a `QImage` to use in creating frames, instead of loading a file from disk.
    This is not directly useful to OpenShot (since it isn't accessible from the Python code via the class's JSON interface), but provides a far simpler way to construct unit test data than the `DummyReader`. (Which has to be supplied with a `CacheBase` object and filled with `Frame` objects for individual output frames; `QtImageReader` needs only an image, and will generate as many frames as necessary.)
1. A new header file, `tests/test_utils.h`, which can be included in any unit test file. It contains stream output operator overloads for (so far) `QColor` and `QSize`, allowing those types to be used directly in Catch2 `CHECK()` calls without sacrificing useful reporting. (See below for more info.) Other types can be added as needs arise.
1. Expanded unit testing for QtImageReader covers all of the new code, plus more of what previously lacked test covered.

### QtImageReader

#### Non-shared-pointer `QImage`
As I noted, the `QtImageReader` constructor takes a bare `QImage` (by `const` reference), _not_ a `std::shared_ptr<QImage>`. The reason for this is simple: **QImage is one of several Qt types that are [implicitly shared by design](https://doc.qt.io/qt-5/implicit-sharing.html)**, and our own `std::shared_ptr` wrapping of the class is a wholly-unnecessary leftover from way back when it was used to replace the previous frame image datatype, `Magick::Image`. (Which _does_ need to be wrapped in a smart pointer to avoid memory leaks.)

Back in 2015 when the change was made (b612f333), `std::shared_ptr<Magick::Image>` became `std::shared_ptr<QImage>` (actually, at the time it was `tr1::shared_ptr`)... then inertia set in, leaving it that way. And so it remains, over 7 years later.

Ideally, we would _**un**_-wrap all of our `QImage` objects at some point, but that will require effort and careful testing. The opportunity was available to not continue the same error when passing an image to `QtImageReader()`, though, so I took it. (As things currently stand, `QtImageReader` takes that `QImage` reference and wraps it in a `std::shared_ptr` _anyway_, since that's still how its member storage is still defined.)

#### Other methods
I also added methods to QtImageReader to _change_ its stored image, by supplying either a new `path` string to load from  disk, or a new `QImage` to generate frames with: `QtImageReader::SetPath(const std::string& new_path)` and `QtImageReader::SetQImage(const QImage& new_image)`.

Again, this is intended primarily for unit testing convenience, not for OpenShot use. (It could already update the `path` via JSON, and still can just as before.) But the new methods potentially make it easier to set up a Timeline with multiple Clips, then vary the frames produced by the Reader(s) in order to test different aspects.

(Granted, too much of that would make for poorly-compartmentalized testing, though potentially that timeline could be set up as a [test fixture](https://catch2.docsforge.com/v2.13.2/writing-tests/test-fixtures/#defining-test-fixtures) for use by multiple test cases.)

### Stream output operators

The advantage to defining stream output operators for types being evaluated by Catch2 is that it makes the output more readable when tests _fail_. As I noted in https://github.com/OpenShot/libopenshot/pull/791#issuecomment-1010580800 while a Catch2 comparison between two QColors _without_ the stream operator looks like this:
```text
tests/ChromaKey.cpp:69: FAILED:
  CHECK( pix_e == expected )
with expansion:
  {?} == {?}
```
**with** the stream operator, it looks like this:
```text
tests/ChromaKey.cpp:69: FAILED:
  CHECK( pix_e == expected )
with expansion:
  QColor(0, 204, 0, 255)
  ==
  QColor(0, 192, 0, 255)
```
that's _very_ readable, compared to CheckPixel which looks like this:
```text
tests/FFmpegReader.cpp:95: FAILED:
  CHECK( f->CheckPixel(10, 112, 21, 191, 84, 255, 5) == true )
with expansion:
  false == true
```

Of course, the stream operator alone doesn't make it possible to test `QColor` or any other class with _fuzzy_ values... for that, we'd need to add a Catch2 [Matcher](https://catch2.docsforge.com/v2.13.2/writing-tests/matchers/#custom-matchers). (But it **is** possible to do that as well, is the real point.) And stream operators can be added for any other classes that support useful comparison via arithmetic operations like `==`, `!=`, `<`, `>`, etc., 

#### Testing complex types
It turns out, as a general rule, that it's not only quicker to test complex types _directly_ inside `CHECK()` calls, rather than breaking them down and comparing individual values one at a time "by hand", but it's also _better_ to do it that way. As long as the operands can be represented as strings in the Catch2 output, the failure reporting is far more robust with more complex types. (See above.)

If I'd written the test as four `CHECK(color1.red() == color2.red())`, `CHECK(color1.green() == color2.green())`, etc. calls, then when the colors don't match either the output is four times as verbose, and therefore harder to read, **or** only the non-matching channels are shown without the larger context of the entire color value. Either way, it's less useful information when trying to track down the problem.

cc: @nilp0inter for #791