### PR TITLE
Fix regression caused by Object Detector renamed to Object Detection

### DIFF
--- a/examples/Example_opencv.cpp
+++ b/examples/Example_opencv.cpp
@@ -152,7 +152,7 @@ int main(int argc, char* argv[]) {
         objectDetection.SaveObjDetectedData();
 
         // Create a object detector effect
-        EffectBase* e = EffectInfo().CreateEffect("Object Detector");
+        EffectBase* e = EffectInfo().CreateEffect("ObjectDetection");
 
         // Pass a JSON string with the saved detections data
         // The effect will read and save the detections in a map::<frame,data_struct>

--- a/src/ClipProcessingJobs.cpp
+++ b/src/ClipProcessingJobs.cpp
@@ -30,7 +30,7 @@ void ClipProcessingJobs::processClip(Clip& clip, std::string json){
     if(processingType == "Tracker"){
         t = std::thread(&ClipProcessingJobs::trackClip, this, std::ref(clip), std::ref(this->processingController));
     }
-    if(processingType == "Object Detector"){
+    if(processingType == "ObjectDetection"){
         t = std::thread(&ClipProcessingJobs::detectObjectsClip, this, std::ref(clip), std::ref(this->processingController));
     }
 }

--- a/src/EffectInfo.cpp
+++ b/src/EffectInfo.cpp
@@ -104,7 +104,7 @@ EffectBase* EffectInfo::CreateEffect(std::string effect_type) {
 	else if(effect_type == "Tracker")
 		return new Tracker();
 
-	else if(effect_type == "Object Detector")
+	else if(effect_type == "ObjectDetection")
 		return new ObjectDetection();
 	#endif
 


### PR DESCRIPTION
Fixed regression in https://github.com/OpenShot/libopenshot/pull/827. Many places in libopenshot and openshot-qt refer to the class name of this effect, causing errors on the daily build, and breakages in various places.