### PR TITLE
Fix CVTracker to use INT values for the Rect2d bounding box

### DIFF
--- a/src/CVTracker.cpp
+++ b/src/CVTracker.cpp
@@ -98,8 +98,8 @@ void CVTracker::trackClip(openshot::Clip& video, size_t _start, size_t _end, boo
 
         if(frame == start){
             // Take the normalized inital bounding box and multiply to the current video shape
-            bbox = cv::Rect2d(bbox.x*cvimage.cols,bbox.y*cvimage.rows,bbox.width*cvimage.cols,
-                                        bbox.height*cvimage.rows);
+            bbox = cv::Rect2d(int(bbox.x*cvimage.cols), int(bbox.y*cvimage.rows),
+                              int(bbox.width*cvimage.cols), int(bbox.height*cvimage.rows));
         }
 
         // Pass the first frame to initialize the tracker

--- a/tests/CVTracker.cpp
+++ b/tests/CVTracker.cpp
@@ -102,7 +102,7 @@ TEST_CASE( "Track_Video", "[libopenshot][opencv][tracker]" )
 
     // Compare if tracked data is equal to pre-tested ones
     CHECK(x == Approx(256).margin(1));
-    CHECK(y == Approx(134).margin(1));
+    CHECK(y == Approx(132).margin(1));
     CHECK(width == Approx(180).margin(1));
     CHECK(height == Approx(166).margin(2));
 }


### PR DESCRIPTION
Ensure CVTracker bbox uses Integer values for it's Rect2d bounding box, and not float. The floats are killing the BOOSTING detector. Very sneaky bug... not sure why Rect2d allows for floats to be passed in.