### PR TITLE
WIP: Expect caption timestamps relative to the clips position

### DIFF
--- a/src/effects/Caption.cpp
+++ b/src/effects/Caption.cpp
@@ -202,6 +202,9 @@ std::shared_ptr<openshot::Frame> Caption::GetFrame(std::shared_ptr<openshot::Fra
 							   match->captured(3).toFloat() + (match->captured(4).toFloat() / 1000.0)) * fps.ToFloat();
 		int64_t end_frame = ((match->captured(5).toFloat() * 60.0 * 60.0 ) + (match->captured(6).toFloat() * 60.0 ) +
 							 match->captured(7).toFloat() + (match->captured(8).toFloat() / 1000.0)) * fps.ToFloat();
+		// Times are relative to the start of the clip. Add the clip's position to the times.
+		start_frame += clip->Position();
+		end_frame += clip->Position();
 
 		// Split multiple lines into separate paths
 		QStringList lines = match->captured(9).split("\n");


### PR DESCRIPTION
**Closing, because this code was already accounting for the position of it's clip.**

# Issue:
Timestamps took absolute times for when to start and stop displaying.

This meant that they had to be adjusted any time a clip was moved.

# Solution:
Subtract the `position` (the time at the left edge of a clip) before creating the timestamp, and add it back in when calculating when to display the text.

I also created a [PR](https://github.com/OpenShot/openshot-qt/pull/4691) in openshot-qt for subtracting the clip's position before creating the timestamps. (These two PR's need each other to work properly)