### PR TITLE
Allow Caching on Initial 'Pause' (based on Timeline cache size)

### DIFF
--- a/src/Qt/VideoCacheThread.cpp
+++ b/src/Qt/VideoCacheThread.cpp
@@ -74,7 +74,7 @@ namespace openshot
         // Types for storing time durations in whole and fractional microseconds
         using micro_sec = std::chrono::microseconds;
         using double_micro_sec = std::chrono::duration<double, micro_sec::period>;
-        bool should_pause = false;
+        bool should_pause_cache = false;
 
 		while (!threadShouldExit() && is_playing) {
             // Calculate on-screen time for a single frame
@@ -84,7 +84,7 @@ namespace openshot
             // Calculate increment (based on speed)
             // Support caching in both directions
             int16_t increment = speed;
-            if (current_speed == 0 && should_pause) {
+            if (current_speed == 0 && should_pause_cache) {
                 // Sleep during pause (after caching additional frames when paused)
                 std::this_thread::sleep_for(frame_duration / 4);
                 continue;
@@ -92,7 +92,7 @@ namespace openshot
             } else if (current_speed == 0) {
                 // Allow 'max frames' to increase when pause is detected (based on cache)
                 // To allow the cache to fill-up only on the initial pause.
-                should_pause = true;
+                should_pause_cache = true;
 
                 // Calculate bytes per frame. If we have a reference openshot::Frame, use that instead (the preview
                 // window can be smaller, can thus reduce the bytes per frame)
@@ -123,7 +123,7 @@ namespace openshot
             } else {
                 // Default max frames ahead (normal playback)
                 max_frames_ahead = 8;
-                should_pause = false;
+                should_pause_cache = false;
             }
 
 			// Always cache frames from the current display position to our maximum (based on the cache size).

--- a/src/QtPlayer.cpp
+++ b/src/QtPlayer.cpp
@@ -227,8 +227,9 @@ namespace openshot
     	speed = new_speed;
     	p->speed = new_speed;
     	p->videoCache->setSpeed(new_speed);
-    	if (p->reader->info.has_audio)
-    		p->audioPlayback->setSpeed(new_speed);
+    	if (p->reader && p->reader->info.has_audio) {
+            p->audioPlayback->setSpeed(new_speed);
+    	}
     }
 
     // Get the Volume


### PR DESCRIPTION
Allow cache on initial pause, to use the Timeline cache size to initially cache a bunch more frames... and then fully pause. This allows for a balance between not-caching during pause (for Transform and Scrubbing performance), but still caching frames on pause so the user can wait for a smoother playback experience.

**Use Cases Supported:**
- When real-time playback is not possible (due to CPU or project complexity), pausing playback will cache a bunch of frames, allowing for very smooth playback once the caching is completed
- Transforming a clip in the preview window (i.e. select a clip, and drag the blue handles) should be very smooth, once initial pause caching has finished.
- Scrubbing the timeline should be very fast (and not laggy)