### PR TITLE
Silence Clip's audio when requesting a Frame past the end of the reader

### DIFF
--- a/src/Clip.cpp
+++ b/src/Clip.cpp
@@ -712,10 +712,14 @@ std::shared_ptr<Frame> Clip::GetOrCreateFrame(int64_t number)
 			// This allows a clip to modify the pixels and audio of this frame without
 			// changing the underlying reader's frame data
 			auto reader_copy = std::make_shared<Frame>(*reader_frame.get());
-                        if (has_video.GetInt(number) == 0)
-                            reader_copy->AddColor(QColor(Qt::transparent));
-                        if (has_audio.GetInt(number) == 0)
-                            reader_copy->AddAudioSilence(reader_copy->GetAudioSamplesCount());
+            if (has_video.GetInt(number) == 0) {
+                // No video, so add transparent pixels
+                reader_copy->AddColor(QColor(Qt::transparent));
+            }
+            if (has_audio.GetInt(number) == 0 || number > reader->info.video_length) {
+                // No audio, so include silence (also, mute audio if past end of reader)
+                reader_copy->AddAudioSilence(reader_copy->GetAudioSamplesCount());
+            }
 			return reader_copy;
 		}
 

--- a/src/DummyReader.h
+++ b/src/DummyReader.h
@@ -87,6 +87,7 @@ namespace openshot
 	private:
 		CacheBase* dummy_cache;
 		std::shared_ptr<openshot::Frame> image_frame;
+        std::shared_ptr<openshot::Frame> last_cached_frame;
 		bool is_open;
 
 		/// Initialize variables used by constructor

--- a/tests/DummyReader.cpp
+++ b/tests/DummyReader.cpp
@@ -21,7 +21,6 @@
 #include "Frame.h"
 
 TEST_CASE( "Default constructor", "[libopenshot][dummyreader]" ) {
-	// Create a default fraction (should be 1/1)
 	openshot::DummyReader r;
 	r.Open(); // Open the reader
 
@@ -41,7 +40,6 @@ TEST_CASE( "Default constructor", "[libopenshot][dummyreader]" ) {
 }
 
 TEST_CASE( "Constructor", "[libopenshot][dummyreader]" ) {
-	// Create a default fraction (should be 1/1)
 	openshot::DummyReader r(openshot::Fraction(30, 1), 1920, 1080, 44100, 2, 60.0);
 	r.Open(); // Open the reader
 
@@ -56,7 +54,6 @@ TEST_CASE( "Constructor", "[libopenshot][dummyreader]" ) {
 }
 
 TEST_CASE( "Blank_Frame", "[libopenshot][dummyreader]" ) {
-	// Create a default fraction (should be 1/1)
 	openshot::DummyReader r(openshot::Fraction(30, 1), 1920, 1080, 44100, 2, 30.0);
 	r.Open(); // Open the reader
 
@@ -96,7 +93,7 @@ TEST_CASE( "Fake_Frame", "[libopenshot][dummyreader]" ) {
 		delete[] audio_buffer;
 	}
 
-	// Create a default fraction (should be 1/1)
+	// Create a dummy reader, with a pre-existing cache
 	openshot::DummyReader r(openshot::Fraction(30, 1), 1920, 1080, 44100, 2, 30.0, &cache);
 	r.Open(); // Open the reader
 
@@ -108,30 +105,6 @@ TEST_CASE( "Fake_Frame", "[libopenshot][dummyreader]" ) {
 	CHECK(r.GetFrame(2)->GetAudioSamples(0)[0] == 2);
 	CHECK(r.GetFrame(2)->GetAudioSamples(0)[1] == Approx(2.00068033).margin(0.00001));
 	CHECK(r.GetFrame(2)->GetAudioSamples(0)[2] == Approx(2.00136054).margin(0.00001));
-
-	// Clean up
-	cache.Clear();
-	r.Close();
-}
-
-TEST_CASE( "Invalid_Fake_Frame", "[libopenshot][dummyreader]" ) {
-	// Create fake frames (with specific frame #, samples, and channels)
-	auto f1 = std::make_shared<openshot::Frame>(1, 1470, 2);
-	auto f2 = std::make_shared<openshot::Frame>(2, 1470, 2);
-
-	// Add test frames to cache object
-	openshot::CacheMemory cache;
-	cache.Add(f1);
-	cache.Add(f2);
-
-	// Create a default fraction (should be 1/1)
-	openshot::DummyReader r(openshot::Fraction(30, 1), 1920, 1080, 44100, 2, 30.0, &cache);
-	r.Open();
-
-	// Verify exception
-	CHECK(r.GetFrame(1)->number == 1);
-	CHECK(r.GetFrame(2)->number == 2);
-	CHECK_THROWS_AS(r.GetFrame(3)->number, openshot::InvalidFile);
 
 	// Clean up
 	cache.Clear();

--- a/tests/FrameMapper.cpp
+++ b/tests/FrameMapper.cpp
@@ -243,7 +243,7 @@ TEST_CASE( "resample_audio_mapper", "[libopenshot][framemapper]" ) {
 		delete[] audio_buffer;
 	}
 
-	// Create a default fraction (should be 1/1)
+	// Create a dummy reader, with a pre-existing cache
 	openshot::DummyReader r(openshot::Fraction(30, 1), 1, 1, 44100, 2, 30.0, &cache);
 	r.Open(); // Open the reader
 
@@ -383,7 +383,7 @@ TEST_CASE( "redistribute_samples_per_frame", "[libopenshot][framemapper]" ) {
 		delete[] audio_buffer;
 	}
 
-	// Create a default fraction (should be 1/1)
+	// Create a dummy reader, with a pre-existing cache
 	openshot::DummyReader r(openshot::Fraction(30, 1), 1920, 1080, 44100, 2, 30.0, &cache);
 	r.Open(); // Open the reader
 


### PR DESCRIPTION
Silence Clip's audio when requesting a Frame past the end of the reader. For example, if a Clip has 1000 frames, and the user requests frame 1001, we will return the last valid openshot::Frame object (repeating the last image), but we don't want to repeat the audio samples (causing a stutter). Any frame past the end of the reader, should always return audio silence. Also, fixed a few invalid comments, and added a Unit test.

This also required removing a unit test which would not allow invalid frames to be requested from a DummyReader object. Since most readers support requesting any frames #'s, regardless of validity, this change actually makes the DummyReader much more similar to our other readers.

This is addressing an issue that many customers have faced on OpenShot Cloud API, which allows customers to easily create a Clip object longer than a File (especially when using templates, and replacing a clip's source asset with a user uploaded file, that might be shorter). This results in the last frame of the video being repeated (stuttering the audio).

**Testing Instructions:**
- If all unit tests pass (since we are verifying the audio silence after the end of the reader)
- Create a project in openshot-qt, drop a video that has a solid tone (needs loud audio on all frames), save the *.osp project, edit the project in a text editor (update the "End" and "Duration" of the clip to be longer than the video file), re-open the *.osp project, and playback the project. Audio should go silent after the last valid frame, but the picture will remain/repeat.