### PR TITLE
Quick Fix: Correct `class_name`s for Tracker and ObjectDetection

### DIFF
--- a/src/effects/ObjectDetection.cpp
+++ b/src/effects/ObjectDetection.cpp
@@ -57,7 +57,7 @@ void ObjectDetection::init_effect_details()
     InitEffectInfo();
 
     /// Set the effect info
-    info.class_name = "Object Detector";
+    info.class_name = "ObjectDetection";
     info.name = "Object Detector";
     info.description = "Detect objects through the video.";
     info.has_audio = false;

--- a/src/effects/Tracker.cpp
+++ b/src/effects/Tracker.cpp
@@ -247,7 +247,7 @@ Json::Value Tracker::JsonValue() const {
 	// Save the effect's properties on root
 	root["type"] = info.class_name;
 	root["protobuf_data_path"] = protobuf_data_path;
-    root["BaseFPS"]["num"] = BaseFPS.num;
+	root["BaseFPS"]["num"] = BaseFPS.num;
 	root["BaseFPS"]["den"] = BaseFPS.den;
 	root["TimeScale"] = this->TimeScale;
 
@@ -287,9 +287,6 @@ void Tracker::SetJsonValue(const Json::Value root) {
 
 	// Set parent data
 	EffectBase::SetJsonValue(root);
-
-	if(!root["type"].isNull())
-		info.class_name = root["type"].asString();
 
 	if (!root["BaseFPS"].isNull() && root["BaseFPS"].isObject())
 	{


### PR DESCRIPTION
Effect class name is used when introspecting the available effects for a given build of libopenshot, for example when extracting translation strings for OpenShot. The `EffectInfo::class_name` member needs to match the name of the class it describes, which two of ours did not.

- `ObjectDetection` had its `class_name` set to "Object Detector", which obviously isn't the class name.
- `Tracker`, worse, was allowing `class_name` to be **SET** from the JSON parameters passed to its `SetJSON()` method, making the class name mutable at the whim of the class's callers.