### PR TITLE
Fix none double scaling

### DIFF
--- a/src/Clip.cpp
+++ b/src/Clip.cpp
@@ -1459,8 +1459,12 @@ QTransform Clip::get_transform(std::shared_ptr<Frame> frame, int width, int heig
 		sy*= parentObject_scale_y;
 	}
 
-    float scaled_source_width = source_size.width() * sx;
-	float scaled_source_height = source_size.height() * sy;
+	float scaled_source_width = source_size.width();
+	float scaled_source_height = source_size.height();
+	if (scale != SCALE_NONE) {
+		scaled_source_width *= sx;
+		scaled_source_height *= sy;
+	}
 
 	switch (gravity)
 	{
@@ -1528,11 +1532,13 @@ QTransform Clip::get_transform(std::shared_ptr<Frame> frame, int width, int heig
 		transform.translate(-origin_x_offset,-origin_y_offset);
 	}
 	// SCALE CLIP (if needed)
-	float source_width_scale = (float(source_size.width()) / float(source_image->width())) * sx;
-	float source_height_scale = (float(source_size.height()) / float(source_image->height())) * sy;
-	if (!isEqual(source_width_scale, 1.0) || !isEqual(source_height_scale, 1.0)) {
-		transform.scale(source_width_scale, source_height_scale);
+	if (scale != SCALE_NONE) {
+		float source_width_scale = (float(source_size.width()) / float(source_image->width())) * sx;
+		float source_height_scale = (float(source_size.height()) / float(source_image->height())) * sy;
+		if (!isEqual(source_width_scale, 1.0) || !isEqual(source_height_scale, 1.0)) {
+			transform.scale(source_width_scale, source_height_scale);
+		}
 	}
 
-    return transform;
+	return transform;
 }

--- a/src/Clip.h
+++ b/src/Clip.h
@@ -120,6 +120,9 @@ namespace openshot {
 		/// (reader member variable itself may have been replaced)
 		openshot::ReaderBase* allocated_reader;
 
+		/// The type of reader passed to the clip
+		std::string reader_type;
+
 		/// Adjust frame number minimum value
 		int64_t adjust_frame_number_minimum(int64_t frame_number);
 
@@ -149,6 +152,10 @@ namespace openshot {
 
 		/// Reverse an audio buffer
 		void reverse_buffer(juce::AudioBuffer<float>* buffer);
+
+		/// When scale mode is SCALE_NONE, we don't need to scale QtImageReader/FFmpegReader again
+		/// because those readers already scaled before.
+		bool shouldScale() const;
 
 
 	public:


### PR DESCRIPTION
This PR attempts to resolve the following issue: https://github.com/OpenShot/libopenshot/issues/754

There is a problem where QtImageReader and FFmpegReader scale the image or video. The scaling is then done again in the Clip. When the scale type is set to SCALE_NONE, the image or video appears to be scaled twice when it shouldn't be scaled. The issue description demonstrates this.

Also note that other readers, like QtHtmlReader, TextReader, etc.. do not have any scaling functionality so the scaling in the Clip still needs to be applied.

The new code adds a check to see if the scale type is SCALE_NONE and the reader type is QtImageReader or FFmpegReader. If so, it skips the scaling step.

The code resolves the issue but not sure if this is the best approach or the code is particularly clean. It might highlight the issue and give clues to where this could be improved.

