### PR TITLE
Win CI: Prune Qt5 package set

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,10 @@ jobs:
               mingw-w64-x86_64-make
               mingw-w64-x86_64-cmake
               mingw-w64-x86_64-pkgconf
-              mingw-w64-x86_64-qt5
+              mingw-w64-x86_64-qt5-base
+              mingw-w64-x86_64-qt5-svg
+              mingw-w64-x86_64-qt5-winextras
+              mingw-w64-x86_64-qt5-tools
               mingw-w64-x86_64-libvpx
               mingw-w64-x86_64-ffmpeg
               mingw-w64-x86_64-zeromq


### PR DESCRIPTION
And, hot on the heels of #799, the MSYS2 team informed me that they've broken up their Qt5 monopackage into separate, per-component packages. (`mingw-w64-x86_64-qt5` is now a metapackage that pulls them all in.)

Which means that, since libopenshot only needs `Qt5{Core, GUI, Widgets}` along with possibly `Qt5Svg`, we can skip installing all the rest of the modules, _and_ any of their dependencies that were only being pulled in for modules we don't use.

<s>(The `mingw-w64-x86_64-python3-pyqt5` package now only requires Qt modules as _optional_ dependencies, so a similar pruning should be possible for the OpenShot build as well! We'll have to pull in a few more modules there (Webkit, WebChannel, WebView, translations...) but still far fewer than **all** of them.)</s>

**Edit:** Oh, right... I forgot. What I meant was, "Someday, if we actually _have_ OpenShot CI jobs running on Windows, we'll be able to use a reduced package set there as well." **#DareToDream**