### PR TITLE
tests/ChromaKey: Test QColor stream operator

### DIFF
--- a/tests/ChromaKey.cpp
+++ b/tests/ChromaKey.cpp
@@ -69,3 +69,12 @@ TEST_CASE( "threshold", "[libopenshot][effect][chromakey]" )
     CHECK(pix_e == expected);
 }
 
+TEST_CASE( "QColor stream operator", "[libopenshot][tests][internal][chromakey]" )
+{
+    QColor c("red");
+    std::stringstream stream;
+    stream << c;
+    std::string expected("QColor(255, 0, 0, 255)");
+    CHECK(stream.str() == expected);
+}
+


### PR DESCRIPTION
The `tests/ChromaKey.cpp` file contains an `operator<<` implementation for QColor that I threw together to facilitate direct comparisons in unit tests. For the _test file itself_ to be fully covered, that operator also needs to be unit-tested.