### PR TITLE
WIP: Add FPS, a Fraction subclass with converting powers

### DIFF
--- a/bindings/python/openshot.i
+++ b/bindings/python/openshot.i
@@ -54,40 +54,41 @@
 #include "OpenShotVersion.h"
 #include "ReaderBase.h"
 #include "WriterBase.h"
-#include "AudioDevices.h"
-#include "CacheBase.h"
-#include "CacheDisk.h"
-#include "CacheMemory.h"
-#include "ChannelLayouts.h"
-#include "ChunkReader.h"
-#include "ChunkWriter.h"
+    #include "ChunkReader.h"
+    #include "ChunkWriter.h"
+    #include "DummyReader.h"
+    #include "FFmpegReader.h"
+    #include "FFmpegWriter.h"
+    #include "FrameMapper.h"
+    #include "QtHtmlReader.h"
+    #include "QtImageReader.h"
+    #include "QtTextReader.h"
+#include "Fraction.h"
+    #include "FPS.h"
 #include "ClipBase.h"
-#include "Clip.h"
+    #include "Clip.h"
+#include "CacheBase.h"
+    #include "CacheDisk.h"
+    #include "CacheMemory.h"
+#include "AudioDevices.h"
+#include "ChannelLayouts.h"
 #include "Coordinate.h"
 #include "Color.h"
-#include "DummyReader.h"
 #include "EffectBase.h"
-#include "Effects.h"
-#include "EffectInfo.h"
+    #include "Effects.h"
+    #include "EffectInfo.h"
 #include "Enums.h"
 #include "Exceptions.h"
-#include "FFmpegReader.h"
-#include "FFmpegWriter.h"
-#include "Fraction.h"
 #include "Frame.h"
-#include "FrameMapper.h"
 #include "PlayerBase.h"
+    #include "QtPlayer.h"
 #include "Point.h"
 #include "Profiles.h"
-#include "QtHtmlReader.h"
-#include "QtImageReader.h"
-#include "QtPlayer.h"
-#include "QtTextReader.h"
 #include "KeyFrame.h"
 #include "RendererBase.h"
 #include "Settings.h"
 #include "TimelineBase.h"
-#include "Timeline.h"
+    #include "Timeline.h"
 #include "ZmqLogger.h"
 
 %}
@@ -202,7 +203,7 @@
     }
     const std::string __repr__() {
         std::ostringstream result;
-        result << "Fraction(" << $self->num << ", " << $self->den << ")";
+        result << *$self;
         return result.str();
     }
     /* Implement dict methods in Python */
@@ -245,6 +246,19 @@
             return "{value:{spec}}".format(value=value, spec=format_spec)
     %}
 }
+%extend openshot::FPS {
+	const std::string __str__() {
+		std::ostringstream result;
+		result << $self->num << "/" << $self->den;
+		return result.str();
+	}
+    const std::string __repr__() {
+        std::ostringstream result;
+        result << *$self;
+        return result.str();
+    }
+}
+
 
 %extend openshot::OpenShotVersion {
         // Give the struct a string representation
@@ -282,6 +296,7 @@
 %include "FFmpegReader.h"
 %include "FFmpegWriter.h"
 %include "Fraction.h"
+    %include "FPS.h"
 %include "Frame.h"
 %include "FrameMapper.h"
 %include "PlayerBase.h"

--- a/bindings/ruby/openshot.i
+++ b/bindings/ruby/openshot.i
@@ -59,7 +59,7 @@
   #define RB_RSHIFT(a, b) RSHIFT(a, b)
   #undef RSHIFT
 #endif
-include "OpenShotVersion.h"
+#include "OpenShotVersion.h"
 #include "ReaderBase.h"
 #include "WriterBase.h"
     #include "ChunkReader.h"

--- a/bindings/ruby/openshot.i
+++ b/bindings/ruby/openshot.i
@@ -59,43 +59,44 @@
   #define RB_RSHIFT(a, b) RSHIFT(a, b)
   #undef RSHIFT
 #endif
-#include "OpenShotVersion.h"
+include "OpenShotVersion.h"
 #include "ReaderBase.h"
 #include "WriterBase.h"
-#include "AudioDevices.h"
-#include "CacheBase.h"
-#include "CacheDisk.h"
-#include "CacheMemory.h"
-#include "ChannelLayouts.h"
-#include "ChunkReader.h"
-#include "ChunkWriter.h"
+    #include "ChunkReader.h"
+    #include "ChunkWriter.h"
+    #include "DummyReader.h"
+    #include "FFmpegReader.h"
+    #include "FFmpegWriter.h"
+    #include "FrameMapper.h"
+    #include "QtHtmlReader.h"
+    #include "QtImageReader.h"
+    #include "QtTextReader.h"
+#include "Fraction.h"
+    #include "FPS.h"
 #include "ClipBase.h"
-#include "Clip.h"
+    #include "Clip.h"
+#include "CacheBase.h"
+    #include "CacheDisk.h"
+    #include "CacheMemory.h"
+#include "AudioDevices.h"
+#include "ChannelLayouts.h"
 #include "Coordinate.h"
 #include "Color.h"
-#include "DummyReader.h"
 #include "EffectBase.h"
-#include "Effects.h"
-#include "EffectInfo.h"
+    #include "Effects.h"
+    #include "EffectInfo.h"
 #include "Enums.h"
 #include "Exceptions.h"
-#include "FFmpegReader.h"
-#include "FFmpegWriter.h"
-#include "Fraction.h"
 #include "Frame.h"
-#include "FrameMapper.h"
 #include "PlayerBase.h"
+    #include "QtPlayer.h"
 #include "Point.h"
 #include "Profiles.h"
-#include "QtHtmlReader.h"
-#include "QtImageReader.h"
-#include "QtPlayer.h"
-#include "QtTextReader.h"
 #include "KeyFrame.h"
 #include "RendererBase.h"
 #include "Settings.h"
 #include "TimelineBase.h"
-#include "Timeline.h"
+    #include "Timeline.h"
 #include "ZmqLogger.h"
 
 /* Move FFmpeg's RSHIFT to FF_RSHIFT, if present */
@@ -114,6 +115,18 @@
 		#include "ImageReader.h"
 		#include "ImageWriter.h"
 		#include "TextReader.h"
+	%}
+#endif
+
+
+#ifdef USE_OPENCV
+	%{
+		#include "ClipProcessingJobs.h"
+		#include "effects/Stabilizer.h"
+		#include "effects/Tracker.h"
+		#include "effects/ObjectDetection.h"
+		#include "TrackedObjectBase.h"
+		#include "TrackedObjectBBox.h"
 	%}
 #endif
 
@@ -173,6 +186,7 @@
 #endif
 
 %include "Fraction.h"
+    %include "FPS.h"
 %include "Frame.h"
 %include "FrameMapper.h"
 %include "PlayerBase.h"
@@ -188,6 +202,12 @@
 %include "TimelineBase.h"
 %include "Timeline.h"
 %include "ZmqLogger.h"
+
+#ifdef USE_OPENCV
+	%include "ClipProcessingJobs.h"
+	%include "TrackedObjectBase.h"
+	%include "TrackedObjectBBox.h"
+#endif
 
 #ifdef USE_IMAGEMAGICK
 	%include "ImageReader.h"
@@ -211,5 +231,8 @@
 %include "effects/Saturation.h"
 %include "effects/Shift.h"
 %include "effects/Wave.h"
-
-
+#ifdef USE_OPENCV
+	%include "effects/Stabilizer.h"
+	%include "effects/Tracker.h"
+	%include "effects/ObjectDetection.h"
+#endif

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -66,6 +66,7 @@ set(OPENSHOT_SOURCES
   EffectInfo.cpp
   FFmpegReader.cpp
   FFmpegWriter.cpp
+  FPS.cpp
   Fraction.cpp
   Frame.cpp
   FrameMapper.cpp

--- a/src/Clip.cpp
+++ b/src/Clip.cpp
@@ -28,6 +28,11 @@
     #include "TextReader.h"
 #endif
 
+#ifdef HAVE_OPENCV
+    #include "TrackedObjectBBox.h"
+#endif
+#include "TrackedObjectBase.h"
+
 #include <Qt>
 
 using namespace openshot;

--- a/src/Clip.cpp
+++ b/src/Clip.cpp
@@ -28,7 +28,7 @@
     #include "TextReader.h"
 #endif
 
-#ifdef HAVE_OPENCV
+#ifdef USE_OPENCV
     #include "TrackedObjectBBox.h"
 #endif
 #include "TrackedObjectBase.h"

--- a/src/Coordinate.h
+++ b/src/Coordinate.h
@@ -14,7 +14,6 @@
 #define OPENSHOT_COORDINATE_H
 
 #include <iostream>
-#include "Fraction.h"
 #include "Json.h"
 
 namespace openshot {

--- a/src/FFmpegReader.cpp
+++ b/src/FFmpegReader.cpp
@@ -21,6 +21,8 @@
 
 #include "FFmpegReader.h"
 #include "Exceptions.h"
+#include "Fraction.h"
+#include "FPS.h"
 #include "Timeline.h"
 #include "ZmqLogger.h"
 
@@ -2362,7 +2364,7 @@ void FFmpegReader::CheckFPS() {
 		int avg_fps = round(sum_fps / 4.0f);
 
 		// Update FPS
-		info.fps = Fraction(avg_fps, 1);
+		info.fps = FPS(avg_fps, 1);
 
 		// Update Duration and Length
 		info.video_length = frames_detected;
@@ -2375,7 +2377,7 @@ void FFmpegReader::CheckFPS() {
 		int sum_fps = second_second_counter;
 
 		// Update FPS
-		info.fps = Fraction(sum_fps, 1);
+		info.fps = FPS(sum_fps, 1);
 
 		// Update Duration and Length
 		info.video_length = frames_detected;

--- a/src/FPS.cpp
+++ b/src/FPS.cpp
@@ -1,0 +1,31 @@
+/**
+ * @file
+ * @brief Source file for Fraction class
+ * @author Jonathan Thomas <jonathan@openshot.org>
+ *
+ * @ref License
+ */
+
+// Copyright (c) 2008-2019 OpenShot Studios, LLC
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "FPS.h"
+#include <cmath>
+
+using namespace openshot;
+
+int64_t openshot::FPS::frame(double time) const {
+    return static_cast<int64_t>(*this * time) + 1;
+}
+
+double openshot::FPS::time(int64_t frame) const {
+    return static_cast<double>(frame - 1) / *this;
+}
+
+int64_t openshot::FPS::sample(int64_t frame, int sample_rate) const {
+    const auto spf = static_cast<double>(sample_rate) * this->Reciprocal();
+    return frame > 1
+        ? std::floor(static_cast<double>(frame - 1) * spf)
+        : 0;
+}

--- a/src/FPS.h
+++ b/src/FPS.h
@@ -1,0 +1,91 @@
+/**
+ * @file
+ * @brief Header file for Fraction class
+ * @author Jonathan Thomas <jonathan@openshot.org>
+ * @author FeRD (Frank Dana) <ferdnyc@gmail.com>
+ *
+ * @ref License
+ */
+
+// Copyright (c) 2008-2022 OpenShot Studios, LLC
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#ifndef OPENSHOT_FPS_H
+#define OPENSHOT_FPS_H
+
+#include "Fraction.h"
+
+namespace openshot {
+
+/**
+ * @brief An openshot::Fraction subclass with converting powers
+ */
+class FPS : public openshot::Fraction {
+public:
+    std::string type{"FPS"};
+
+    FPS() = default;
+    FPS(const FPS& other) = default;
+    FPS(const openshot::Fraction& other) : Fraction(other) {}
+    FPS(int a, int b) : Fraction(a, b) {}
+
+    FPS Reciprocal() const {
+        return FPS(den, num);
+    };
+
+    // Unit conversions
+
+    /// Convert a relative time (seconds since start) to the nearest whole frame number.
+    int64_t frame(double time) const;
+
+    /// Convert a frame number (1-based) to a relative time
+    /// in whole and partial seconds.
+    double time(int64_t frame) const;
+
+    /// Find a frame's first sample, for a given sample rate
+    int64_t sample(int64_t frame, int sample_rate) const;
+
+    // Multiplication and division
+    using Fraction::operator*;
+    using Fraction::operator/;
+
+    /// Multiplication in the form (openshot::FPS * numeric_value)
+    template<class numT>
+    numT operator*(const numT& other) const {
+        return static_cast<numT>(ToDouble() * other);
+    }
+
+    /// Division in the form (openshot::FPS / numeric_value)
+    template<class numT>
+    numT operator/(const numT& other) const {
+        return static_cast<numT>(ToDouble() / other);
+    }
+};
+
+/// Multiplication in the form (numeric_value * openshot::FPS)
+template<class numT>
+numT operator*(const numT& left, const openshot::FPS& right) {
+    return static_cast<numT>(left * right.ToDouble());
+}
+
+/// Division in the form (numeric_value / openshot::FPS)
+template<class numT>
+numT operator/(const numT& left, const openshot::FPS& right) {
+    return static_cast<numT>(left / right.ToDouble());
+}
+
+// // Stream output operator for openshot::FPS
+// template<class charT, class traits>
+// std::basic_ostream<charT, traits>&
+// operator<<(std::basic_ostream<charT, traits>& o, const openshot::FPS& f) {
+//     std::basic_ostringstream<charT, traits> s;
+//     s.flags(o.flags());
+//     s.imbue(o.getloc());
+//     s.precision(o.precision());
+//     s << "FPS(" << f.num << ", " << f.den << ")";
+//     return o << s.str();
+// }
+
+}  // namespace openshot
+#endif

--- a/src/Fraction.cpp
+++ b/src/Fraction.cpp
@@ -15,37 +15,6 @@
 
 using namespace openshot;
 
-// Delegating constructors
-Fraction::Fraction() : Fraction::Fraction(1, 1) {}
-
-Fraction::Fraction(std::pair<int, int> pair)
-	: Fraction::Fraction(pair.first, pair.second) {}
-
-Fraction::Fraction(std::map<std::string, int> mapping)
-	: Fraction::Fraction(mapping["num"], mapping["den"]) {}
-
-Fraction::Fraction(std::vector<int> vector)
-	: Fraction::Fraction(vector[0], vector[1]) {}
-
-// Full constructor
-Fraction::Fraction(int num, int den) :
-	num(num), den(den) {}
-
-// Return this fraction as a float (i.e. 1/2 = 0.5)
-float Fraction::ToFloat() {
-	return float(num) / float(den);
-}
-
-// Return this fraction as a double (i.e. 1/2 = 0.5)
-double Fraction::ToDouble() const {
-	return double(num) / double(den);
-}
-
-// Return a rounded integer of the frame rate (for example 30000/1001 returns 30 fps)
-int Fraction::ToInt() {
-	return round((double) num / den);
-}
-
 // Calculate the greatest common denominator
 int Fraction::GreatestCommonDenominator() {
 	int first = num;
@@ -69,11 +38,4 @@ void Fraction::Reduce() {
 	// Reduce this fraction to the smallest possible whole numbers
 	num = num / GCD;
 	den = den / GCD;
-}
-
-// Return the reciprocal as a new Fraction
-Fraction Fraction::Reciprocal() const
-{
-	// flip the fraction
-	return Fraction(den, num);
 }

--- a/src/FrameMapper.cpp
+++ b/src/FrameMapper.cpp
@@ -17,6 +17,8 @@
 #include "FrameMapper.h"
 #include "Exceptions.h"
 #include "Clip.h"
+#include "Fraction.h"
+#include "FPS.h"
 #include "ZmqLogger.h"
 
 using namespace std;
@@ -26,14 +28,12 @@ FrameMapper::FrameMapper(ReaderBase *reader, Fraction target, PulldownType targe
 		reader(reader), target(target), pulldown(target_pulldown), is_dirty(true), avr(NULL), parent_position(0.0)
 {
 	// Set the original frame rate from the reader
-	original = Fraction(reader->info.fps.num, reader->info.fps.den);
+	original = FPS(reader->info.fps);
 
 	// Set all info struct members equal to the internal reader
 	info = reader->info;
-	info.fps.num = target.num;
-	info.fps.den = target.den;
-	info.video_timebase.num = target.den;
-	info.video_timebase.den = target.num;
+	info.fps = target;
+	info.video_timebase = target.Reciprocal();
 	info.video_length = round(info.duration * info.fps.ToDouble());
 	info.sample_rate = target_sample_rate;
 	info.channels = target_channels;
@@ -767,12 +767,9 @@ void FrameMapper::ChangeMapping(Fraction target_fps, PulldownType target_pulldow
 	is_dirty = true;
 
 	// Update mapping details
-	target.num = target_fps.num;
-	target.den = target_fps.den;
-	info.fps.num = target_fps.num;
-	info.fps.den = target_fps.den;
-	info.video_timebase.num = target_fps.den;
-	info.video_timebase.den = target_fps.num;
+	target = target_fps;
+	info.fps = target_fps;
+	info.video_timebase = target_fps.Reciprocal();
 	pulldown = target_pulldown;
 	info.sample_rate = target_sample_rate;
 	info.channels = target_channels;

--- a/src/FrameMapper.h
+++ b/src/FrameMapper.h
@@ -120,8 +120,8 @@ namespace openshot
 	class FrameMapper : public ReaderBase {
 	private:
 		bool field_toggle;		// Internal odd / even toggle (used when building the mapping)
-		Fraction original;		// The original frame rate
-		Fraction target;		// The target frame rate
+		FPS original;		// The original frame rate
+		FPS target;		// The target frame rate
 		PulldownType pulldown;	// The pull-down technique
 		ReaderBase *reader;		// The source video reader
 		CacheMemory final_cache; 		// Cache of actual Frame objects

--- a/src/ImageReader.cpp
+++ b/src/ImageReader.cpp
@@ -18,6 +18,8 @@
 
 #include "ImageReader.h"
 #include "Exceptions.h"
+#include "Fraction.h"
+#include "FPS.h"
 #include "Frame.h"
 
 using namespace openshot;
@@ -62,7 +64,7 @@ void ImageReader::Open()
 		info.height = image->size().height();
 		info.pixel_ratio = openshot::Fraction(1, 1);
 		info.duration = 60 * 60 * 1;  // 1 hour duration
-		info.fps = openshot::Fraction(30, 1);
+		info.fps = openshot::FPS(30, 1);
 		info.video_timebase = info.fps.Reciprocal();
 		info.video_length = std::round(info.duration * info.fps.ToDouble());
 

--- a/src/Profiles.cpp
+++ b/src/Profiles.cpp
@@ -13,6 +13,11 @@
 #include "Profiles.h"
 #include "Exceptions.h"
 
+#include <QString>
+#include <QStringList>
+#include <QFile>
+#include <QTextStream>
+
 using namespace openshot;
 
 

--- a/src/Profiles.h
+++ b/src/Profiles.h
@@ -13,17 +13,8 @@
 #ifndef OPENSHOT_PROFILE_H
 #define OPENSHOT_PROFILE_H
 
-#include <iostream>
-#include <string>
-#include <sstream>
-#include <fstream>
-#include <QtCore/QString>
-#include <QtCore/QStringList>
-#include <QtCore/QFile>
-#include <QTextStream>
-#include <cstdio>
-#include <cstdlib>
 #include "Fraction.h"
+#include "FPS.h"
 #include "Json.h"
 
 namespace openshot
@@ -41,7 +32,7 @@ namespace openshot
 		int height;		///< The height of the video (in pixels)
 		int width;		///< The width of the video (in pixels)
 		int pixel_format;	///< The pixel format (i.e. YUV420P, RGB24, etc...)
-		Fraction fps;		///< Frames per second, as a fraction (i.e. 24/1 = 24 fps)
+		FPS fps;		///< Frames per second, as a fraction (i.e. 24/1 = 24 fps)
 		Fraction pixel_ratio;	///< The pixel ratio of the video stream as a fraction (i.e. some pixels are not square)
 		Fraction display_ratio;	///< The ratio of width to height of the video stream (i.e. 640x480 has a ratio of 4/3)
 		bool interlaced_frame;	// Are the contents of this frame interlaced

--- a/src/ReaderBase.cpp
+++ b/src/ReaderBase.cpp
@@ -16,6 +16,8 @@
 
 #include "ReaderBase.h"
 #include "ClipBase.h"
+#include "Fraction.h"
+#include "FPS.h"
 #include "Frame.h"
 
 #include "Json.h"
@@ -35,14 +37,14 @@ ReaderBase::ReaderBase()
 	info.height = 0;
 	info.width = 0;
 	info.pixel_format = -1;
-	info.fps = Fraction();
+	info.fps = FPS();
 	info.video_bit_rate = 0;
 	info.pixel_ratio = Fraction();
 	info.display_ratio = Fraction();
 	info.vcodec = "";
 	info.video_length = 0;
 	info.video_stream_index = -1;
-	info.video_timebase = Fraction();
+	info.video_timebase = FPS();
 	info.interlaced_frame = false;
 	info.top_field_first = true;
 	info.acodec = "";
@@ -51,7 +53,7 @@ ReaderBase::ReaderBase()
 	info.channels = 0;
 	info.channel_layout = LAYOUT_MONO;
 	info.audio_stream_index = -1;
-	info.audio_timebase = Fraction();
+	info.audio_timebase = FPS();
 
 	// Init parent clip
 	clip = NULL;
@@ -182,7 +184,7 @@ void ReaderBase::SetJsonValue(const Json::Value root) {
 		if (!root["fps"]["num"].isNull())
 			info.fps.num = root["fps"]["num"].asInt();
 		if (!root["fps"]["den"].isNull())
-		info.fps.den = root["fps"]["den"].asInt();
+			info.fps.den = root["fps"]["den"].asInt();
 	}
 	if (!root["video_bit_rate"].isNull())
 		info.video_bit_rate = root["video_bit_rate"].asInt();

--- a/src/ReaderBase.h
+++ b/src/ReaderBase.h
@@ -22,6 +22,7 @@
 
 #include "ChannelLayouts.h"
 #include "Fraction.h"
+#include "FPS.h"
 #include "Json.h"
 
 namespace openshot
@@ -45,14 +46,14 @@ namespace openshot
 		int height;					///< The height of the video (in pixels)
 		int width;					///< The width of the video (in pixesl)
 		int pixel_format;			///< The pixel format (i.e. YUV420P, RGB24, etc...)
-		openshot::Fraction fps;				///< Frames per second, as a fraction (i.e. 24/1 = 24 fps)
+		openshot::FPS fps;  ///< Frames per second, as a ratio (i.e. 24/1 = 24 fps)
 		int video_bit_rate;			///< The bit rate of the video stream (in bytes)
 		openshot::Fraction pixel_ratio;		///< The pixel ratio of the video stream as a fraction (i.e. some pixels are not square)
 		openshot::Fraction display_ratio;		///< The ratio of width to height of the video stream (i.e. 640x480 has a ratio of 4/3)
 		std::string vcodec;				///< The name of the video codec used to encode / decode the video stream
 		int64_t video_length;		///< The number of frames in the video stream
 		int video_stream_index;		///< The index of the video stream
-		openshot::Fraction video_timebase;	///< The video timebase determines how long each frame stays on the screen
+		openshot::FPS video_timebase;	///< The video timebase determines how long each frame stays on the screen
 		bool interlaced_frame;		// Are the contents of this frame interlaced
 		bool top_field_first;		// Which interlaced field should be displayed first
 		std::string acodec;				///< The name of the audio codec used to encode / decode the video stream
@@ -61,7 +62,7 @@ namespace openshot
 		int channels;				///< The number of audio channels used in the audio stream
 		openshot::ChannelLayout channel_layout;	///< The channel layout (mono, stereo, 5 point surround, etc...)
 		int audio_stream_index;		///< The index of the audio stream
-		openshot::Fraction audio_timebase;	///< The audio timebase determines how long each audio packet should be played
+		openshot::FPS audio_timebase;	///< The audio timebase determines how long each audio packet should be played
 		std::map<std::string, std::string> metadata;	///< An optional map/dictionary of metadata for this reader
 	};
 

--- a/src/Timeline.cpp
+++ b/src/Timeline.cpp
@@ -19,7 +19,7 @@
 #include "FrameMapper.h"
 #include "Exceptions.h"
 
-#ifdef HAVE_OPENCV
+#ifdef USE_OPENCV
     #include "TrackedObjectBBox.h"
 #endif
 #include "TrackedObjectBase.h"

--- a/src/Timeline.cpp
+++ b/src/Timeline.cpp
@@ -19,6 +19,11 @@
 #include "FrameMapper.h"
 #include "Exceptions.h"
 
+#ifdef HAVE_OPENCV
+    #include "TrackedObjectBBox.h"
+#endif
+#include "TrackedObjectBase.h"
+
 #include <QDir>
 #include <QFileInfo>
 

--- a/src/Timeline.h
+++ b/src/Timeline.h
@@ -28,20 +28,15 @@
 #include "Clip.h"
 #include "EffectBase.h"
 #include "Fraction.h"
-#include "Frame.h"
 #include "KeyFrame.h"
-#ifdef USE_OPENCV
-#include "TrackedObjectBBox.h"
-#endif
-#include "TrackedObjectBase.h"
-
-
 
 namespace openshot {
 
 	// Forward decls
+        class Frame;
 	class FrameMapper;
 	class CacheBase;
+        class TrackedObjectBase;
 
 	/// Comparison method for sorting clip pointers (by Layer and then Position). Clips are sorted
 	/// from lowest layer to top layer (since that is the sequence they need to be combined), and then
@@ -187,7 +182,7 @@ namespace openshot {
 		std::vector<openshot::Clip*> find_intersecting_clips(int64_t requested_frame, int number_of_frames, bool include);
 
 		/// Get a clip's frame or generate a blank frame
-		std::shared_ptr<openshot::Frame> GetOrCreateFrame(std::shared_ptr<Frame> background_frame, openshot::Clip* clip, int64_t number, openshot::TimelineInfoStruct* options);
+		std::shared_ptr<openshot::Frame> GetOrCreateFrame(std::shared_ptr<openshot::Frame> background_frame, openshot::Clip* clip, int64_t number, openshot::TimelineInfoStruct* options);
 
 		/// Compare 2 floating point numbers for equality
 		bool isEqual(double a, double b);

--- a/src/WriterBase.cpp
+++ b/src/WriterBase.cpp
@@ -16,6 +16,8 @@
 
 #include "WriterBase.h"
 #include "Exceptions.h"
+#include "Fraction.h"
+#include "FPS.h"
 #include "Frame.h"
 #include "ReaderBase.h"
 
@@ -33,14 +35,14 @@ WriterBase::WriterBase()
 	info.height = 0;
 	info.width = 0;
 	info.pixel_format = -1;
-	info.fps = Fraction();
+	info.fps = FPS();
 	info.video_bit_rate = 0;
 	info.pixel_ratio = Fraction();
 	info.display_ratio = Fraction();
 	info.vcodec = "";
 	info.video_length = 0;
 	info.video_stream_index = -1;
-	info.video_timebase = Fraction();
+	info.video_timebase = FPS();
 	info.interlaced_frame = false;
 	info.top_field_first = true;
 	info.acodec = "";
@@ -49,7 +51,7 @@ WriterBase::WriterBase()
 	info.channels = 0;
 	info.channel_layout = LAYOUT_MONO;
 	info.audio_stream_index = -1;
-	info.audio_timebase = Fraction();
+	info.audio_timebase = FPS();
 }
 
 // This method copy's the info struct of a reader, and sets the writer with the same info
@@ -63,18 +65,14 @@ void WriterBase::CopyReaderInfo(ReaderBase* reader)
 	info.height = reader->info.height;
 	info.width = reader->info.width;
 	info.pixel_format = reader->info.pixel_format;
-	info.fps.num = reader->info.fps.num;
-	info.fps.den = reader->info.fps.den;
+	info.fps = reader->info.fps;
 	info.video_bit_rate = reader->info.video_bit_rate;
-	info.pixel_ratio.num = reader->info.pixel_ratio.num;
-	info.pixel_ratio.den = reader->info.pixel_ratio.den;
-	info.display_ratio.num = reader->info.display_ratio.num;
-	info.display_ratio.den = reader->info.display_ratio.den;
+	info.pixel_ratio = reader->info.pixel_ratio;
+	info.display_ratio = reader->info.display_ratio;
 	info.vcodec = reader->info.vcodec;
 	info.video_length = reader->info.video_length;
 	info.video_stream_index = reader->info.video_stream_index;
-	info.video_timebase.num = reader->info.video_timebase.num;
-	info.video_timebase.den = reader->info.video_timebase.den;
+	info.video_timebase = reader->info.video_timebase;
 	info.interlaced_frame = reader->info.interlaced_frame;
 	info.top_field_first = reader->info.top_field_first;
 	info.acodec = reader->info.acodec;
@@ -83,8 +81,7 @@ void WriterBase::CopyReaderInfo(ReaderBase* reader)
 	info.channels = reader->info.channels;
 	info.channel_layout = reader->info.channel_layout;
 	info.audio_stream_index = reader->info.audio_stream_index;
-	info.audio_timebase.num = reader->info.audio_timebase.num;
-	info.audio_timebase.den = reader->info.audio_timebase.den;
+	info.audio_timebase = reader->info.audio_timebase;
 }
 
 // Display file information

--- a/src/WriterBase.h
+++ b/src/WriterBase.h
@@ -17,6 +17,7 @@
 
 #include "ChannelLayouts.h"
 #include "Fraction.h"
+#include "FPS.h"
 #include "Json.h"
 
 namespace openshot
@@ -39,14 +40,14 @@ namespace openshot
 		int height;					///< The height of the video (in pixels)
 		int width;					///< The width of the video (in pixels)
 		int pixel_format;			///< The pixel format (i.e. YUV420P, RGB24, etc...)
-		openshot::Fraction fps;				///< Frames per second, as a fraction (i.e. 24/1 = 24 fps)
+		openshot::FPS fps;				///< Frames per second, as a fraction (i.e. 24/1 = 24 fps)
 		int video_bit_rate;		///< The bit rate of the video stream (in bytes)
 		openshot::Fraction pixel_ratio;		///< The pixel ratio of the video stream as a fraction (i.e. some pixels are not square)
 		openshot::Fraction display_ratio;		///< The ratio of width to height of the video stream (i.e. 640x480 has a ratio of 4/3)
 		std::string vcodec;				///< The name of the video codec used to encode / decode the video stream
 		int64_t video_length;		///< The number of frames in the video stream
 		int video_stream_index;		///< The index of the video stream
-		openshot::Fraction video_timebase;	///< The video timebase determines how long each frame stays on the screen
+		openshot::FPS video_timebase;	///< The video timebase determines how long each frame stays on the screen
 		bool interlaced_frame;		///< Are the contents of this frame interlaced
 		bool top_field_first;		///< Which interlaced field should be displayed first
 		std::string acodec;				///< The name of the audio codec used to encode / decode the video stream
@@ -55,7 +56,7 @@ namespace openshot
 		int channels;				///< The number of audio channels used in the audio stream
 		openshot::ChannelLayout channel_layout;	///< The channel layout (mono, stereo, 5 point surround, etc...)
 		int audio_stream_index;		///< The index of the audio stream
-		openshot::Fraction audio_timebase;	///< The audio timebase determines how long each audio packet should be played
+		openshot::FPS audio_timebase;	///< The audio timebase determines how long each audio packet should be played
 		std::map<std::string, std::string> metadata;	///< An optional map/dictionary of video & audio metadata
 	};
 


### PR DESCRIPTION
#### Motivation
To do basically any type of timing conversion in libopenshot, you need to know the FPS you're working with. We pass it into nearly every conversion function, in one way or another, because without it you're dead in the water.

In fact, FPS is so central to the process of conversions like frame<->time or frame<->sample that it makes sense for the object holding the FPS value to be able to _perform_ those conversions itself!

#### Solution (so far)

So, this (very much work-in-progress) PR is an attempt at empowering our FPS values, by subclassing `Fraction` into a new class, `FPS`. The `FPS` class doesn't carry any more **information** than `Fraction`, it just has additional methods useful for common conversions. (In fact, the classes are freely convertible in either direction. Which is why all function signatures that take timing values still pass them as `Fraction`s, not `FPS`s.)

Where I _have_ made use of `FPS`, so far, is in  the class member objects stored by things like `ReaderBase`, `WriterBase`, `FrameMapper`, etc. Any members holding `fps`, `video_timebase`, or `audio_timebase` values, which used to be type `Fraction`, are now type `FPS`.

The code doesn't (yet) make any more _use_ of those objects than it did when they were `Fraction`s, but all of the unit tests still pass and the change appears to have had zero effect on functionality, which was the goal for this stage.

#### Demonstration

The utility of `FPS` can be seen in the Python bindings (though the same operations are available to the C++ code directly):

```python
>>> import openshot
>>> # If we have an FPS value...
>>> fps = openshot.FPS(24000, 1001)
>>> # We can convert frame numbers to (start) times: 
>>> fps.time(1)
0.0
>>> fps.time(25)
1.001
>>> # We can convert time values to frame numbers
>>> fps.frame(10.0)
240
>>> fps.frame(10.01)
241
>>> # We can convert frame# to start sample, for a given samplerate
>>> fps.sample(1, 44100)
0
>>> fps.sample(2, 44100)
1839
>>> fps.sample(3, 44100)
3678
>>> fps.sample(2, 48000)
2002
>>> fps.sample(3, 48000)
4004
>>> # Want to know the sample count for the first 30 frames of video?
>>> sr = 44100
>>> from pprint import pp
>>> pp([fps.sample(f+1, sr) - fps.sample(f, sr)
...     for f in range(1, 31)], compact=True)
[1839, 1839, 1840, 1839, 1839, 1840, 1839, 1839, 1840, 1839, 1839, 1840, 1839,
 1839, 1840, 1839, 1839, 1840, 1839, 1839, 1840, 1839, 1839, 1840, 1839, 1839,
 1840, 1839, 1839, 1840]
```

#### A case of naming

You may notice that the new method names on `FPS` are lowercase. Yeah, sorry. I just couldn't, with the capitalized method names. `TitleCase` is for classes, not for functions. `SomeClass::lowerTitleCase` (aka `antiSentenceCase`) is fine, but not `SomeClass::FullTitleCase`.

You may also notice that `FPS` is fully capitalized, rather than the class name being `Fps`. Yes, yes it is. I'm not even remotely sorry, on that one.

Though I'll have to consider whether a hypothetical method to retrieve a Frame's FPS should be called `Frame::FPS()`  or `Frame::fps()`. (`Frame::fPS()` is no more on the table than `Frame::Fps()` is.) I think I'm leaning towards the latter, if for no other reason than to avoid clashes with the class name. (...And now I suddenly appreciate just how critical things like `decltype()` and `typename` are to writing template code.)

...Even more squirrelly, would the Frame class's method to self-convert into other frame rates be called `Frame::toFPS()` or `Frame::toFps()`? That's kind of a hard one!

FPS also has some other adjustments compared to Fraction. Like, where the Python string representation of a Fraction is <code><var>num</var>:<var>den</var></code> (used by the OpenShot Profile Selector dialog when displaying Profile details), for FPS I've changed that to <code><var>num</var>/<var>den</var></code>. Though, there are arguments for and against displaying _either_ type of value in either format, so I'm not really married to this change yet.

#### Next steps

There's plenty more to add (aside from, like, actually _using_ this in the code itself), but that's the basic idea. 

- [ ] **Additional conversions:**: More types of conversions could also be added, if they'd be useful. (I thought about adding time<->sample, but I couldn't really think of anyplace where that would actually be useful for anything.)
    Some sort of ability to convert _between_ different sample rates in some fashion, OTOH, might actually be handy. It could theoretically centralize the calculations necessary to configure resamplers and size buffers, which are currently scattered, in whole or in part, across ad-hoc implementations found in at least `FFmpegReader`, `AudioResampler`, and I believe `FFmpegWriter` as well.

- [ ] **Storing FPS in Frame?:** Another thing I've been thinking about is storing an `FPS` value _inside_ each Frame object that gets created. Frames basically _do_ have an inherent FPS, since things like their sample count and corresponding time duration (also not currently tracked within Frame itself) are completely dependent on the FPS from which it was created, and Frames moving between FPS values need to be converted (hence FrameMapper).
    But if Frame carried its FPS internally, then it could produce values like start sample and sample duration / time duration on demand, and determining when conversions are required would be simpler.

- [ ] **Unit tests:** `FPS` needs them for itself, and test coverage of anywhere else it's used should ideally be increased to 100% as well.

- [ ] **Documentation:** Filling in the class's missing docstrings, at the very least. (But not the ones inherited from `Fraction`, because it's a _feature_ of Doxygen that you don't have to repeat documentation in every subclass that inherits a member/method. One we should make better use if.)
