### PR TITLE
Fraction: == and != operators, unit tests

### DIFF
--- a/src/Fraction.h
+++ b/src/Fraction.h
@@ -65,15 +65,29 @@ public:
 	/// Return the reciprocal as a Fraction
 	Fraction Reciprocal() const;
 
+    /// Equality test for two Fractions
+    ///
+    /// Fractions are equal if the left-hand Fraction multiplied by
+    /// the right-hand reciprocal produces the Fraction x/x for some x.
+    bool operator==(const openshot::Fraction& other) const {
+        const auto result = *this * other.Reciprocal();
+        return static_cast<bool>(result.num == result.den);
+    }
+
+    /// Inequality test for two Fractions
+    bool operator!=(const openshot::Fraction& other) const {
+        return static_cast<bool>(!(*this == other));
+    }
+
     // Multiplication and division
 
     /// Multiply two Fraction objects together
-    openshot::Fraction operator*(openshot::Fraction other) {
+    openshot::Fraction operator*(openshot::Fraction other) const {
         return openshot::Fraction(num * other.num, den * other.den);
     }
 
     /// Divide a Fraction by another Fraction
-    openshot::Fraction operator/(openshot::Fraction other) {
+    openshot::Fraction operator/(openshot::Fraction other) const {
         return *this * other.Reciprocal();
     }
 

--- a/tests/Fraction.cpp
+++ b/tests/Fraction.cpp
@@ -134,6 +134,31 @@ TEST_CASE( "Reciprocal", "[libopenshot][fraction]" )
 	CHECK(f1.ToDouble() == Approx(1.77777f).margin(0.00001));
 }
 
+TEST_CASE( "Equality tests", "[libopenshot][fraction]" ) {
+    openshot::Fraction f1(30, 1);
+    openshot::Fraction f2(30000, 1000);
+    openshot::Fraction f3(30000, 1001);
+    openshot::Fraction f4(1001, 30000);
+    openshot::Fraction f5((30000.0/1001), 1.0);
+
+    CHECK(f1 == f1);
+    CHECK(f3 == f3);
+
+    CHECK(f1 == f2);
+    CHECK(f2 == f1);
+
+    CHECK(f2 != f3);
+    CHECK(f3 != f2);
+
+    CHECK(f3 != f4);
+    CHECK(f4 != f3);
+
+    CHECK(f3 == f4.Reciprocal());
+
+    CHECK(f5 != f3);
+    CHECK(f5 == openshot::Fraction(29, 1));
+}
+
 TEST_CASE( "Fraction operations", "[libopenshot][fraction]" ) {
     openshot::Fraction f1(30, 1);
     openshot::Fraction f2(3, 9);


### PR DESCRIPTION
Both `operator==()` and `operator!=()` are fully unit tested.

Equality is determined by multiplying the LHS by the RHS reciprocal and checking that it reduces to `1`.
IOW, a new Fraction is created such that,
```c++
const auto result = openshot::Fraction(lhs.num * rhs.den, lhs.den * rhs.num);
```
Then, the equality condition is that `result.num == result.den`.

So,
```c++
// Result is openshot::Fraction(10, 10)
openshot::Fraction(1, 2) == openshot::Fraction(5, 10)

// Result is openshot::Fraction(30000, 30000)
openshot::Fraction(30, 1) == openshot::Fraction(30000, 1000)

// Result is openshot::Fraction(30000000, 30030000)
openshot::Fraction(30000, 1001) != openshot::Fraction(30000, 1000)

// It does work with both existing and ad hoc objects,
// so you can do either of the following in code

if (info.fps == openshot::Fraction(30, 1)) {  ... }

const openshot::Fraction expected(30, 1);
if (info.fps == expected) { ... }
```

Python support is also provided (automatically by SWIG)

```python
>>> import openshot
>>> openshot.Fraction(30, 1) == openshot.Fraction(300, 10)
True
>>> result = openshot.Fraction(30, 1) * openshot.Fraction(10, 300)
>>> result
Fraction(300, 300)
>>> result == openshot.Fraction(1, 1)
True
```

If  nothing else, it'll be handy for the unit tests:
```c++
FFmpegReader r("/path/to/some.mp4");
r.Open();

# Instead of
CHECK(r.info.fps.num == 30);
CHECK(r.info.fps.den == 1);
# just
CHECK(r.info.fps == Fraction(30, 1));
```
