### PR TITLE
CMake: Permit reconfiguration of build dir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,8 +70,11 @@ option(APPIMAGE_BUILD "Build to install in an AppImage (Linux only)" OFF)
 
 option(USE_SYSTEM_JSONCPP "Use system installed JsonCpp, if found" ON)
 option(DISABLE_BUNDLED_JSONCPP "Don't fall back to bundled JsonCpp" OFF)
+
+option(ENABLE_BABL "Use the babl colorspace library, if available" ON)
 option(ENABLE_MAGICK "Use ImageMagick, if available" ON)
 option(ENABLE_OPENCV "Build with OpenCV algorithms (requires Boost, Protobuf 3)" ON)
+option(ENABLE_RESVG "Use the Rust SVG renderer Resvg (set Resvg_ROOT to dir)" ON)
 option(USE_HW_ACCEL "Enable hardware-accelerated encoding-decoding with FFmpeg 3.4+" ON)
 
 # Legacy commandline override

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,6 +74,7 @@ option(DISABLE_BUNDLED_JSONCPP "Don't fall back to bundled JsonCpp" OFF)
 option(ENABLE_BABL "Use the babl colorspace library, if available" ON)
 option(ENABLE_MAGICK "Use ImageMagick, if available" ON)
 option(ENABLE_OPENCV "Build with OpenCV algorithms (requires Boost, Protobuf 3)" ON)
+option(ENABLE_OPENMP "Use OpenMP parallelism" ON)
 option(ENABLE_RESVG "Use the Rust SVG renderer Resvg (set Resvg_ROOT to dir)" ON)
 option(USE_HW_ACCEL "Enable hardware-accelerated encoding-decoding with FFmpeg 3.4+" ON)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -230,10 +230,12 @@ if (ENABLE_MAGICK)
     # Link with ImageMagick library
     target_link_libraries(openshot PUBLIC ImageMagick::Magick++)
 
-    set(HAVE_IMAGEMAGICK TRUE CACHE BOOL "Building with ImageMagick support" FORCE)
-    mark_as_advanced(HAVE_IMAGEMAGICK)
   endif()
+else()
+  set(ImageMagick_FOUND FALSE)
 endif()
+set(HAVE_IMAGEMAGICK ${ImageMagick_FOUND} CACHE BOOL "Building with ImageMagick support" FORCE)
+mark_as_advanced(HAVE_IMAGEMAGICK)
 
 ################### JSONCPP #####################
 # Include jsoncpp headers (needed for JSON parsing)
@@ -294,10 +296,10 @@ if (TARGET Resvg::Resvg)
   target_compile_definitions(openshot PUBLIC USE_RESVG=1)
 
   set(HAVE_RESVG TRUE CACHE BOOL "Building with Resvg support" FORCE)
-  mark_as_advanced(HAVE_RESVG)
 else()
   set(HAVE_RESVG FALSE CACHE BOOL "Building with Resvg support" FORCE)
 endif()
+mark_as_advanced(HAVE_RESVG)
 
 ###
 ### Qt Toolkit
@@ -432,10 +434,8 @@ endif()
 # Find babl library for colourspace conversion (used for advanced chroma keying
 find_package(babl)
 
-if (babl_FOUND)
-  set(HAVE_BABL TRUE CACHE BOOL "Building with babl support" FORCE)
-  mark_as_advanced(HAVE_BABL)
-endif()
+set(HAVE_BABL ${babl_FOUND} CACHE BOOL "Building with babl support" FORCE)
+mark_as_advanced(HAVE_BABL)
 
 if (TARGET babl_lib)
   target_compile_definitions(openshot PUBLIC USE_BABL=1)
@@ -455,6 +455,7 @@ OpenCV version 4.5.1 contains header errors which make it unable to be used with
 See https://github.com/opencv/opencv/issues/19260]])
     set(ENABLE_OPENCV FALSE CACHE BOOL
       "Build with OpenCV algorithms (requires Protobuf 3)" FORCE)
+    set(OpenCV_FOUND FALSE)
   else()
     ###
     ### Protocol Buffers
@@ -497,8 +498,6 @@ See https://github.com/opencv/opencv/issues/19260]])
       opencv_dnn
       opencv_tracking
     )
-    set(HAVE_OPENCV TRUE CACHE BOOL "Building with OpenCV effects" FORCE)
-    mark_as_advanced(HAVE_OPENCV)
 
     # Keep track of OpenCV version, to embed in our version header
     set(OPENCV_VERSION_STR "${OpenCV_VERSION}" CACHE STRING "OpenCV version linked with" FORCE)
@@ -510,7 +509,12 @@ See https://github.com/opencv/opencv/issues/19260]])
     endif()
 
   endif()
+else()
+  set(OpenCV_FOUND FALSE)
 endif()  # ENABLE_OPENCV
+
+set(HAVE_OPENCV ${OpenCV_FOUND} CACHE BOOL "Building with OpenCV effects" FORCE)
+mark_as_advanced(HAVE_OPENCV)
 add_feature_info("OpenCV algorithms" ENABLE_OPENCV "Use OpenCV algorithms")
 
 ###############  LINK LIBRARY  #################

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -396,18 +396,31 @@ endif()
 ################### OPENMP #####################
 # Check for OpenMP (used for multi-core processing)
 
-# OpenMP is required by FFmpegReader/Writer
-find_package(OpenMP REQUIRED)
+if(NOT DEFINED REQUIRED_OPENMP_OVERRIDE OR NOT REQUIRED_OPENMP_OVERRIDE)
+  # OpenMP is required unless explicitly disabled
+  set_package_properties(OpenMP PROPERTIES TYPE REQUIRED)
+  set(ENABLE_OPENMP TRUE)
+endif()
 
-if(NOT TARGET OpenMP::OpenMP_CXX)
+if(ENABLE_OPENMP)
+  find_package(OpenMP)
+  if(OpenMP_FOUND AND NOT TARGET OpenMP::OpenMP_CXX)
     # Older CMake versions (< 3.9) don't create find targets.
     add_library(OpenMP_TARGET INTERFACE)
     add_library(OpenMP::OpenMP_CXX ALIAS OpenMP_TARGET)
     target_compile_options(OpenMP_TARGET INTERFACE ${OpenMP_CXX_FLAGS})
     target_link_libraries(OpenMP_TARGET INTERFACE ${OpenMP_CXX_FLAGS})
+  endif()
+  if(TARGET OpenMP::OpenMP_CXX)
+    target_link_libraries(openshot PUBLIC OpenMP::OpenMP_CXX)
+    target_compile_definitions(openshot PUBLIC USE_OPENMP=1)
+  endif()
+else()
+  set(OpenMP_FOUND FALSE)
 endif()
 
-target_link_libraries(openshot PUBLIC OpenMP::OpenMP_CXX)
+set(HAVE_OPENMP ${OpenMP_FOUND} CACHE BOOL "Build with support for parllel algorithms" FORCE)
+mark_as_advanced(HAVE_OPENMP)
 
 ###
 ### ZeroMQ

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -285,20 +285,22 @@ if(DEFINED ENV{RESVGDIR} AND NOT DEFINED Resvg_ROOT)
   set(Resvg_ROOT $ENV{RESVGDIR})
 endif()
 
-# Find resvg library (used for rendering svg files)
-find_package(Resvg)
+if(ENABLE_RESVG)
+  # Find resvg library (used for rendering svg files)
+  find_package(Resvg)
 
-# Include resvg headers (optional SVG library)
-if (TARGET Resvg::Resvg)
-  #include_directories(${Resvg_INCLUDE_DIRS})
-  target_link_libraries(openshot PUBLIC Resvg::Resvg)
+  # Include resvg headers (optional SVG library)
+  if (TARGET Resvg::Resvg)
+    #include_directories(${Resvg_INCLUDE_DIRS})
+    target_link_libraries(openshot PUBLIC Resvg::Resvg)
 
-  target_compile_definitions(openshot PUBLIC USE_RESVG=1)
-
-  set(HAVE_RESVG TRUE CACHE BOOL "Building with Resvg support" FORCE)
+    target_compile_definitions(openshot PUBLIC USE_RESVG=1)
+  endif()
 else()
-  set(HAVE_RESVG FALSE CACHE BOOL "Building with Resvg support" FORCE)
+  set(Resvg_FOUND FALSE)
 endif()
+
+set(HAVE_RESVG ${Resvg_FOUND} CACHE BOOL "Building with Resvg support" FORCE)
 mark_as_advanced(HAVE_RESVG)
 
 ###
@@ -431,16 +433,20 @@ endif()
 ### Babl
 ###
 
-# Find babl library for colourspace conversion (used for advanced chroma keying
-find_package(babl)
+if (ENABLE_BABL)
+  # Find babl colourspace conversion lib (used for advanced chroma keying
+  find_package(babl)
+
+  if (TARGET babl_lib)
+    target_compile_definitions(openshot PUBLIC USE_BABL=1)
+    target_link_libraries(openshot PUBLIC babl_lib)
+  endif ()
+else()
+  set(babl_FOUND FALSE)
+endif()
 
 set(HAVE_BABL ${babl_FOUND} CACHE BOOL "Building with babl support" FORCE)
 mark_as_advanced(HAVE_BABL)
-
-if (TARGET babl_lib)
-  target_compile_definitions(openshot PUBLIC USE_BABL=1)
-  target_link_libraries(openshot PUBLIC babl_lib)
-endif ()
 
 ################## OPENCV ###################
 if(ENABLE_OPENCV)

--- a/src/OpenMPUtilities.h
+++ b/src/OpenMPUtilities.h
@@ -13,22 +13,29 @@
 #ifndef OPENSHOT_OPENMP_UTILITIES_H
 #define OPENSHOT_OPENMP_UTILITIES_H
 
-#include <omp.h>
-#include <algorithm>
-#include <string>
+#ifdef USE_OPENMP
+  #include <omp.h>
+  #include <algorithm>
+  #include <string>
 
-#include "Settings.h"
+  #include "Settings.h"
 
-// Calculate the # of OpenMP Threads to allow
-#define OPEN_MP_NUM_PROCESSORS (std::min(omp_get_num_procs(), std::max(2, openshot::Settings::Instance()->OMP_THREADS) ))
-#define FF_NUM_PROCESSORS (std::min(omp_get_num_procs(), std::max(2, openshot::Settings::Instance()->FF_THREADS) ))
+  // Calculate the # of OpenMP Threads to allow
+  #define OPEN_MP_NUM_PROCESSORS (std::min(omp_get_num_procs(), std::max(2, openshot::Settings::Instance()->OMP_THREADS) ))
+  #define FF_NUM_PROCESSORS (std::min(omp_get_num_procs(), std::max(2, openshot::Settings::Instance()->FF_THREADS) ))
 
-// Set max-active-levels to the max supported, if possible
-// (supported_active_levels is OpenMP 5.0 (November 2018) or later, only.)
-#if (_OPENMP >= 201811)
-  #define OPEN_MP_MAX_ACTIVE omp_get_supported_active_levels()
-#else
-  #define OPEN_MP_MAX_ACTIVE OPEN_MP_NUM_PROCESSORS
-#endif
+  // Set max-active-levels to the max supported, if possible
+  // (supported_active_levels is OpenMP 5.0 (November 2018) or later, only.)
+  #if (_OPENMP >= 201811)
+    #define OPEN_MP_MAX_ACTIVE omp_get_supported_active_levels()
+  #else
+    #define OPEN_MP_MAX_ACTIVE OPEN_MP_NUM_PROCESSORS
+  #endif
+
+#else  // USE_OPENMP
+  #define OPEN_MP_NUM_PROCESSORS 1
+  #define FF_NUM_PROCESSORS 1
+  #define OPEN_MP_MAX_ACTIVE 1
+#endif  // USE_OPENMP
 
 #endif

--- a/src/OpenShotVersion.h.in
+++ b/src/OpenShotVersion.h.in
@@ -34,6 +34,7 @@
 #cmakedefine01 HAVE_IMAGEMAGICK
 #cmakedefine01 HAVE_RESVG
 #cmakedefine01 HAVE_OPENCV
+#cmakedefine01 HAVE_OPENMP
 #cmakedefine01 FFMPEG_USE_SWRESAMPLE
 #cmakedefine01 APPIMAGE_BUILD
 

--- a/src/Timeline.cpp
+++ b/src/Timeline.cpp
@@ -18,6 +18,7 @@
 #include "CrashHandler.h"
 #include "FrameMapper.h"
 #include "Exceptions.h"
+#include "Settings.h"
 
 #include <QDir>
 #include <QFileInfo>
@@ -824,10 +825,16 @@ std::shared_ptr<Frame> Timeline::GetFrame(int64_t requested_frame)
 		nearby_clips = find_intersecting_clips(requested_frame, 1, true);
 
         // Debug output
+    #ifdef USE_OMP
         ZmqLogger::Instance()->AppendDebugMethod(
             "Timeline::GetFrame (processing frame)",
             "requested_frame", requested_frame,
             "omp_get_thread_num()", omp_get_thread_num());
+    #else
+        ZmqLogger::Instance()->AppendDebugMethod(
+            "Timeline::GetFrame (processing frame)",
+            "requested_frame", requested_frame);
+    #endif
 
         // Init some basic properties about this frame
         int samples_in_frame = Frame::GetSamplesPerFrame(requested_frame, info.fps, info.sample_rate, info.channels);


### PR DESCRIPTION
The way our build system has been tracking optional components' availability works for one-shot CI builds and from-scratch configurations, but it breaks if you try to reconfigure an existing build dir's optional components.

e.g., if you were to run this:
```sh
cmake -B build -S . -DENABLE_OPENCV=0
```
on a `build` dir that had already been configured to use OpenCV, subsequent compiles would break because it was still looking for OpenCV pieces in things like the unit tests. The only recourse was to blow away the `CMakeCache.txt` file and regenerate everything.

This PR fixes that by making sure that the `HAVE_FOO` cache variables we use to track optional components are updated during every config run. This permits subsequent reconfigurations to disable something that was previously enabled.

I also decided to:
  * Add `ENABLE_BABL` and `ENABLE_RESVG` switches
    (previously, if they were found on the system they were always used)
    
  * **Make OpenMP optional (with caveats)**

That last one is somewhat dangerous, because of the way OpenMP is used in the code.

For the most part, OpenMP is used via `#pragma` messages to the preprocessor, which means if it's not there, those pragmas will simply be ignored (unless you've set the flags to make unknown pragmas an error) and the code will simply proceed without parallelism. That's how it's _supposed_ to work.

However, even though it's no longer used for FFmpegReader/Writer, several parts of the libopenshot code make decisions based on data available from OpenMP, such as processor count. If OpenMP is disabled, **those variables are all defined with a value of `1`**, so that the code doesn't crash when it can't find them. And due to the fact that libopenshot's cache size is computed using processor count (for some reason), the playback threads will configure an extremely small cache, seriously impacting performance.

Because of that, disabling OpenMP in a libopenshot build currently renders it unsuitable for normal use. This experimental build option is intended to be used only when creating test builds or for debugging purposes. Activating it requires setting both the usual `-DENABLE_OPENMP=0` flag on the CMake command line, as well as a second flag, `-DREQUIRED_OPENMP_OVERRIDE=1`.
