### PR TITLE
Don't force the sample rate to 44100, then complain about it

### DIFF
--- a/src/Qt/AudioPlaybackThread.cpp
+++ b/src/Qt/AudioPlaybackThread.cpp
@@ -30,10 +30,10 @@ namespace openshot
 	// Global reference to device manager
 	AudioDeviceManagerSingleton *AudioDeviceManagerSingleton::m_pInstance = NULL;
 
-    // Create or Get audio device singleton with default settings (44100, 2)
+    // Create or Get audio device singleton with default settings (48000, 2)
     AudioDeviceManagerSingleton *AudioDeviceManagerSingleton::Instance()
     {
-        return AudioDeviceManagerSingleton::Instance(44100, 2);
+        return AudioDeviceManagerSingleton::Instance(48000, 2);
     }
 
 	// Create or Get an instance of the device manager singleton (with custom sample rate & channels)


### PR DESCRIPTION
I noticed that OpenShot was now complaining about the 48kHz default sample rate I use, because it was under the impression that my card's default is 44.1kHz. Which I know for a fact is incorrect, but seems like _this_ probably had something to do with it:

https://github.com/OpenShot/libopenshot/blob/f2b89e3254d3db177ad99cef9034eea978d95678/src/Qt/AudioPlaybackThread.cpp#L33-L37

Now, I question the utility of those rate-checks _at all_, since clearly we're not actually checking it against the device's selected rate, we're checking it against the rate **WE'RE** defaulting to. But, we might as well at least default to the same rate everywhere, so we aren't contradicting ourselves.