### PR TITLE
Make unit tests work with Catch2v3 (for macOS CI)

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -68,20 +68,37 @@ if(NOT BUILD_TESTING)
   return()
 endif()
 
-# Create object library for test executable main(),
-# to avoid recompiling for every test
-add_library(catch-main OBJECT catch_main.cpp)
-target_link_libraries(catch-main PUBLIC Catch2::Catch2)
+add_library(openshot_catch2 INTERFACE)
+target_include_directories(openshot_catch2 INTERFACE
+  "${CMAKE_CURRENT_BINARY_DIR}"
+)
+target_compile_definitions(openshot_catch2 INTERFACE
+  TEST_MEDIA_PATH="${TEST_MEDIA_PATH}")
+
+if(TARGET Catch2::Catch2WithMain)
+  # Catch2 v3 works a bit differently
+  configure_file(catch2v3.h.in openshot_catch.h)
+  target_link_libraries(openshot_catch2 INTERFACE Catch2::Catch2WithMain)
+else()
+  configure_file(catch2v2.h.in openshot_catch.h)
+  # Create object library for test executable main(),
+  # to avoid recompiling for every test
+  add_library(catch-main OBJECT catch_main.cpp)
+  target_link_libraries(catch-main PUBLIC Catch2::Catch2)
+  target_include_directories(catch-main PUBLIC
+    "${CMAKE_CURRENT_BINARY_DIR}")
+  target_link_libraries(openshot_catch2 INTERFACE Catch2::Catch2)
+  target_sources(openshot_catch2 INTERFACE $<TARGET_OBJECTS:catch-main>)
+endif()
 
 foreach(tname ${OPENSHOT_TESTS})
   add_executable(openshot-${tname}-test
     ${tname}.cpp
-    $<TARGET_OBJECTS:catch-main>
   )
-  target_compile_definitions(openshot-${tname}-test PRIVATE
-    TEST_MEDIA_PATH="${TEST_MEDIA_PATH}"
+  target_link_libraries(openshot-${tname}-test
+    openshot_catch2
+    openshot
   )
-  target_link_libraries(openshot-${tname}-test Catch2::Catch2 openshot)
 
   # Automatically configure CTest targets from Catch2 test cases
   catch_discover_tests(

--- a/tests/CVObjectDetection.cpp
+++ b/tests/CVObjectDetection.cpp
@@ -14,7 +14,7 @@
 #include <sstream>
 #include <memory>
 
-#include <catch2/catch.hpp>
+#include "openshot_catch.h"
 
 #include "Clip.h"
 #include "CVObjectDetection.h"

--- a/tests/CVStabilizer.cpp
+++ b/tests/CVStabilizer.cpp
@@ -14,7 +14,7 @@
 #include <sstream>
 #include <memory>
 
-#include <catch2/catch.hpp>
+#include "openshot_catch.h"
 
 #include "Clip.h"
 #include "CVStabilization.h"  // for TransformParam, CamTrajectory, CVStabilization

--- a/tests/CVTracker.cpp
+++ b/tests/CVTracker.cpp
@@ -14,7 +14,7 @@
 #include <sstream>
 #include <memory>
 
-#include <catch2/catch.hpp>
+#include "openshot_catch.h"
 
 #include "Clip.h"
 #include "CVTracker.h"  // for FrameData, CVTracker

--- a/tests/CacheDisk.cpp
+++ b/tests/CacheDisk.cpp
@@ -13,7 +13,7 @@
 #include <memory>
 #include <QDir>
 
-#include <catch2/catch.hpp>
+#include "openshot_catch.h"
 
 #include "CacheDisk.h"
 #include "Frame.h"

--- a/tests/CacheMemory.cpp
+++ b/tests/CacheMemory.cpp
@@ -13,7 +13,7 @@
 #include <memory>
 #include <QDir>
 
-#include <catch2/catch.hpp>
+#include "openshot_catch.h"
 
 #include "CacheMemory.h"
 #include "Frame.h"

--- a/tests/ChromaKey.cpp
+++ b/tests/ChromaKey.cpp
@@ -28,7 +28,7 @@ std::ostream& operator << ( std::ostream& os, QColor const& value ) {
     return os;
 }
 
-#include <catch2/catch.hpp>
+#include "openshot_catch.h"
 
 using namespace openshot;
 

--- a/tests/Clip.cpp
+++ b/tests/Clip.cpp
@@ -13,7 +13,7 @@
 #include <sstream>
 #include <memory>
 
-#include <catch2/catch.hpp>
+#include "openshot_catch.h"
 
 #include <QColor>
 #include <QImage>

--- a/tests/Color.cpp
+++ b/tests/Color.cpp
@@ -13,7 +13,7 @@
 #include <string>
 #include <vector>
 
-#include <catch2/catch.hpp>
+#include "openshot_catch.h"
 
 #include <QColor>
 

--- a/tests/Coordinate.cpp
+++ b/tests/Coordinate.cpp
@@ -10,7 +10,7 @@
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
-#include <catch2/catch.hpp>
+#include "openshot_catch.h"
 
 #include "Coordinate.h"
 #include "Exceptions.h"

--- a/tests/Crop.cpp
+++ b/tests/Crop.cpp
@@ -13,7 +13,7 @@
 
 #include <memory>
 
-#include <catch2/catch.hpp>
+#include "openshot_catch.h"
 
 #include "Frame.h"
 #include "effects/Crop.h"

--- a/tests/DummyReader.cpp
+++ b/tests/DummyReader.cpp
@@ -12,7 +12,7 @@
 
 #include <memory>
 
-#include <catch2/catch.hpp>
+#include "openshot_catch.h"
 
 #include "DummyReader.h"
 #include "Exceptions.h"

--- a/tests/FFmpegReader.cpp
+++ b/tests/FFmpegReader.cpp
@@ -13,7 +13,7 @@
 #include <sstream>
 #include <memory>
 
-#include <catch2/catch.hpp>
+#include "openshot_catch.h"
 
 #include "FFmpegReader.h"
 #include "Exceptions.h"

--- a/tests/FFmpegWriter.cpp
+++ b/tests/FFmpegWriter.cpp
@@ -13,7 +13,7 @@
 #include <sstream>
 #include <memory>
 
-#include <catch2/catch.hpp>
+#include "openshot_catch.h"
 
 #include "FFmpegWriter.h"
 #include "Exceptions.h"

--- a/tests/Fraction.cpp
+++ b/tests/Fraction.cpp
@@ -10,7 +10,7 @@
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
-#include <catch2/catch.hpp>
+#include "openshot_catch.h"
 
 #include <map>
 #include <vector>

--- a/tests/Frame.cpp
+++ b/tests/Frame.cpp
@@ -24,7 +24,7 @@
 #undef uint64
 #endif
 
-#include <catch2/catch.hpp>
+#include "openshot_catch.h"
 
 #include "Clip.h"
 #include "Fraction.h"

--- a/tests/FrameMapper.cpp
+++ b/tests/FrameMapper.cpp
@@ -10,7 +10,7 @@
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
-#include <catch2/catch.hpp>
+#include "openshot_catch.h"
 
 #include "CacheMemory.h"
 #include "Clip.h"

--- a/tests/ImageWriter.cpp
+++ b/tests/ImageWriter.cpp
@@ -15,7 +15,7 @@
 #include <sstream>
 #include <memory>
 
-#include <catch2/catch.hpp>
+#include "openshot_catch.h"
 
 #include "ImageWriter.h"
 #include "Exceptions.h"

--- a/tests/KeyFrame.cpp
+++ b/tests/KeyFrame.cpp
@@ -10,7 +10,7 @@
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
-#include <catch2/catch.hpp>
+#include "openshot_catch.h"
 
 #include <sstream>
 #include <memory>

--- a/tests/Point.cpp
+++ b/tests/Point.cpp
@@ -10,7 +10,7 @@
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
-#include <catch2/catch.hpp>
+#include "openshot_catch.h"
 #include <sstream>
 
 #include "Point.h"

--- a/tests/QtImageReader.cpp
+++ b/tests/QtImageReader.cpp
@@ -10,7 +10,7 @@
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
-#include <catch2/catch.hpp>
+#include "openshot_catch.h"
 
 #include <QGuiApplication>
 

--- a/tests/ReaderBase.cpp
+++ b/tests/ReaderBase.cpp
@@ -13,7 +13,7 @@
 #include <memory>
 #include <string>
 
-#include <catch2/catch.hpp>
+#include "openshot_catch.h"
 
 #include "ReaderBase.h"
 #include "CacheBase.h"

--- a/tests/Settings.cpp
+++ b/tests/Settings.cpp
@@ -10,7 +10,7 @@
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
-#include <catch2/catch.hpp>
+#include "openshot_catch.h"
 
 #include "Settings.h"
 

--- a/tests/Timeline.cpp
+++ b/tests/Timeline.cpp
@@ -15,7 +15,7 @@
 #include <memory>
 #include <list>
 
-#include <catch2/catch.hpp>
+#include "openshot_catch.h"
 
 #include "Timeline.h"
 #include "Clip.h"

--- a/tests/catch2v2.h.in
+++ b/tests/catch2v2.h.in
@@ -1,0 +1,19 @@
+/**
+ * @file
+ * @brief Header (template) for tests built with Catch2 v2
+ * @author Jonathan Thomas <jonathan@openshot.org>
+ * @author FeRD (Frank Dana) <ferdnyc@gmail.com>
+ *
+ * @ref License
+ */
+
+// Copyright (c) 2008-2022 OpenShot Studios, LLC
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#ifndef OPENSHOT_CATCH2_H
+#define OPENSHOT_CATCH2_H
+
+#include <catch2/catch.hpp>
+
+#endif

--- a/tests/catch2v3.h.in
+++ b/tests/catch2v3.h.in
@@ -14,6 +14,6 @@
 #ifndef OPENSHOT_CATCH2_H
 #define OPENSHOT_CATCH2_H
 
-#include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_all.hpp>
 
 #endif

--- a/tests/catch2v3.h.in
+++ b/tests/catch2v3.h.in
@@ -15,5 +15,6 @@
 #define OPENSHOT_CATCH2_H
 
 #include <catch2/catch_all.hpp>
+using namespace Catch;
 
 #endif

--- a/tests/catch2v3.h.in
+++ b/tests/catch2v3.h.in
@@ -1,0 +1,19 @@
+/**
+ * @file
+ * @brief Header (template) for tests built with Catch2 v3.0 or later
+ * @author Jonathan Thomas <jonathan@openshot.org>
+ * @author FeRD (Frank Dana) <ferdnyc@gmail.com>
+ *
+ * @ref License
+ */
+
+// Copyright (c) 2008-2022 OpenShot Studios, LLC
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#ifndef OPENSHOT_CATCH2_H
+#define OPENSHOT_CATCH2_H
+
+#include <catch2/catch_test_macros.hpp>
+
+#endif

--- a/tests/catch_main.cpp
+++ b/tests/catch_main.cpp
@@ -11,5 +11,5 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
 #define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>
+#include "openshot_catch.h"
 


### PR DESCRIPTION
Homebrew has upgraded Catch2 to version 3.0.1, which is structured significantly different from the previous version 2. This PR adds logic to check which version of Catch is loaded, and configures one of either `tests/catch2v2.h.in` or `tests/catch2v3.h.in` as the runtime header `openshot_catch.h` which is what all of our unit tests now `#include`. The different headers, along with some CMake logic to build the test runners differently, papers over the differences in the Catch configuration.

That papering-over includes the use of `using namespace Catch;` in the v3 header, which normally I would be the first one to  oppose. I'm still not happy about it, but because it's an internal header only ever intended to be included by our internal unit test code, I've found it within me to rationalize it as a necessary evil.

The changes here don't yet harness the full power of Catch2v3 to speed up compilation times, which they accomplished by splitting up their code into multiple headers so that you only import what you absolutely need. It may or may not be possible to take full, or better, advantage of that without sacrificing Catch2v2 compatibility, but for the moment I've punted to just using `#include <catch2/catch_all.hpp>` which emulates the previous monolithic `#include <catch2/catch.hpp>` setup from v2. There's definitely room for improvement in followup PRs, but the immediate goal is to fix macOS CI.