### PR TITLE
CI: Use windows-2022, start with a clean-slate MSYS2 image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
           - { os: ubuntu-18.04, shell: bash }
           - { os: ubuntu-latest, shell: bash }
           - { os: macos-latest, shell: bash }
-          - { os: windows-latest, shell: 'msys2 {0}' }
+          - { os: windows-2022, shell: 'msys2 {0}' }
         compiler:
           - { cc: gcc, cxx: g++ }
           - { cc: clang, cxx: clang++ }
@@ -22,7 +22,7 @@ jobs:
           # Windows clang isn't being our friend,
           # JUCE seems to think it can use _get_tzname there
           # (it can't)
-          - sys: { os: windows-latest, shell: 'msys2 {0}' }
+          - sys: { os: windows-2022, shell: 'msys2 {0}' }
             compiler: { cc: clang, cxx: clang++ }
     defaults:
       run:
@@ -102,11 +102,10 @@ jobs:
         if: ${{ runner.os == 'Windows' }}
         uses: msys2/setup-msys2@v2
         with:
-          release: false
+          release: true
           update: true
           install: >-
               mingw-w64-x86_64-gcc
-              mingw-w64-x86_64-clang
               mingw-w64-x86_64-lld
               mingw-w64-x86_64-make
               mingw-w64-x86_64-cmake


### PR DESCRIPTION
Turns out that when setting up to build on Windows, it's almost 35% faster (**#WhoKnew?**; see msys2/MSYS2-packages#2788) if we start from a clean slate and directly install all 204 packages that make up our build environment. (That's the total count after dependency resolution.) Using a preinstalled MSYS2 package set, we have to update all of those packages _first_ (a slow process), before we can even start our own installs.

(When I say 35% faster, I mean the _package setup_ phase on Windows drops from ~ `9m 10s` to ~ `6m 10s`. The entire job runtime is still around `22m - 25m`, down from `25m - 30m`, so this only represents a 10-15% speedup overall. But still, that's 15% less thumb-twiddling time waiting for CI runs to complete.)