### PR TITLE
WIP: Cache refactor

### DIFF
--- a/src/Qt/PlayerPrivate.cpp
+++ b/src/Qt/PlayerPrivate.cpp
@@ -68,9 +68,13 @@ namespace openshot
             // Calculate on-screen time for a single frame
             const auto frame_duration = double_micro_sec(1000000.0 / reader->info.fps.ToDouble());
             const auto max_sleep = frame_duration * 4; ///< Don't sleep longer than X times a frame duration
+            const int max_frames_ahead = videoCache->MaxFramesAhead(); // TODO: make reader cache size available to this thread
 
+            auto time1 = std::chrono::high_resolution_clock::now();
             // Get the current video frame (if it's different)
             frame = getFrame();
+            auto time2 = std::chrono::high_resolution_clock::now();
+            auto get_frame_time = time2 - time1;
 
             // Pausing Code (if frame has not changed)
             if ((speed == 0 && video_position == last_video_position) || (video_position > reader->info.video_length))
@@ -79,6 +83,9 @@ namespace openshot
                 // Set start time to prepare for next playback period and reset frame counter
                 start_time = std::chrono::high_resolution_clock::now();
                 playback_frames = 0;
+                int count = 0;
+                while (std::chrono::high_resolution_clock::now() < start_time + frame_duration / 4  && (count <= max_frames_ahead))
+                  auto nothing = reader->GetFrame(video_position + count++);
 
                 // Sleep for a fraction of frame duration
                 std::this_thread::sleep_for(frame_duration / 4);
@@ -110,8 +117,19 @@ namespace openshot
             }
 
             // Calculate the diff between 'now' and the predicted frame end time
-            const auto current_time = std::chrono::high_resolution_clock::now();
-            const auto remaining_time = double_micro_sec(start_time + (frame_duration * playback_frames) - current_time);
+            auto current_time = std::chrono::high_resolution_clock::now();
+            auto remaining_time = double_micro_sec( start_time + (frame_duration * playback_frames) - current_time);
+
+            // Cache frames ahead
+            int count = 0;
+            while ((remaining_time > get_frame_time * 2) && count <= max_frames_ahead){
+                // As long as remaining time is more than twice the time to get the last frame, get another
+                count += 1;
+                reader->GetFrame(video_position + count);
+                // Update remaining_time
+                current_time = std::chrono::high_resolution_clock::now();
+                remaining_time = double_micro_sec(start_time + (frame_duration * playback_frames) - current_time);
+            }
 
             // Sleep to display video image on screen
             if (remaining_time > remaining_time.zero() ) {

--- a/src/Qt/VideoCacheThread.cpp
+++ b/src/Qt/VideoCacheThread.cpp
@@ -57,65 +57,15 @@ namespace openshot
     // Start the thread
     void VideoCacheThread::run()
     {
-        // Types for storing time durations in whole and fractional microseconds
-        using micro_sec = std::chrono::microseconds;
-        using double_micro_sec = std::chrono::duration<double, micro_sec::period>;
-
-		while (!threadShouldExit() && is_playing) {
-            // Calculate on-screen time for a single frame
-            const auto frame_duration = double_micro_sec(1000000.0 / reader->info.fps.ToDouble());
-
-            // Calculate bytes per frame. If we have a reference openshot::Frame, use that instead (the preview
-            // window can be smaller, can thus reduce the bytes per frame)
-            int64_t bytes_per_frame = (reader->info.height * reader->info.width * 4) +
-                    (reader->info.sample_rate * reader->info.channels * 4);
-            if (last_cached_frame && last_cached_frame->has_image_data && last_cached_frame->has_audio_data) {
-                bytes_per_frame = last_cached_frame->GetBytes();
-            }
-
-            // Calculate # of frames on Timeline cache
-            if (reader->GetCache() && reader->GetCache()->GetMaxBytes() > 0) {
-                // Use 1/2 the cache size (so our cache will be 50% before the play-head, and 50% after it)
-                max_frames_ahead = (reader->GetCache()->GetMaxBytes() / bytes_per_frame) / 2;
-                if (max_frames_ahead > 1000) {
-                    // Ignore values that are too large, and default to a safer value
-                    max_frames_ahead = OPEN_MP_NUM_PROCESSORS * 2;
-                }
-            }
-
-            // Calculate increment (based on speed)
-            // Support caching in both directions
-            int16_t increment = 1;
-            if (speed < 0) {
-                increment = -1;
-            }
-
-			// Always cache frames from the current display position to our maximum (based on the cache size).
-			// Frames which are already cached are basically free. Only uncached frames have a big CPU cost.
-			// By always looping through the expected frame range, we can fill-in missing frames caused by a
-			// fragmented cache object (i.e. the user clicking all over the timeline).
-            int64_t starting_frame = current_display_frame;
-            int64_t ending_frame = starting_frame + max_frames_ahead;
-            if (speed < 0) {
-                ending_frame = starting_frame - max_frames_ahead;
-            }
-
-            for (int64_t cache_frame = starting_frame; cache_frame != ending_frame; cache_frame += increment) {
-                if (reader && reader->GetCache() && !reader->GetCache()->Contains(cache_frame)) {
-                    try
-                    {
-                        // This frame is not already cached... so request it again (to force the creation & caching)
-                        // This will also re-order the missing frame to the front of the cache
-                        last_cached_frame = reader->GetFrame(cache_frame);
-                    }
-                    catch (const OutOfBoundsFrame & e) {  }
-                }
-            }
-
-			// Sleep for a fraction of frame duration
-			std::this_thread::sleep_for(frame_duration / 4);
-		}
-
-	return;
+      return;
     }
+
+  int VideoCacheThread::MaxFramesAhead() {
+      if (reader && reader->GetCache() && reader->GetCache()->GetMaxBytes() > 0) {
+          int64_t bytes_per_frame = (reader->info.height * reader->info.width * 4) +
+                                    (reader->info.sample_rate * reader->info.channels * 4);
+          return (reader->GetCache()->GetMaxBytes() / bytes_per_frame) / 2;
+      }
+      return 0;
+  }
 }

--- a/src/Qt/VideoCacheThread.h
+++ b/src/Qt/VideoCacheThread.h
@@ -62,6 +62,8 @@ namespace openshot
 	/// Set the current thread's reader
 	void Reader(ReaderBase *new_reader) { reader=new_reader; Play(); };
 
+    int MaxFramesAhead();
+
 	/// Parent class of VideoCacheThread
 	friend class PlayerPrivate;
 	friend class QtPlayer;

--- a/test.sh
+++ b/test.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-#cd build; cmake ../; make -j9; make install;
-
-cmake --build build -j9; cmake --install build;


### PR DESCRIPTION
# Problem
I found that if my frame rate wasn't too high, playback was smoother with the cache thread doing nothing. This might mean that the threads aren't sharing the reader nicely.

# Solution
This is one solution: If the preview thread is going to sleep more than twice the time it took to get the last frame, prepare another.

# Issues
**Note: This is working for me. These issues mainly regard organized code**
1) As is, the cache thread is still there but does nothing. I need find what other places depend on it before removing it.
2) The variables needed to calculate `Max_frames_ahead` aren't currently available to preview thread, so it's calculated by the cache thread.
    - It's messy but it's enough to see if it performs on other's computers.