### PR TITLE
Improved PTS support (presentation time stamps)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,6 @@ jobs:
         sys:
           - { os: ubuntu-18.04, shell: bash }
           - { os: ubuntu-latest, shell: bash }
-          - { os: macos-latest, shell: bash }
           - { os: windows-2022, shell: 'msys2 {0}' }
         compiler:
           - { cc: gcc, cxx: g++ }

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -77,7 +77,7 @@ windows-builder-x64:
     - Expand-Archive -Path artifacts.zip -DestinationPath .
     - $env:Path = "C:\msys64\mingw64\bin;C:\msys64\usr\bin;C:\msys64\usr\local\bin;" + $env:Path;
     - $env:MSYSTEM = "MINGW64"
-    - cmake -B build -S . -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -D"babl_DIR=C:/msys64/mingw64" -D"CMAKE_INSTALL_PREFIX:PATH=$CI_PROJECT_DIR\build\install-x64" -D"OpenShotAudio_ROOT=$CI_PROJECT_DIR\build\install-x64" -D"PYTHON_MODULE_PATH=python" -D"RUBY_MODULE_PATH=ruby" -G "MinGW Makefiles" -D"CMAKE_BUILD_TYPE:STRING=Debug"
+    - cmake -B build -S . -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -D"babl_DIR=C:/msys64/mingw64" -D"CMAKE_INSTALL_PREFIX:PATH=$CI_PROJECT_DIR\build\install-x64" -D"OpenShotAudio_ROOT=$CI_PROJECT_DIR\build\install-x64" -D"PYTHON_MODULE_PATH=python" -D"RUBY_MODULE_PATH=ruby" -G "MinGW Makefiles" -D"CMAKE_BUILD_TYPE:STRING=Release"
     - cmake --build build
     - cmake --build build --target coverage
     - cmake --install build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -77,7 +77,7 @@ windows-builder-x64:
     - Expand-Archive -Path artifacts.zip -DestinationPath .
     - $env:Path = "C:\msys64\mingw64\bin;C:\msys64\usr\bin;C:\msys64\usr\local\bin;" + $env:Path;
     - $env:MSYSTEM = "MINGW64"
-    - cmake -B build -S . -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -D"babl_DIR=C:/msys64/mingw64" -D"CMAKE_INSTALL_PREFIX:PATH=$CI_PROJECT_DIR\build\install-x64" -D"OpenShotAudio_ROOT=$CI_PROJECT_DIR\build\install-x64" -D"PYTHON_MODULE_PATH=python" -D"RUBY_MODULE_PATH=ruby" -G "MinGW Makefiles" -D"CMAKE_BUILD_TYPE:STRING=Release"
+    - cmake -B build -S . -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -D"babl_DIR=C:/msys64/mingw64" -D"CMAKE_INSTALL_PREFIX:PATH=$CI_PROJECT_DIR\build\install-x64" -D"OpenShotAudio_ROOT=$CI_PROJECT_DIR\build\install-x64" -D"PYTHON_MODULE_PATH=python" -D"RUBY_MODULE_PATH=ruby" -G "MinGW Makefiles" -D"CMAKE_BUILD_TYPE:STRING=Debug"
     - cmake --build build
     - cmake --build build --target coverage
     - cmake --install build

--- a/examples/Example.cpp
+++ b/examples/Example.cpp
@@ -23,50 +23,15 @@ using namespace openshot;
 
 int main(int argc, char* argv[]) {
 
-    // Types for storing time durations in whole and fractional milliseconds
-    using ms = std::chrono::milliseconds;
-    using s = std::chrono::seconds;
-    using double_ms = std::chrono::duration<double, ms::period>;
-
     // FFmpeg Reader performance test
-    const auto total_1 = std::chrono::high_resolution_clock::now();
-    FFmpegReader r9("/home/jonathan/Videos/sintel_trailer-1080p.mp4");
+    FFmpegReader r9("/home/jonathan/Downloads/pts-test-files/broken-files/lady-talking-1.mp4");
     r9.Open();
-    for (long int frame = 1; frame <= 1000; frame++)
+    for (long int frame = 1; frame <= r9.info.video_length; frame++)
     {
-        const auto time1 = std::chrono::high_resolution_clock::now();
+        std::cout << "Requesting Frame: #: " << frame << std::endl;
         std::shared_ptr<Frame> f = r9.GetFrame(frame);
-        const auto time2 = std::chrono::high_resolution_clock::now();
-        std::cout << "FFmpegReader: " << frame
-                  << " (" << double_ms(time2 - time1).count() << " ms)\n";
     }
-    const auto total_2 = std::chrono::high_resolution_clock::now();
-    auto total_sec = std::chrono::duration_cast<ms>(total_2 - total_1);
-    std::cout << "FFmpegReader TOTAL: " << total_sec.count() << " ms\n";
     r9.Close();
 
-
-    // Timeline Reader performance test
-    Timeline tm(r9.info);
-    Clip *c = new Clip(&r9);
-    tm.AddClip(c);
-    tm.Open();
-
-    const auto total_3 = std::chrono::high_resolution_clock::now();
-    for (long int frame = 1; frame <= 1000; frame++)
-    {
-        const auto time1 = std::chrono::high_resolution_clock::now();
-        std::shared_ptr<Frame> f = tm.GetFrame(frame);
-        const auto time2 = std::chrono::high_resolution_clock::now();
-        std::cout << "Timeline: " << frame
-                  << " (" << double_ms(time2 - time1).count() << " ms)\n";
-    }
-    const auto total_4 = std::chrono::high_resolution_clock::now();
-    total_sec = std::chrono::duration_cast<ms>(total_4 - total_3);
-    std::cout << "Timeline TOTAL: " << total_sec.count() << " ms\n";
-    tm.Close();
-
-    std::cout << "Completed successfully!\n";
-
-    return 0;
+    exit(0);
 }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -19,6 +19,8 @@ if (POLICY CMP0057)
 endif()
 
 ###############  PROFILING  #################
+#set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-omit-frame-pointer -fsanitize=address")
+#set (CMAKE_LINKER_FLAGS "${CMAKE_LINKER_FLAGS} -fno-omit-frame-pointer -fsanitize=address")
 #set(PROFILER "/usr/lib/x86_64-linux-gnu/libprofiler.so.0")
 #set(PROFILER "/usr/lib/x86_64-linux-gnu/libtcmalloc.so.4")
 
@@ -176,6 +178,8 @@ if(NOT TARGET OpenShot::Audio)
   find_package(OpenShotAudio 0.2.0 REQUIRED)
 endif()
 target_link_libraries(openshot PUBLIC OpenShot::Audio)
+
+#find_package(FindAsan)
 
 ###
 ### ImageMagick

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -179,8 +179,6 @@ if(NOT TARGET OpenShot::Audio)
 endif()
 target_link_libraries(openshot PUBLIC OpenShot::Audio)
 
-#find_package(FindAsan)
-
 ###
 ### ImageMagick
 ###

--- a/src/CacheBase.h
+++ b/src/CacheBase.h
@@ -64,6 +64,9 @@ namespace openshot {
 		/// @param frame_number The frame number of the cached frame
 		virtual std::shared_ptr<openshot::Frame> GetFrame(int64_t frame_number) = 0;
 
+        /// @brief Get an vector of all Frames
+        virtual std::vector<std::shared_ptr<openshot::Frame>> GetFrames() = 0;
+
 		/// Gets the maximum bytes value
 		virtual int64_t GetBytes() = 0;
 

--- a/src/CacheBase.h
+++ b/src/CacheBase.h
@@ -53,9 +53,9 @@ namespace openshot {
 		/// Clear the cache of all frames
 		virtual void Clear() = 0;
 
-        /// @brief Check if frame is already contained in cache
-        /// @param frame_number The frame number to be checked
-        virtual bool Contains(int64_t frame_number) = 0;
+		/// @brief Check if frame is already contained in cache
+		/// @param frame_number The frame number to be checked
+		virtual bool Contains(int64_t frame_number) = 0;
 
 		/// Count the frames in the queue
 		virtual int64_t Count() = 0;
@@ -64,8 +64,8 @@ namespace openshot {
 		/// @param frame_number The frame number of the cached frame
 		virtual std::shared_ptr<openshot::Frame> GetFrame(int64_t frame_number) = 0;
 
-        /// @brief Get an vector of all Frames
-        virtual std::vector<std::shared_ptr<openshot::Frame>> GetFrames() = 0;
+		/// @brief Get an vector of all Frames
+		virtual std::vector<std::shared_ptr<openshot::Frame>> GetFrames() = 0;
 
 		/// Gets the maximum bytes value
 		virtual int64_t GetBytes() = 0;

--- a/src/CacheDisk.cpp
+++ b/src/CacheDisk.cpp
@@ -279,6 +279,23 @@ std::shared_ptr<Frame> CacheDisk::GetFrame(int64_t frame_number)
 	return std::shared_ptr<Frame>();
 }
 
+// @brief Get an array of all Frames
+std::vector<std::shared_ptr<openshot::Frame>> CacheDisk::GetFrames()
+{
+	// Create a scoped lock, to protect the cache from multiple threads
+	const std::lock_guard<std::recursive_mutex> lock(*cacheMutex);
+
+	std::vector<std::shared_ptr<openshot::Frame>> all_frames;
+    std::vector<int64_t>::iterator itr_ordered;
+    for(itr_ordered = ordered_frame_numbers.begin(); itr_ordered != ordered_frame_numbers.end(); ++itr_ordered)
+    {
+        int64_t frame_number = *itr_ordered;
+		all_frames.push_back(GetFrame(frame_number));
+	}
+
+	return all_frames;
+}
+
 // Get the smallest frame number (or NULL shared_ptr if no frame is found)
 std::shared_ptr<Frame> CacheDisk::GetSmallestFrame()
 {

--- a/src/CacheDisk.cpp
+++ b/src/CacheDisk.cpp
@@ -81,7 +81,7 @@ void CacheDisk::CalculateRanges() {
 	if (needs_range_processing) {
 
 		// Create a scoped lock, to protect the cache from multiple threads
-                const std::lock_guard<std::recursive_mutex> lock(*cacheMutex);
+		const std::lock_guard<std::recursive_mutex> lock(*cacheMutex);
 
 		// Sort ordered frame #s, and calculate JSON ranges
 		std::sort(ordered_frame_numbers.begin(), ordered_frame_numbers.end());
@@ -135,7 +135,7 @@ void CacheDisk::CalculateRanges() {
 // Default destructor
 CacheDisk::~CacheDisk()
 {
-    Clear();
+	Clear();
 
 	// remove mutex
 	delete cacheMutex;
@@ -202,11 +202,11 @@ void CacheDisk::Add(std::shared_ptr<Frame> frame)
 
 // Check if frame is already contained in cache
 bool CacheDisk::Contains(int64_t frame_number) {
-    if (frames.count(frame_number) > 0) {
-        return true;
-    } else {
-        return false;
-    }
+	if (frames.count(frame_number) > 0) {
+		return true;
+	} else {
+		return false;
+	}
 }
 
 // Get a frame from the cache (or NULL shared_ptr if no frame is found)
@@ -286,10 +286,10 @@ std::vector<std::shared_ptr<openshot::Frame>> CacheDisk::GetFrames()
 	const std::lock_guard<std::recursive_mutex> lock(*cacheMutex);
 
 	std::vector<std::shared_ptr<openshot::Frame>> all_frames;
-    std::vector<int64_t>::iterator itr_ordered;
-    for(itr_ordered = ordered_frame_numbers.begin(); itr_ordered != ordered_frame_numbers.end(); ++itr_ordered)
-    {
-        int64_t frame_number = *itr_ordered;
+	std::vector<int64_t>::iterator itr_ordered;
+	for(itr_ordered = ordered_frame_numbers.begin(); itr_ordered != ordered_frame_numbers.end(); ++itr_ordered)
+	{
+		int64_t frame_number = *itr_ordered;
 		all_frames.push_back(GetFrame(frame_number));
 	}
 
@@ -311,12 +311,12 @@ std::shared_ptr<Frame> CacheDisk::GetSmallestFrame()
 			smallest_frame = *itr;
 	}
 
-    // Return frame (if any)
-    if (smallest_frame != -1) {
-        return GetFrame(smallest_frame);
-    } else {
-        return NULL;
-    }
+	// Return frame (if any)
+	if (smallest_frame != -1) {
+		return GetFrame(smallest_frame);
+	} else {
+		return NULL;
+	}
 }
 
 // Gets the maximum bytes value
@@ -423,11 +423,11 @@ void CacheDisk::Clear()
 	const std::lock_guard<std::recursive_mutex> lock(*cacheMutex);
 
 	// Clear all containers
-    frames.clear();
-    frame_numbers.clear();
-    frame_numbers.shrink_to_fit();
-    ordered_frame_numbers.clear();
-    ordered_frame_numbers.shrink_to_fit();
+	frames.clear();
+	frame_numbers.clear();
+	frame_numbers.shrink_to_fit();
+	ordered_frame_numbers.clear();
+	ordered_frame_numbers.shrink_to_fit();
 	needs_range_processing = true;
 	frame_size_bytes = 0;
 

--- a/src/CacheDisk.h
+++ b/src/CacheDisk.h
@@ -82,9 +82,9 @@ namespace openshot {
 		/// Clear the cache of all frames
 		void Clear();
 
-        /// @brief Check if frame is already contained in cache
-        /// @param frame_number The frame number to be checked
-        bool Contains(int64_t frame_number);
+		/// @brief Check if frame is already contained in cache
+		/// @param frame_number The frame number to be checked
+		bool Contains(int64_t frame_number);
 
 		/// Count the frames in the queue
 		int64_t Count();
@@ -93,8 +93,8 @@ namespace openshot {
 		/// @param frame_number The frame number of the cached frame
 		std::shared_ptr<openshot::Frame> GetFrame(int64_t frame_number);
 
-        /// @brief Get an array of all Frames
-        std::vector<std::shared_ptr<openshot::Frame>> GetFrames();
+		/// @brief Get an array of all Frames
+		std::vector<std::shared_ptr<openshot::Frame>> GetFrames();
 
 		/// Gets the maximum bytes value
 		int64_t GetBytes();

--- a/src/CacheDisk.h
+++ b/src/CacheDisk.h
@@ -93,6 +93,9 @@ namespace openshot {
 		/// @param frame_number The frame number of the cached frame
 		std::shared_ptr<openshot::Frame> GetFrame(int64_t frame_number);
 
+        /// @brief Get an array of all Frames
+        std::vector<std::shared_ptr<openshot::Frame>> GetFrames();
+
 		/// Gets the maximum bytes value
 		int64_t GetBytes();
 

--- a/src/CacheMemory.cpp
+++ b/src/CacheMemory.cpp
@@ -152,6 +152,23 @@ std::shared_ptr<Frame> CacheMemory::GetFrame(int64_t frame_number)
 		return std::shared_ptr<Frame>();
 }
 
+// @brief Get an array of all Frames
+std::vector<std::shared_ptr<openshot::Frame>> CacheMemory::GetFrames()
+{
+    // Create a scoped lock, to protect the cache from multiple threads
+    const std::lock_guard<std::recursive_mutex> lock(*cacheMutex);
+
+    std::vector<std::shared_ptr<openshot::Frame>> all_frames;
+    std::vector<int64_t>::iterator itr_ordered;
+    for(itr_ordered = ordered_frame_numbers.begin(); itr_ordered != ordered_frame_numbers.end(); ++itr_ordered)
+    {
+        int64_t frame_number = *itr_ordered;
+        all_frames.push_back(GetFrame(frame_number));
+    }
+
+    return all_frames;
+}
+
 // Get the smallest frame number (or NULL shared_ptr if no frame is found)
 std::shared_ptr<Frame> CacheMemory::GetSmallestFrame()
 {

--- a/src/CacheMemory.cpp
+++ b/src/CacheMemory.cpp
@@ -36,9 +36,9 @@ CacheMemory::CacheMemory(int64_t max_bytes) : CacheBase(max_bytes) {
 // Default destructor
 CacheMemory::~CacheMemory()
 {
-    Clear();
+	Clear();
 
-    // remove mutex
+	// remove mutex
 	delete cacheMutex;
 }
 
@@ -129,11 +129,11 @@ void CacheMemory::Add(std::shared_ptr<Frame> frame)
 
 // Check if frame is already contained in cache
 bool CacheMemory::Contains(int64_t frame_number) {
-    if (frames.count(frame_number) > 0) {
-        return true;
-    } else {
-        return false;
-    }
+	if (frames.count(frame_number) > 0) {
+		return true;
+	} else {
+		return false;
+	}
 }
 
 // Get a frame from the cache (or NULL shared_ptr if no frame is found)
@@ -155,18 +155,18 @@ std::shared_ptr<Frame> CacheMemory::GetFrame(int64_t frame_number)
 // @brief Get an array of all Frames
 std::vector<std::shared_ptr<openshot::Frame>> CacheMemory::GetFrames()
 {
-    // Create a scoped lock, to protect the cache from multiple threads
-    const std::lock_guard<std::recursive_mutex> lock(*cacheMutex);
+	// Create a scoped lock, to protect the cache from multiple threads
+	const std::lock_guard<std::recursive_mutex> lock(*cacheMutex);
 
-    std::vector<std::shared_ptr<openshot::Frame>> all_frames;
-    std::vector<int64_t>::iterator itr_ordered;
-    for(itr_ordered = ordered_frame_numbers.begin(); itr_ordered != ordered_frame_numbers.end(); ++itr_ordered)
-    {
-        int64_t frame_number = *itr_ordered;
-        all_frames.push_back(GetFrame(frame_number));
-    }
+	std::vector<std::shared_ptr<openshot::Frame>> all_frames;
+	std::vector<int64_t>::iterator itr_ordered;
+	for(itr_ordered = ordered_frame_numbers.begin(); itr_ordered != ordered_frame_numbers.end(); ++itr_ordered)
+	{
+		int64_t frame_number = *itr_ordered;
+		all_frames.push_back(GetFrame(frame_number));
+	}
 
-    return all_frames;
+	return all_frames;
 }
 
 // Get the smallest frame number (or NULL shared_ptr if no frame is found)
@@ -186,9 +186,9 @@ std::shared_ptr<Frame> CacheMemory::GetSmallestFrame()
 
 	// Return frame (if any)
 	if (smallest_frame != -1) {
-        return frames[smallest_frame];
-    } else {
-	    return NULL;
+		return frames[smallest_frame];
+	} else {
+		return NULL;
 	}
 }
 

--- a/src/CacheMemory.h
+++ b/src/CacheMemory.h
@@ -65,9 +65,9 @@ namespace openshot {
 		/// Clear the cache of all frames
 		void Clear();
 
-        /// @brief Check if frame is already contained in cache
-        /// @param frame_number The frame number to be checked
-        bool Contains(int64_t frame_number);
+		/// @brief Check if frame is already contained in cache
+		/// @param frame_number The frame number to be checked
+		bool Contains(int64_t frame_number);
 
 		/// Count the frames in the queue
 		int64_t Count();
@@ -76,8 +76,8 @@ namespace openshot {
 		/// @param frame_number The frame number of the cached frame
 		std::shared_ptr<openshot::Frame> GetFrame(int64_t frame_number);
 
-        /// @brief Get an array of all Frames
-        std::vector<std::shared_ptr<openshot::Frame>> GetFrames();
+		/// @brief Get an array of all Frames
+		std::vector<std::shared_ptr<openshot::Frame>> GetFrames();
 
 		/// Gets the maximum bytes value
 		int64_t GetBytes();

--- a/src/CacheMemory.h
+++ b/src/CacheMemory.h
@@ -76,6 +76,9 @@ namespace openshot {
 		/// @param frame_number The frame number of the cached frame
 		std::shared_ptr<openshot::Frame> GetFrame(int64_t frame_number);
 
+        /// @brief Get an array of all Frames
+        std::vector<std::shared_ptr<openshot::Frame>> GetFrames();
+
 		/// Gets the maximum bytes value
 		int64_t GetBytes();
 

--- a/src/FFmpegReader.cpp
+++ b/src/FFmpegReader.cpp
@@ -587,15 +587,7 @@ void FFmpegReader::Close() {
 		// Mark as "closed"
 		is_open = false;
 
-		ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::Close");
-
-		if (packet) {
-            ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::Close (Remove Packet)");
-
-			// Remove previous packet before getting next one
-			RemoveAVPacket(packet);
-			packet = NULL;
-		}
+		ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::Close (Start)");
 
 		// Close the codec
 		if (info.has_video) {
@@ -621,6 +613,12 @@ void FFmpegReader::Close() {
             ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::Close (Free audio context)");
 			AV_FREE_CONTEXT(aCodecCtx);
 		}
+
+        if (packet) {
+            ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::Close (Remove packet)");
+            RemoveAVPacket(packet);
+            packet = NULL;
+        }
 
 		// Clear final cache
         ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::Close (Clear cache)");

--- a/src/FFmpegReader.cpp
+++ b/src/FFmpegReader.cpp
@@ -2077,7 +2077,7 @@ void FFmpegReader::CheckWorkingFrames(int64_t requested_frame) {
 					if (previous_frame_instance && previous_frame_instance->has_image_data) {
 						// Copy image from last decoded frame
                         ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::CheckWorkingFrames (override video A)", "frame_number", f->number, "previous_frame_instance", previous_frame_instance->number);
-						f->AddImage(std::make_shared<QImage>(*previous_frame_instance->GetImage()));
+						f->AddImage(std::make_shared<QImage>(previous_frame_instance->GetImage()->copy()));
 						break;
 					}
 				}
@@ -2085,7 +2085,7 @@ void FFmpegReader::CheckWorkingFrames(int64_t requested_frame) {
 				if (last_video_frame && !f->has_image_data) {
 					// Copy image from last decoded frame
                     ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::CheckWorkingFrames (override video B)", "frame_number", f->number, "last_video_frame", last_video_frame->number);
-					f->AddImage(std::make_shared<QImage>(*last_video_frame->GetImage()));
+					f->AddImage(std::make_shared<QImage>(last_video_frame->GetImage()->copy()));
 				} else if (!f->has_image_data) {
                     ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::CheckWorkingFrames (override video C)", "frame_number", f->number, "solid_color", 0.0);
 					f->AddColor("#000000");

--- a/src/FFmpegReader.cpp
+++ b/src/FFmpegReader.cpp
@@ -602,11 +602,6 @@ void FFmpegReader::Close() {
             ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::Close (Flush video context)");
 			avcodec_flush_buffers(pCodecCtx);
 
-			// Delete video stream
-            ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::Close (Clear video stream)");
-			pStream = NULL;
-			videoStream = -1;
-
             ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::Close (Free video context)");
 			AV_FREE_CONTEXT(pCodecCtx);
 #if USE_HW_ACCEL
@@ -622,11 +617,6 @@ void FFmpegReader::Close() {
 		if (info.has_audio) {
             ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::Close (Flush audio context)");
 			avcodec_flush_buffers(aCodecCtx);
-
-			// Delete audio stream
-            ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::Close (Clear audio stream)");
-			aStream = NULL;
-			audioStream = -1;
 
             ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::Close (Free audio context)");
 			AV_FREE_CONTEXT(aCodecCtx);

--- a/src/FFmpegReader.cpp
+++ b/src/FFmpegReader.cpp
@@ -1465,6 +1465,12 @@ void FFmpegReader::ProcessAudioPacket(int64_t requested_frame) {
 	// Estimate the # of samples and the end of this packet's location (to prevent GAPS for the next timestamp)
 	int pts_remaining_samples = packet_samples / info.channels; // Adjust for zero based array
 
+	// Bail if no samples found
+	if (pts_remaining_samples == 0) {
+        ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::ProcessAudioPacket (No samples, bailing)", "packet_samples", packet_samples, "info.channels", info.channels, "pts_remaining_samples", pts_remaining_samples);
+	    return;
+    }
+
 	// DEBUG (FOR AUDIO ISSUES) - Get the audio packet start time (in seconds)
 	int64_t adjusted_pts = audio_pts;
 	double audio_seconds = (double(adjusted_pts) * info.audio_timebase.ToDouble()) + pts_offset_seconds;

--- a/src/FFmpegReader.cpp
+++ b/src/FFmpegReader.cpp
@@ -2076,6 +2076,7 @@ void FFmpegReader::CheckWorkingFrames(int64_t requested_frame) {
 					std::shared_ptr<Frame> previous_frame_instance = final_cache.GetFrame(previous_frame);
 					if (previous_frame_instance && previous_frame_instance->has_image_data) {
 						// Copy image from last decoded frame
+                        ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::CheckWorkingFrames (override video A)", "frame_number", f->number, "previous_frame_instance", previous_frame_instance->number);
 						f->AddImage(std::make_shared<QImage>(*previous_frame_instance->GetImage()));
 						break;
 					}
@@ -2083,8 +2084,10 @@ void FFmpegReader::CheckWorkingFrames(int64_t requested_frame) {
 				
 				if (last_video_frame && !f->has_image_data) {
 					// Copy image from last decoded frame
+                    ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::CheckWorkingFrames (override video B)", "frame_number", f->number, "last_video_frame", last_video_frame->number);
 					f->AddImage(std::make_shared<QImage>(*last_video_frame->GetImage()));
 				} else if (!f->has_image_data) {
+                    ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::CheckWorkingFrames (override video C)", "frame_number", f->number, "solid_color", 0.0);
 					f->AddColor("#000000");
 				}
 			}

--- a/src/FFmpegReader.cpp
+++ b/src/FFmpegReader.cpp
@@ -590,60 +590,58 @@ void FFmpegReader::Close() {
 		ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::Close (Start)");
 
 		// Close the codec
-		if (info.has_video) {
-            //ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::Close (Flush video context)");
-            if(avcodec_is_open(pCodecCtx)) {
-                ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::Close (Skipping flush video context)");
-                //avcodec_flush_buffers(pCodecCtx);
-            }
-
-            ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::Close (Free video context)");
-			AV_FREE_CONTEXT(pCodecCtx);
-#if USE_HW_ACCEL
-			if (hw_de_on) {
-				if (hw_device_ctx) {
-                    ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::Close (Free hw context)");
-					av_buffer_unref(&hw_device_ctx);
-					hw_device_ctx = NULL;
-				}
-			}
-#endif // USE_HW_ACCEL
-		}
-		if (info.has_audio) {
-            //ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::Close (Flush audio context)");
-            if(avcodec_is_open(aCodecCtx)) {
-                ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::Close (Skipping flush audio context)");
-                //avcodec_flush_buffers(aCodecCtx);
-            }
-
-            ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::Close (Free audio context)");
-			AV_FREE_CONTEXT(aCodecCtx);
-		}
-
-        if (packet) {
-            ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::Close (Remove packet)");
-            RemoveAVPacket(packet);
-            packet = NULL;
-        }
-
-		// Clear final cache
-        ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::Close (Clear cache)");
-		final_cache.Clear();
-		working_cache.Clear();
-
-		// Close the video file
-        ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::Close (Close format context)");
-		avformat_close_input(&pFormatCtx);
-		av_freep(&pFormatCtx);
-
-		// Reset some variables
-        ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::Close (Clear variables)");
-		last_frame = 0;
-		largest_frame_processed = 0;
-		seek_audio_frame_found = 0;
-		seek_video_frame_found = 0;
-		current_video_frame = 0;
-		last_video_frame.reset();
+//		if (info.has_video) {
+//            ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::Close (Flush video context)");
+//            if(avcodec_is_open(pCodecCtx)) {
+//                avcodec_flush_buffers(pCodecCtx);
+//            }
+//
+//            ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::Close (Free video context)");
+//			AV_FREE_CONTEXT(pCodecCtx);
+//#if USE_HW_ACCEL
+//			if (hw_de_on) {
+//				if (hw_device_ctx) {
+//                    ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::Close (Free hw context)");
+//					av_buffer_unref(&hw_device_ctx);
+//					hw_device_ctx = NULL;
+//				}
+//			}
+//#endif // USE_HW_ACCEL
+//		}
+//		if (info.has_audio) {
+//            ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::Close (Flush audio context)");
+//            if(avcodec_is_open(aCodecCtx)) {
+//                avcodec_flush_buffers(aCodecCtx);
+//            }
+//
+//            ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::Close (Free audio context)");
+//			AV_FREE_CONTEXT(aCodecCtx);
+//		}
+//
+//        if (packet) {
+//            ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::Close (Remove packet)");
+//            RemoveAVPacket(packet);
+//            packet = NULL;
+//        }
+//
+//		// Clear final cache
+//        ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::Close (Clear cache)");
+//		final_cache.Clear();
+//		working_cache.Clear();
+//
+//		// Close the video file
+//        ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::Close (Close format context)");
+//		avformat_close_input(&pFormatCtx);
+//		av_freep(&pFormatCtx);
+//
+//		// Reset some variables
+//        ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::Close (Clear variables)");
+//		last_frame = 0;
+//		largest_frame_processed = 0;
+//		seek_audio_frame_found = 0;
+//		seek_video_frame_found = 0;
+//		current_video_frame = 0;
+//		last_video_frame.reset();
 	}
     ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::Close (End)");
 }

--- a/src/FFmpegReader.cpp
+++ b/src/FFmpegReader.cpp
@@ -1358,9 +1358,11 @@ void FFmpegReader::ProcessVideoPacket(int64_t requested_frame) {
 	// Add Image data to frame
 	if (!ffmpeg_has_alpha(AV_GET_CODEC_PIXEL_FORMAT(pStream, pCodecCtx))) {
 		// Add image with no alpha channel, Speed optimization
+		std::cout << "FFmpegReader::ProcessVideoPacket (A AddImage for frame: " << f->number << ", buffer: " << ( void * )&buffer[0] << ")" << std::endl;
 		f->AddImage(width, height, bytes_per_pixel, QImage::Format_RGBA8888_Premultiplied, buffer);
 	} else {
 		// Add image with alpha channel (this will be converted to premultipled when needed, but is slower)
+        std::cout << "FFmpegReader::ProcessVideoPacket (B AddImage for frame: " << f->number << ", buffer: " << ( void * )&buffer[0] << ")" << std::endl;
 		f->AddImage(width, height, bytes_per_pixel, QImage::Format_RGBA8888, buffer);
 	}
 

--- a/src/FFmpegReader.cpp
+++ b/src/FFmpegReader.cpp
@@ -584,7 +584,7 @@ void FFmpegReader::Open() {
 void FFmpegReader::Close() {
 	// Close all objects, if reader is 'open'
 	if (is_open) {
-	    // Prevent calls to GetFrame when Closing
+		// Prevent calls to GetFrame when Closing
 		const std::lock_guard<std::recursive_mutex> lock(processingMutex);
 
 		// Mark as "closed"
@@ -1536,11 +1536,10 @@ void FFmpegReader::ProcessAudioPacket(int64_t requested_frame) {
 
 	// Copy audio samples over original samples
 	memcpy(audio_buf,
-		   audio_converted->data[0],
-		   static_cast<size_t>(audio_converted->nb_samples)
-			   * av_get_bytes_per_sample(AV_SAMPLE_FMT_S16)
-			   * info.channels
-		  );
+		audio_converted->data[0],
+		static_cast<size_t>(audio_converted->nb_samples)
+		* av_get_bytes_per_sample(AV_SAMPLE_FMT_S16)
+		* info.channels);
 
 	// Deallocate resample buffer
 	SWR_CLOSE(avr);
@@ -2058,7 +2057,11 @@ void FFmpegReader::CheckWorkingFrames(int64_t requested_frame) {
 			// Video stream is past this frame (so it must be done)
 			// OR video stream is too far behind, missing, or end-of-file
 			is_video_ready = true;
-			ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::CheckWorkingFrames (video ready)", "frame_number", f->number, "frame_pts_seconds", frame_pts_seconds, "video_pts_seconds", video_pts_seconds, "recent_pts_diff", recent_pts_diff);
+			ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::CheckWorkingFrames (video ready)",
+											"frame_number", f->number, 
+											"frame_pts_seconds", frame_pts_seconds, 
+											"video_pts_seconds", video_pts_seconds, 
+											"recent_pts_diff", recent_pts_diff);
 			if (info.has_video && !f->has_image_data) {
 				// Frame has no image data (copy from previous frame)
 				// Loop backwards through final frames (looking for the nearest, previous frame image)
@@ -2088,7 +2091,12 @@ void FFmpegReader::CheckWorkingFrames(int64_t requested_frame) {
 			// OR audio stream is too far behind, missing, or end-of-file
 			// Adding a bit of margin here, to allow for partial audio packets
 			is_audio_ready = true;
-			ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::CheckWorkingFrames (audio ready)", "frame_number", f->number, "frame_pts_seconds", frame_pts_seconds, "audio_pts_seconds", audio_pts_seconds, "audio_pts_diff", audio_pts_diff, "recent_pts_diff", recent_pts_diff);
+			ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::CheckWorkingFrames (audio ready)",
+											"frame_number", f->number, 
+											"frame_pts_seconds", frame_pts_seconds, 
+											"audio_pts_seconds", audio_pts_seconds, 
+											"audio_pts_diff", audio_pts_diff, 
+											"recent_pts_diff", recent_pts_diff);
 		}
 		bool is_seek_trash = IsPartialFrame(f->number);
 
@@ -2097,12 +2105,24 @@ void FFmpegReader::CheckWorkingFrames(int64_t requested_frame) {
 		if (!info.has_audio) is_audio_ready = true;
 
 		// Debug output
-		ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::CheckWorkingFrames", "frame_number", f->number, "is_video_ready", is_video_ready, "is_audio_ready", is_audio_ready, "video_eof", video_eof, "audio_eof", audio_eof, "end_of_file", end_of_file);
+		ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::CheckWorkingFrames",
+										   "frame_number", f->number, 
+										   "is_video_ready", is_video_ready, 
+										   "is_audio_ready", is_audio_ready, 
+										   "video_eof", video_eof, 
+										   "audio_eof", audio_eof, 
+										   "end_of_file", end_of_file);
 
 		// Check if working frame is final
 		if ((!end_of_file && is_video_ready && is_audio_ready) || end_of_file || is_seek_trash) {
 			// Debug output
-			ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::CheckWorkingFrames (mark frame as final)", "requested_frame", requested_frame, "f->number", f->number, "is_seek_trash", is_seek_trash, "Working Cache Count", working_cache.Count(), "Final Cache Count", final_cache.Count(), "end_of_file", end_of_file);
+			ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::CheckWorkingFrames (mark frame as final)", 
+											"requested_frame", requested_frame, 
+											"f->number", f->number, 
+											"is_seek_trash", is_seek_trash, 
+											"Working Cache Count", working_cache.Count(), 
+											"Final Cache Count", final_cache.Count(), 
+											"end_of_file", end_of_file);
 
 			if (!is_seek_trash) {
 				// Move frame to final cache

--- a/src/FFmpegReader.cpp
+++ b/src/FFmpegReader.cpp
@@ -1746,7 +1746,6 @@ void FFmpegReader::Seek(int64_t requested_frame) {
 
 		} else {
 			// seek failed
-			is_seeking = false;
 			seeking_pts = 0;
 			seeking_frame = 0;
 
@@ -1802,7 +1801,6 @@ void FFmpegReader::UpdatePTSOffset() {
     }
 
     // Loop through the stream (until a packet from all streams is found)
-    int64_t pts = 0;
     while (!has_video_pts || !has_audio_pts) {
         // Get the next packet (if any)
         if (GetNextPacket() < 0)
@@ -1810,7 +1808,7 @@ void FFmpegReader::UpdatePTSOffset() {
             break;
 
         // Get PTS of this packet
-        pts = GetPacketPTS();
+        int64_t pts = GetPacketPTS();
 
         // Video packet
         if (!has_video_pts && packet->stream_index == videoStream) {
@@ -2021,7 +2019,7 @@ void FFmpegReader::CheckWorkingFrames(int64_t requested_frame) {
         std::shared_ptr<Frame> f = *working_itr;
 
 		// Was a frame found? Is frame requested yet?
-		if (!f || (f && f->number > requested_frame)) {
+		if (!f || f && f->number > requested_frame) {
 		    // If not, skip to next one
             continue;
         }
@@ -2147,7 +2145,7 @@ void FFmpegReader::CheckFPS() {
 
 	// Calculate FPS (based on the first few seconds of video packets)
 	float avg_fps = 30.0;
-	if (starting_frames_detected > 0 && fps_index > 0 && max_fps_index > 0) {
+	if (starting_frames_detected > 0 && fps_index > 0) {
         avg_fps = float(starting_frames_detected) / std::min(fps_index, max_fps_index);
     }
 

--- a/src/FFmpegReader.cpp
+++ b/src/FFmpegReader.cpp
@@ -586,62 +586,83 @@ void FFmpegReader::Close() {
 	if (is_open) {
 		// Mark as "closed"
 		is_open = false;
-
 		ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::Close (Start)");
 
-		// Close the codec
-//		if (info.has_video) {
-//            ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::Close (Flush video context)");
-//            if(avcodec_is_open(pCodecCtx)) {
-//                avcodec_flush_buffers(pCodecCtx);
-//            }
-//
-//            ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::Close (Free video context)");
-//			AV_FREE_CONTEXT(pCodecCtx);
-//#if USE_HW_ACCEL
-//			if (hw_de_on) {
-//				if (hw_device_ctx) {
-//                    ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::Close (Free hw context)");
-//					av_buffer_unref(&hw_device_ctx);
-//					hw_device_ctx = NULL;
-//				}
-//			}
-//#endif // USE_HW_ACCEL
-//		}
-//		if (info.has_audio) {
-//            ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::Close (Flush audio context)");
-//            if(avcodec_is_open(aCodecCtx)) {
-//                avcodec_flush_buffers(aCodecCtx);
-//            }
-//
-//            ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::Close (Free audio context)");
-//			AV_FREE_CONTEXT(aCodecCtx);
-//		}
-//
-//        if (packet) {
-//            ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::Close (Remove packet)");
-//            RemoveAVPacket(packet);
-//            packet = NULL;
-//        }
-//
-//		// Clear final cache
-//        ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::Close (Clear cache)");
-//		final_cache.Clear();
-//		working_cache.Clear();
-//
-//		// Close the video file
-//        ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::Close (Close format context)");
-//		avformat_close_input(&pFormatCtx);
-//		av_freep(&pFormatCtx);
-//
-//		// Reset some variables
-//        ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::Close (Clear variables)");
-//		last_frame = 0;
-//		largest_frame_processed = 0;
-//		seek_audio_frame_found = 0;
-//		seek_video_frame_found = 0;
-//		current_video_frame = 0;
-//		last_video_frame.reset();
+		// Keep track of most recent packet
+        AVPacket *recent_packet = packet;
+
+		// Drain any packets from the decoder
+        packet = NULL;
+        int attempts = 0;
+		while (packets_decoded < packets_read && attempts < 256) {
+            ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::Close (Drain decoder loop)",
+                                                     "packets_read", packets_read,
+                                                     "packets_decoded", packets_decoded,
+                                                     "attempts", attempts);
+            if (info.has_video) {
+                ProcessVideoPacket(info.video_length);
+            }
+            if (info.has_audio) {
+                ProcessAudioPacket(info.video_length);
+            }
+            attempts++;
+		}
+
+		// Remove packet
+        if (recent_packet) {
+            ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::Close (Remove packet)");
+            RemoveAVPacket(recent_packet);
+        }
+
+		// Close the video codec
+		if (info.has_video) {
+            ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::Close (Flush video context)");
+            if(avcodec_is_open(pCodecCtx)) {
+                avcodec_flush_buffers(pCodecCtx);
+            }
+
+            ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::Close (Free video context)");
+			AV_FREE_CONTEXT(pCodecCtx);
+#if USE_HW_ACCEL
+			if (hw_de_on) {
+				if (hw_device_ctx) {
+                    ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::Close (Free hw context)");
+					av_buffer_unref(&hw_device_ctx);
+					hw_device_ctx = NULL;
+				}
+			}
+#endif // USE_HW_ACCEL
+		}
+
+        // Close the audio codec
+		if (info.has_audio) {
+            ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::Close (Flush audio context)");
+            if(avcodec_is_open(aCodecCtx)) {
+                avcodec_flush_buffers(aCodecCtx);
+            }
+
+            ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::Close (Free audio context)");
+			AV_FREE_CONTEXT(aCodecCtx);
+		}
+
+		// Clear final cache
+        ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::Close (Clear cache)");
+		final_cache.Clear();
+		working_cache.Clear();
+
+		// Close the video file
+        ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::Close (Close format context)");
+		avformat_close_input(&pFormatCtx);
+		av_freep(&pFormatCtx);
+
+		// Reset some variables
+        ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::Close (Clear variables)");
+		last_frame = 0;
+		largest_frame_processed = 0;
+		seek_audio_frame_found = 0;
+		seek_video_frame_found = 0;
+		current_video_frame = 0;
+		last_video_frame.reset();
 	}
     ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::Close (End)");
 }

--- a/src/FFmpegReader.cpp
+++ b/src/FFmpegReader.cpp
@@ -68,21 +68,27 @@ int hw_de_on = 0;
 	AVHWDeviceType hw_de_av_device_type_global = AV_HWDEVICE_TYPE_NONE;
 #endif
 
-FFmpegReader::FFmpegReader(const std::string& path, bool inspect_reader)
-		: last_frame(0), is_seeking(0), seeking_pts(0), seeking_frame(0), seek_count(0),
-		  audio_pts_offset(99999), video_pts_offset(99999), path(path), is_video_seek(true), check_interlace(false),
-		  check_fps(false), enable_seek(true), is_open(false), seek_audio_frame_found(0), seek_video_frame_found(0),
-		  prev_samples(0), prev_pts(0), pts_total(0), pts_counter(0), is_duration_known(false), largest_frame_processed(0),
-		  current_video_frame(0), has_missing_frames(false), num_packets_since_video_frame(0), num_checks_since_final(0),
-		  packet(NULL), max_concurrent_frames(OPEN_MP_NUM_PROCESSORS) {
+FFmpegReader::FFmpegReader(const std::string &path, bool inspect_reader)
+        : last_frame(0), is_seeking(0), seeking_pts(0), seeking_frame(0), seek_count(0), NO_PTS_OFFSET(-99999),
+          path(path), is_video_seek(true), check_interlace(false), check_fps(false), enable_seek(true), is_open(false),
+          seek_audio_frame_found(0), seek_video_frame_found(0), prev_samples(0), prev_pts(0), pts_total(0),
+          pts_counter(0), is_duration_known(false), largest_frame_processed(0), current_video_frame(0), packet(NULL),
+          max_concurrent_frames(OPEN_MP_NUM_PROCESSORS), audio_pts(0), video_pts(0), pFormatCtx(NULL), packets_read(0),
+          packets_decoded(0), videoStream(-1), audioStream(-1), pCodecCtx(NULL), aCodecCtx(NULL), pStream(NULL),
+          aStream(NULL), pFrame(NULL), previous_packet_location{-1,0}, video_eof(false), audio_eof(false),
+          packets_eof(false), end_of_file(false) {
 
 	// Initialize FFMpeg, and register all formats and codecs
 	AV_REGISTER_ALL
 	AVCODEC_REGISTER_ALL
 
+	// Init timestamp offsets
+    pts_offset_seconds = NO_PTS_OFFSET;
+    video_pts_seconds = NO_PTS_OFFSET;
+    audio_pts_seconds = NO_PTS_OFFSET;
+
 	// Init cache
 	working_cache.SetMaxBytesFromInfo(max_concurrent_frames * info.fps.ToDouble() * 2, info.width, info.height, info.sample_rate, info.channels);
-	missing_frames.SetMaxBytesFromInfo(max_concurrent_frames * 2, info.width, info.height, info.sample_rate, info.channels);
 	final_cache.SetMaxBytesFromInfo(max_concurrent_frames * 2, info.width, info.height, info.sample_rate, info.channels);
 
 	// Open and Close the reader, to populate its attributes (such as height, width, etc...)
@@ -218,15 +224,30 @@ void FFmpegReader::Open() {
 
 		videoStream = -1;
 		audioStream = -1;
+
+		// Init end-of-file detection variables
+		video_eof = true;
+		audio_eof = true;
+        packets_eof = true;
+        end_of_file = true;
+        packets_read = 0;
+        packets_decoded = 0;
+
 		// Loop through each stream, and identify the video and audio stream index
 		for (unsigned int i = 0; i < pFormatCtx->nb_streams; i++) {
 			// Is this a video stream?
 			if (AV_GET_CODEC_TYPE(pFormatCtx->streams[i]) == AVMEDIA_TYPE_VIDEO && videoStream < 0) {
 				videoStream = i;
-			}
+                video_eof = false;
+                packets_eof = false;
+                end_of_file = false;
+            }
 			// Is this an audio stream?
 			if (AV_GET_CODEC_TYPE(pFormatCtx->streams[i]) == AVMEDIA_TYPE_AUDIO && audioStream < 0) {
 				audioStream = i;
+                audio_eof = false;
+                packets_eof = false;
+                end_of_file = false;
 			}
 		}
 		if (videoStream == -1 && audioStream == -1)
@@ -537,10 +558,25 @@ void FFmpegReader::Open() {
 
 		// Adjust cache size based on size of frame and audio
 		working_cache.SetMaxBytesFromInfo(max_concurrent_frames * info.fps.ToDouble() * 2, info.width, info.height, info.sample_rate, info.channels);
-		missing_frames.SetMaxBytesFromInfo(max_concurrent_frames * 2, info.width, info.height, info.sample_rate, info.channels);
 		final_cache.SetMaxBytesFromInfo(max_concurrent_frames * 2, info.width, info.height, info.sample_rate, info.channels);
 
-		// Mark as "open"
+        // Scan PTS for any offsets (i.e. non-zero starting streams). At least 1 stream must start at zero timestamp.
+        // This method allows us to shift timestamps to ensure at least 1 stream is starting at zero.
+        UpdatePTSOffset();
+
+        // Override an invalid framerate
+        if (info.fps.ToFloat() > 240.0f || (info.fps.num <= 0 || info.fps.den <= 0) || info.video_length <= 0) {
+            // Calculate FPS, duration, video bit rate, and video length manually
+            // by scanning through all the video stream packets
+            CheckFPS();
+        }
+
+        // Seek back to beginning of file (if not already seeking)
+        if (!is_seeking) {
+            Seek(1);
+        }
+
+        // Mark as "open"
 		is_open = true;
 	}
 }
@@ -562,6 +598,12 @@ void FFmpegReader::Close() {
 		// Close the codec
 		if (info.has_video) {
 			avcodec_flush_buffers(pCodecCtx);
+
+			// Delete video stream
+            pStream->discard = AVDISCARD_ALL;
+            pStream = NULL;
+            videoStream = -1;
+
 			AV_FREE_CONTEXT(pCodecCtx);
 #if USE_HW_ACCEL
 			if (hw_de_on) {
@@ -574,27 +616,18 @@ void FFmpegReader::Close() {
 		}
 		if (info.has_audio) {
 			avcodec_flush_buffers(aCodecCtx);
+
+            // Delete audio stream
+            aStream->discard = AVDISCARD_ALL;
+            aStream = NULL;
+            audioStream = -1;
+
 			AV_FREE_CONTEXT(aCodecCtx);
 		}
 
 		// Clear final cache
 		final_cache.Clear();
 		working_cache.Clear();
-		missing_frames.Clear();
-
-		// Clear processed lists
-		{
-			const std::lock_guard<std::recursive_mutex> lock(processingMutex);
-			processed_video_frames.clear();
-			processed_audio_frames.clear();
-			processing_video_frames.clear();
-			processing_audio_frames.clear();
-			missing_audio_frames.clear();
-			missing_video_frames.clear();
-			missing_audio_frames_source.clear();
-			missing_video_frames_source.clear();
-			checked_frames.clear();
-		}
 
 		// Close the video file
 		avformat_close_input(&pFormatCtx);
@@ -606,8 +639,6 @@ void FFmpegReader::Close() {
 		seek_audio_frame_found = 0;
 		seek_video_frame_found = 0;
 		current_video_frame = 0;
-		has_missing_frames = false;
-
 		last_video_frame.reset();
 	}
 }
@@ -688,10 +719,6 @@ void FFmpegReader::UpdateAudioInfo() {
 }
 
 void FFmpegReader::UpdateVideoInfo() {
-	if (check_fps)
-		// Already initialized all the video metadata, no reason to do it again
-		return;
-
 	// Set values of FileInfo struct
 	info.has_video = true;
 	info.file_size = pFormatCtx->pb ? avio_size(pFormatCtx->pb) : -1;
@@ -702,8 +729,10 @@ void FFmpegReader::UpdateVideoInfo() {
 
 	// Frame rate from the container and codec
 	AVRational framerate = av_guess_frame_rate(pFormatCtx, pStream, NULL);
-	info.fps.num = framerate.num;
-	info.fps.den = framerate.den;
+	if (!check_fps) {
+        info.fps.num = framerate.num;
+        info.fps.den = framerate.den;
+    }
 
 	ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::UpdateVideoInfo", "info.fps.num", info.fps.num, "info.fps.den", info.fps.den);
 
@@ -793,13 +822,6 @@ void FFmpegReader::UpdateVideoInfo() {
 		info.video_length = round(info.duration * info.fps.ToDouble());
 	}
 
-	// Override an invalid framerate
-	if (info.fps.ToFloat() > 240.0f || (info.fps.num <= 0 || info.fps.den <= 0) || info.video_length <= 0) {
-		// Calculate FPS, duration, video bit rate, and video length manually
-		// by scanning through all the video stream packets
-		CheckFPS();
-	}
-
 	// Add video metadata (if any)
 	AVDictionaryEntry *tag = NULL;
 	while ((tag = av_dict_get(pStream->metadata, "", tag, AV_DICT_IGNORE_SUFFIX))) {
@@ -851,11 +873,6 @@ std::shared_ptr<Frame> FFmpegReader::GetFrame(int64_t requested_frame) {
             // Reset seek count
             seek_count = 0;
 
-            // Check for first frame (always need to get frame 1 before other frames, to correctly calculate offsets)
-            if (last_frame == 0 && requested_frame != 1)
-                // Get first frame
-                ReadStream(1);
-
             // Are we within X frames of the requested frame?
             int64_t diff = requested_frame - last_frame;
             if (diff >= 1 && diff <= 20) {
@@ -863,14 +880,14 @@ std::shared_ptr<Frame> FFmpegReader::GetFrame(int64_t requested_frame) {
                 frame = ReadStream(requested_frame);
             } else {
                 // Greater than 30 frames away, or backwards, we need to seek to the nearest key frame
-                if (enable_seek)
+                if (enable_seek) {
                     // Only seek if enabled
                     Seek(requested_frame);
 
-                else if (!enable_seek && diff < 0) {
+                } else if (!enable_seek && diff < 0) {
                     // Start over, since we can't seek, and the requested frame is smaller than our position
-                    Close();
-                    Open();
+                    // Since we are seeking to frame 1, this actually just closes/re-opens the reader
+                    Seek(1);
                 }
 
                 // Then continue walking the stream
@@ -884,144 +901,92 @@ std::shared_ptr<Frame> FFmpegReader::GetFrame(int64_t requested_frame) {
 // Read the stream until we find the requested Frame
 std::shared_ptr<Frame> FFmpegReader::ReadStream(int64_t requested_frame) {
 	// Allocate video frame
-	bool end_of_stream = false;
 	bool check_seek = false;
-	bool frame_finished = false;
 	int packet_error = -1;
-
-	// Minimum number of packets to process (for performance reasons)
-	int packets_processed = 0;
-	int minimum_packets = 1;
-	int max_packets = 4096;
 
 	// Debug output
 	ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::ReadStream", "requested_frame", requested_frame, "max_concurrent_frames", max_concurrent_frames);
 
 	// Loop through the stream until the correct frame is found
 	while (true) {
-		// Get the next packet into a local variable called packet
+        // Check if working frames are 'finished'
+        if (!is_seeking) {
+            // Check for final frames
+            CheckWorkingFrames(requested_frame);
+        }
+
+        // Check if requested 'final' frame is available (and break out of loop if found)
+        bool is_cache_found = (final_cache.GetFrame(requested_frame) != NULL);
+        if (is_cache_found) {
+            break;
+        }
+
+		// Get the next packet
 		packet_error = GetNextPacket();
-
-		int processing_video_frames_size = 0;
-		int processing_audio_frames_size = 0;
-		{
-			const std::lock_guard<std::recursive_mutex> lock(processingMutex);
-			processing_video_frames_size = processing_video_frames.size();
-			processing_audio_frames_size = processing_audio_frames.size();
-		}
-
-		// Wait if too many frames are being processed
-		while (processing_video_frames_size + processing_audio_frames_size >= minimum_packets) {
-			std::this_thread::sleep_for(std::chrono::milliseconds(3));
-			const std::lock_guard<std::recursive_mutex> lock(processingMutex);
-			processing_video_frames_size = processing_video_frames.size();
-			processing_audio_frames_size = processing_audio_frames.size();
-		}
-
-		// Get the next packet (if any)
-		if (packet_error < 0) {
-			// Break loop when no more packets found
-			end_of_stream = true;
-			break;
+		if (packet_error < 0 && !packet) {
+			// No more packets to be found
+            packets_eof = true;
 		}
 
 		// Debug output
-		ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::ReadStream (GetNextPacket)", "requested_frame", requested_frame, "processing_video_frames_size", processing_video_frames_size, "processing_audio_frames_size", processing_audio_frames_size, "minimum_packets", minimum_packets, "packets_processed", packets_processed, "is_seeking", is_seeking);
+		ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::ReadStream (GetNextPacket)", "requested_frame", requested_frame,"packets_read", packets_read, "packets_decoded", packets_decoded, "is_seeking", is_seeking);
+
+        // Check the status of a seek (if any)
+        if (is_seeking) {
+            check_seek = CheckSeek(false);
+        } else {
+            check_seek = false;
+        }
+
+        if (check_seek) {
+            // Packet may become NULL on Close inside Seek if CheckSeek returns false
+            // Jump to the next iteration of this loop
+            continue;
+        }
 
 		// Video packet
-		if (info.has_video && packet->stream_index == videoStream) {
-			// Reset this counter, since we have a video packet
-			num_packets_since_video_frame = 0;
-
-			// Check the status of a seek (if any)
-			if (is_seeking) {
-				check_seek = CheckSeek(true);
-			} else {
-				check_seek = false;
-			}
-
-			if (check_seek) {
-				// Jump to the next iteration of this loop
-				continue;
-			}
-
-			// Packet may become NULL on Close inside Seek if CheckSeek returns false
-			if (!packet) {
-				// Jump to the next iteration of this loop
-				continue;
-			}
-
-			// Get the AVFrame from the current packet
-			frame_finished = GetAVFrame();
-
-			// Check if the AVFrame is finished and set it
-			if (frame_finished) {
-				// Update PTS / Frame Offset (if any)
-				UpdatePTSOffset(true);
-
-				// Process Video Packet
-				ProcessVideoPacket(requested_frame);
-			}
-
+		if ((info.has_video && packet && packet->stream_index == videoStream) ||
+		    (info.has_video && !packet && !video_eof)) {
+            // Process Video Packet
+            ProcessVideoPacket(requested_frame);
 		}
-			// Audio packet
-		else if (info.has_audio && packet->stream_index == audioStream) {
-			// Increment this (to track # of packets since the last video packet)
-			num_packets_since_video_frame++;
-
-			// Check the status of a seek (if any)
-			if (is_seeking) {
-				check_seek = CheckSeek(false);
-			} else {
-				check_seek = false;
-			}
-
-			if (check_seek) {
-				// Jump to the next iteration of this loop
-				continue;
-			}
-
-			// Packet may become NULL on Close inside Seek if CheckSeek returns false
-			if (!packet) {
-				// Jump to the next iteration of this loop
-				continue;
-			}
-
-			// Update PTS / Frame Offset (if any)
-			UpdatePTSOffset(false);
-
-			// Determine related video frame and starting sample # from audio PTS
-			AudioLocation location = GetAudioPTSLocation(packet->pts);
-
+		// Audio packet
+		else if ((info.has_audio && packet && packet->stream_index == audioStream) ||
+		    (info.has_audio && !packet && !audio_eof)) {
 			// Process Audio Packet
-			ProcessAudioPacket(requested_frame, location.frame, location.sample_start);
+			ProcessAudioPacket(requested_frame);
 		}
-
-		// Check if working frames are 'finished'
-		if (!is_seeking) {
-			// Check for final frames
-			CheckWorkingFrames(false, requested_frame);
-		}
-
-		// Check if requested 'final' frame is available
-		bool is_cache_found = (final_cache.GetFrame(requested_frame) != NULL);
-
-		// Increment frames processed
-		packets_processed++;
-
-		// Break once the frame is found
-		if ((is_cache_found && packets_processed >= minimum_packets) || packets_processed > max_packets)
-			break;
-
+        
+        // Determine end-of-stream (waiting until final decoder threads finish)
+        // Force end-of-stream in some situations
+        end_of_file = packets_eof && video_eof && audio_eof;
+        if ((packets_eof && packets_read == packets_decoded) || end_of_file) {
+            // Force EOF (end of file) variables to true, if decoder does not support EOF detection.
+            // If we have no more packets, and all known packets have been decoded
+            ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::ReadStream (force EOF)", "packets_read", packets_read, "packets_decoded", packets_decoded, "packets_eof", packets_eof, "video_eof", video_eof, "audio_eof", audio_eof, "end_of_file", end_of_file);
+            if (!video_eof) {
+                video_eof = true;
+            }
+            if (!audio_eof) {
+                audio_eof = true;
+            }
+            end_of_file = true;
+            break;
+        }
 	} // end while
 
 	// Debug output
-	ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::ReadStream (Completed)", "packets_processed", packets_processed, "end_of_stream", end_of_stream, "largest_frame_processed", largest_frame_processed, "Working Cache Count", working_cache.Count());
+	ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::ReadStream (Completed)", "packets_read", packets_read, "packets_decoded", packets_decoded,"end_of_file", end_of_file, "largest_frame_processed", largest_frame_processed, "Working Cache Count", working_cache.Count());
 
-	// End of stream?
-	if (end_of_stream)
-		// Mark the any other working frames as 'finished'
-		CheckWorkingFrames(end_of_stream, requested_frame);
+	// Have we reached end-of-stream (or the final frame)?
+	if (!end_of_file && requested_frame >= info.video_length) {
+	    // Force end-of-stream
+	    end_of_file = true;
+	}
+	if (end_of_file) {
+		// Mark any other working frames as 'finished'
+		CheckWorkingFrames(requested_frame);
+    }
 
 	// Return requested frame (if found)
 	std::shared_ptr<Frame> frame = final_cache.GetFrame(requested_frame);
@@ -1060,8 +1025,11 @@ int FFmpegReader::GetNextPacket() {
 	if (found_packet >= 0) {
 		// Update current packet pointer
 		packet = next_packet;
+		packets_read++;
 	} else {
+        // No more packets found
 		delete next_packet;
+        packet = NULL;
 	}
 	// Return if packet was found (or error number)
 	return found_packet;
@@ -1069,25 +1037,24 @@ int FFmpegReader::GetNextPacket() {
 
 // Get an AVFrame (if any)
 bool FFmpegReader::GetAVFrame() {
-	int frameFinished = -1;
-	int ret = 0;
+	int frameFinished = 0;
 
 	// Decode video frame
 	AVFrame *next_frame = AV_ALLOCATE_FRAME();
 
 #if IS_FFMPEG_3_2
-	frameFinished = 0;
-	ret = avcodec_send_packet(pCodecCtx, packet);
+    int send_packet_err = avcodec_send_packet(pCodecCtx, packet);
 
 	#if USE_HW_ACCEL
 		// Get the format from the variables set in get_hw_dec_format
 		hw_de_av_pix_fmt = hw_de_av_pix_fmt_global;
 		hw_de_av_device_type = hw_de_av_device_type_global;
 	#endif // USE_HW_ACCEL
-		if (ret < 0 || ret == AVERROR(EAGAIN) || ret == AVERROR_EOF) {
-			ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::GetAVFrame (Packet not sent)");
+		if (send_packet_err < 0 && send_packet_err != AVERROR_EOF) {
+			ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::GetAVFrame (Packet not sent)", "send_packet_err", send_packet_err);
 		}
 		else {
+            int receive_frame_err = 0;
 			AVFrame *next_frame2;
 	#if USE_HW_ACCEL
 			if (hw_de_on && hw_de_supported) {
@@ -1099,14 +1066,22 @@ bool FFmpegReader::GetAVFrame() {
 				next_frame2 = next_frame;
 			}
 			pFrame = AV_ALLOCATE_FRAME();
-			while (ret >= 0) {
-				ret =  avcodec_receive_frame(pCodecCtx, next_frame2);
-				if (ret == AVERROR(EAGAIN) || ret == AVERROR_EOF) {
-					break;
-				}
-				if (ret != 0) {
-					ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::GetAVFrame (invalid return frame received)");
-				}
+			while (receive_frame_err >= 0) {
+                receive_frame_err = avcodec_receive_frame(pCodecCtx, next_frame2);
+
+                if (receive_frame_err == AVERROR_EOF) {
+                    ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::GetAVFrame (EOF - end of file detected from decoder)");
+                    video_eof = true;
+                }
+                if (receive_frame_err == AVERROR(EINVAL) || receive_frame_err == AVERROR_EOF) {
+                    ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::GetAVFrame (invalid frame received or EOF from decoder)");
+                    avcodec_flush_buffers(pCodecCtx);
+                }
+                if (receive_frame_err != 0) {
+                    ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::GetAVFrame (frame not ready yet from decoder)");
+                    break;
+                }
+
 	#if USE_HW_ACCEL
 				if (hw_de_on && hw_de_supported) {
 					int err;
@@ -1128,12 +1103,25 @@ bool FFmpegReader::GetAVFrame() {
 
 				// TODO also handle possible further frames
 				// Use only the first frame like avcodec_decode_video2
-				if (frameFinished == 0 ) {
-					frameFinished = 1;
-					av_image_alloc(pFrame->data, pFrame->linesize, info.width, info.height, (AVPixelFormat)(pStream->codecpar->format), 1);
-					av_image_copy(pFrame->data, pFrame->linesize, (const uint8_t**)next_frame->data, next_frame->linesize,
-												(AVPixelFormat)(pStream->codecpar->format), info.width, info.height);
-				}
+                frameFinished = 1;
+                packets_decoded++;
+
+                av_image_alloc(pFrame->data, pFrame->linesize, info.width, info.height, (AVPixelFormat)(pStream->codecpar->format), 1);
+                av_image_copy(pFrame->data, pFrame->linesize, (const uint8_t**)next_frame->data, next_frame->linesize,
+                                            (AVPixelFormat)(pStream->codecpar->format), info.width, info.height);
+
+                // Get display PTS from video frame, often different than packet->pts.
+                // Sending packets to the decoder (i.e. packet->pts) is async,
+                // and retrieving packets from the decoder (frame->pts) is async. In most decoders
+                // sending and retrieving are separated by multiple calls to this method.
+                if (next_frame->pts != AV_NOPTS_VALUE) {
+                    // This is the current decoded frame (and should be the pts used) for
+                    // processing this data
+                    video_pts = next_frame->pts;
+                }
+
+                // break out of loop after each successful image returned
+                break;
 			}
 	#if USE_HW_ACCEL
 			if (hw_de_on && hw_de_supported) {
@@ -1178,9 +1166,7 @@ bool FFmpegReader::CheckSeek(bool is_video) {
 			return false;
 
 		// Determine max seeked frame
-		int64_t max_seeked_frame = seek_audio_frame_found; // determine max seeked frame
-		if (seek_video_frame_found > max_seeked_frame)
-			max_seeked_frame = seek_video_frame_found;
+		int64_t max_seeked_frame = std::max(seek_audio_frame_found, seek_video_frame_found);
 
 		// determine if we are "before" the requested frame
 		if (max_seeked_frame >= seeking_frame) {
@@ -1191,7 +1177,7 @@ bool FFmpegReader::CheckSeek(bool is_video) {
 			Seek(seeking_frame - (10 * seek_count * seek_count));
 		} else {
 			// SEEK WORKED
-			ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::CheckSeek (Successful)", "is_video_seek", is_video_seek, "current_pts", packet->pts, "seeking_pts", seeking_pts, "seeking_frame", seeking_frame, "seek_video_frame_found", seek_video_frame_found, "seek_audio_frame_found", seek_audio_frame_found);
+			ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::CheckSeek (Successful)", "is_video_seek", is_video_seek, "packet->pts", GetPacketPTS(), "seeking_pts", seeking_pts, "seeking_frame", seeking_frame, "seek_video_frame_found", seek_video_frame_found, "seek_audio_frame_found", seek_audio_frame_found);
 
 			// Seek worked, and we are "before" the requested frame
 			is_seeking = false;
@@ -1206,24 +1192,28 @@ bool FFmpegReader::CheckSeek(bool is_video) {
 
 // Process a video packet
 void FFmpegReader::ProcessVideoPacket(int64_t requested_frame) {
+    // Get the AVFrame from the current packet
+    // This sets the video_pts to the correct timestamp
+    int frame_finished = GetAVFrame();
+
+    // Check if the AVFrame is finished and set it
+    if (!frame_finished) {
+        // No AVFrame decoded yet, bail out
+        return;
+    }
+
 	// Calculate current frame #
-	int64_t current_frame = ConvertVideoPTStoFrame(GetVideoPTS());
+	int64_t current_frame = ConvertVideoPTStoFrame(video_pts);
 
 	// Track 1st video packet after a successful seek
 	if (!seek_video_frame_found && is_seeking)
 		seek_video_frame_found = current_frame;
 
-	// Are we close enough to decode the frame? and is this frame # valid?
-	if ((current_frame < (requested_frame - 20)) or (current_frame == -1)) {
-		// Remove frame and packet
-		RemoveAVFrame(pFrame);
-
-		// Debug output
-		ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::ProcessVideoPacket (Skipped)", "requested_frame", requested_frame, "current_frame", current_frame);
-
-		// Skip to next frame without decoding or caching
-		return;
-	}
+    // Create or get the existing frame object. Requested frame needs to be created
+    // in working_cache at least once. Seek can clear the working_cache, so we must
+    // add the requested frame back to the working_cache here. If it already exists,
+    // it will be moved to the top of the working_cache.
+    working_cache.Add(CreateFrame(requested_frame));
 
 	// Debug output
 	ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::ProcessVideoPacket (Before)", "requested_frame", requested_frame, "current_frame", current_frame);
@@ -1235,10 +1225,6 @@ void FFmpegReader::ProcessVideoPacket(int64_t requested_frame) {
 	int64_t video_length = info.video_length;
 	AVFrame *my_frame = pFrame;
 	pFrame = NULL;
-
-	// Add video frame to list of processing video frames
-	const std::lock_guard<std::recursive_mutex> lock(processingMutex);
-	processing_video_frames[current_frame] = current_frame;
 
 	// Create variables for a RGB Frame (since most videos are not in RGB, we must convert it)
 	AVFrame *pFrameRGB = nullptr;
@@ -1367,34 +1353,34 @@ void FFmpegReader::ProcessVideoPacket(int64_t requested_frame) {
 	RemoveAVFrame(my_frame);
 	sws_freeContext(img_convert_ctx);
 
-	// Remove video frame from list of processing video frames
-	{
-		const std::lock_guard<std::recursive_mutex> lock(processingMutex);
-		processing_video_frames.erase(current_frame);
-		processed_video_frames[current_frame] = current_frame;
-	}
+    // Get video PTS in seconds
+    video_pts_seconds = (double(video_pts) * info.video_timebase.ToDouble()) + pts_offset_seconds;
 
-	// Debug output
-	ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::ProcessVideoPacket (After)", "requested_frame", requested_frame, "current_frame", current_frame, "f->number", f->number);
+    // Debug output
+	ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::ProcessVideoPacket (After)", "requested_frame", requested_frame, "current_frame", current_frame, "f->number", f->number, "video_pts_seconds", video_pts_seconds);
 }
 
 // Process an audio packet
-void FFmpegReader::ProcessAudioPacket(int64_t requested_frame, int64_t target_frame, int starting_sample) {
-	// Track 1st audio packet after a successful seek
-	if (!seek_audio_frame_found && is_seeking)
-		seek_audio_frame_found = target_frame;
+void FFmpegReader::ProcessAudioPacket(int64_t requested_frame) {
+    AudioLocation location;
+    // Calculate location of current audio packet
+	if (packet && packet->pts != AV_NOPTS_VALUE) {
+        // Determine related video frame and starting sample # from audio PTS
+        location = GetAudioPTSLocation(packet->pts);
 
-	// Are we close enough to decode the frame's audio?
-	if (target_frame < (requested_frame - 20)) {
-		// Debug output
-		ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::ProcessAudioPacket (Skipped)", "requested_frame", requested_frame, "target_frame", target_frame, "starting_sample", starting_sample);
-
-		// Skip to next frame without decoding or caching
-		return;
+        // Track 1st audio packet after a successful seek
+        if (!seek_audio_frame_found && is_seeking)
+            seek_audio_frame_found = location.frame;
 	}
 
+    // Create or get the existing frame object. Requested frame needs to be created
+    // in working_cache at least once. Seek can clear the working_cache, so we must
+    // add the requested frame back to the working_cache here. If it already exists,
+    // it will be moved to the top of the working_cache.
+    working_cache.Add(CreateFrame(requested_frame));
+
 	// Debug output
-	ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::ProcessAudioPacket (Before)", "requested_frame", requested_frame, "target_frame", target_frame, "starting_sample", starting_sample);
+	ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::ProcessAudioPacket (Before)", "requested_frame", requested_frame, "target_frame", location.frame, "starting_sample", location.sample_start);
 
 	// Init an AVFrame to hold the decoded audio samples
 	int frame_finished = 0;
@@ -1405,37 +1391,41 @@ void FFmpegReader::ProcessAudioPacket(int64_t requested_frame, int64_t target_fr
 	int data_size = 0;
 
 #if IS_FFMPEG_3_2
-		int ret = 0;
-		frame_finished = 1;
-		while((packet->size > 0 || (!packet->data && frame_finished)) && ret >= 0) {
-			frame_finished = 0;
-			ret =  avcodec_send_packet(aCodecCtx, packet);
-			if (ret < 0 && ret !=  AVERROR(EINVAL) && ret != AVERROR_EOF) {
-				avcodec_send_packet(aCodecCtx, NULL);
-				break;
-			}
-			if (ret >= 0)
-				packet->size = 0;
-			ret =  avcodec_receive_frame(aCodecCtx, audio_frame);
-			if (ret >= 0)
-				frame_finished = 1;
-			if(ret == AVERROR(EINVAL) || ret == AVERROR_EOF) {
-				avcodec_flush_buffers(aCodecCtx);
-				ret = 0;
-			}
-			if (ret >= 0) {
-				ret = frame_finished;
-			}
-		}
-		if (!packet->data && !frame_finished)
-		{
-			ret = -1;
-		}
+        int send_packet_err =  avcodec_send_packet(aCodecCtx, packet);
+        if (send_packet_err < 0 && send_packet_err != AVERROR_EOF) {
+            ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::ProcessAudioPacket (Packet not sent)");
+        }
+        else {
+            int receive_frame_err = avcodec_receive_frame(aCodecCtx, audio_frame);
+            if (receive_frame_err >= 0) {
+                frame_finished = 1;
+            }
+            if (receive_frame_err == AVERROR_EOF) {
+                ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::ProcessAudioPacket (EOF - end of file detected from decoder)");
+                audio_eof = true;
+            }
+            if (receive_frame_err == AVERROR(EINVAL) || receive_frame_err == AVERROR_EOF) {
+                ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::ProcessAudioPacket (invalid frame received or EOF from decoder)");
+                avcodec_flush_buffers(aCodecCtx);
+            }
+            if (receive_frame_err != 0) {
+                ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::ProcessAudioPacket (frame not ready yet from decoder)");
+            }
+        }
 #else
 		int used = avcodec_decode_audio4(aCodecCtx, audio_frame, &frame_finished, packet);
 #endif
 
 	if (frame_finished) {
+        packets_decoded++;
+
+        // This can be different than the current packet, so we need to look
+        // at the current AVFrame from the audio decoder. This timestamp should
+        // be used for the remainder of this function
+        audio_pts = audio_frame->pts;
+
+        // Determine related video frame and starting sample # from audio PTS
+        location = GetAudioPTSLocation(audio_pts);
 
 		// determine how many samples were decoded
 		int plane_size = -1;
@@ -1452,12 +1442,12 @@ void FFmpegReader::ProcessAudioPacket(int64_t requested_frame, int64_t target_fr
 	int pts_remaining_samples = packet_samples / info.channels; // Adjust for zero based array
 
 	// DEBUG (FOR AUDIO ISSUES) - Get the audio packet start time (in seconds)
-	int64_t adjusted_pts = packet->pts + audio_pts_offset;
-	double audio_seconds = double(adjusted_pts) * info.audio_timebase.ToDouble();
-	double sample_seconds = double(pts_total) / info.sample_rate;
+	int64_t adjusted_pts = audio_pts;
+	double audio_seconds = (double(adjusted_pts) * info.audio_timebase.ToDouble()) + pts_offset_seconds;
+	double sample_seconds = (double(pts_total) / info.sample_rate) + pts_offset_seconds;
 
 	// Debug output
-	ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::ProcessAudioPacket (Decode Info A)", "pts_counter", pts_counter, "PTS", adjusted_pts, "Offset", audio_pts_offset, "PTS Diff", adjusted_pts - prev_pts, "Samples", pts_remaining_samples, "Sample PTS ratio", float(adjusted_pts - prev_pts) / pts_remaining_samples);
+	ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::ProcessAudioPacket (Decode Info A)", "pts_counter", pts_counter, "PTS", adjusted_pts, "PTS Diff", adjusted_pts - prev_pts, "Samples", pts_remaining_samples, "Sample PTS ratio", float(adjusted_pts - prev_pts) / pts_remaining_samples);
 	ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::ProcessAudioPacket (Decode Info B)", "Sample Diff", pts_remaining_samples - prev_samples - prev_pts, "Total", pts_total, "PTS Seconds", audio_seconds, "Sample Seconds", sample_seconds, "Seconds Diff", audio_seconds - sample_seconds, "raw samples", packet_samples);
 
 	// DEBUG (FOR AUDIO ISSUES)
@@ -1465,12 +1455,6 @@ void FFmpegReader::ProcessAudioPacket(int64_t requested_frame, int64_t target_fr
 	pts_total += pts_remaining_samples;
 	pts_counter++;
 	prev_samples = pts_remaining_samples;
-
-	// Add audio frame to list of processing audio frames
-	{
-		const std::lock_guard<std::recursive_mutex> lock(processingMutex);
-		processing_audio_frames.insert(std::pair<int, int>(previous_packet_location.frame, previous_packet_location.frame));
-	}
 
 	while (pts_remaining_samples) {
 		// Get Samples per frame (for this frame number)
@@ -1488,13 +1472,6 @@ void FFmpegReader::ProcessAudioPacket(int64_t requested_frame, int64_t target_fr
 			// next frame
 			previous_packet_location.frame++;
 			previous_packet_location.sample_start = 0;
-
-			// Add audio frame to list of processing audio frames
-			{
-				const std::lock_guard<std::recursive_mutex> lock(processingMutex);
-				processing_audio_frames.insert(std::pair<int, int>(previous_packet_location.frame, previous_packet_location.frame));
-			}
-
 		} else {
 			// Increment sample start
 			previous_packet_location.sample_start += samples;
@@ -1558,7 +1535,7 @@ void FFmpegReader::ProcessAudioPacket(int64_t requested_frame, int64_t target_fr
 	bool partial_frame = true;
 	for (int channel_filter = 0; channel_filter < info.channels; channel_filter++) {
 		// Array of floats (to hold samples for each channel)
-		starting_frame_number = target_frame;
+		starting_frame_number = location.frame;
 		int channel_buffer_size = packet_samples / info.channels;
 		float *channel_buffer = new float[channel_buffer_size];
 
@@ -1590,7 +1567,7 @@ void FFmpegReader::ProcessAudioPacket(int64_t requested_frame, int64_t target_fr
 		}
 
 		// Loop through samples, and add them to the correct frames
-		int start = starting_sample;
+		int start = location.sample_start;
 		int remaining_samples = channel_buffer_size;
 		float *iterate_channel_buffer = channel_buffer;    // pointer to channel buffer
 		while (remaining_samples > 0) {
@@ -1644,33 +1621,14 @@ void FFmpegReader::ProcessAudioPacket(int64_t requested_frame, int64_t target_fr
 	delete[] audio_buf;
 	audio_buf = NULL;
 
-	// Remove audio frame from list of processing audio frames
-	{
-		const std::lock_guard<std::recursive_mutex> lock(processingMutex);
-		// Update all frames as completed
-		for (int64_t f = target_frame; f < starting_frame_number; f++) {
-			// Remove the frame # from the processing list. NOTE: If more than one thread is
-			// processing this frame, the frame # will be in this list multiple times. We are only
-			// removing a single instance of it here.
-			processing_audio_frames.erase(processing_audio_frames.find(f));
-
-			// Check and see if this frame is also being processed by another thread
-			if (processing_audio_frames.count(f) == 0)
-				// No other thread is processing it. Mark the audio as processed (final)
-				processed_audio_frames[f] = f;
-		}
-
-		if (target_frame == starting_frame_number) {
-			// This typically never happens, but just in case, remove the currently processing number
-			processing_audio_frames.erase(processing_audio_frames.find(target_frame));
-		}
-	}
-
 	// Free audio frame
 	AV_FREE_FRAME(&audio_frame);
 
+    // Get audio PTS in seconds
+    audio_pts_seconds = (double(audio_pts) * info.audio_timebase.ToDouble()) + pts_offset_seconds;
+
 	// Debug output
-	ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::ProcessAudioPacket (After)", "requested_frame", requested_frame, "starting_frame", target_frame, "end_frame", starting_frame_number - 1);
+	ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::ProcessAudioPacket (After)", "requested_frame", requested_frame, "starting_frame", location.frame, "end_frame", starting_frame_number - 1, "audio_pts_seconds", audio_pts_seconds);
 
 }
 
@@ -1683,50 +1641,26 @@ void FFmpegReader::Seek(int64_t requested_frame) {
 	if (requested_frame > info.video_length)
 		requested_frame = info.video_length;
 
-	int processing_video_frames_size = 0;
-	int processing_audio_frames_size = 0;
-	{
-		const std::lock_guard<std::recursive_mutex> lock(processingMutex);
-		processing_video_frames_size = processing_video_frames.size();
-		processing_audio_frames_size = processing_audio_frames.size();
-	}
-
 	// Debug output
-	ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::Seek", "requested_frame", requested_frame, "seek_count", seek_count, "last_frame", last_frame, "processing_video_frames_size", processing_video_frames_size, "processing_audio_frames_size", processing_audio_frames_size, "video_pts_offset", video_pts_offset);
-
-	// Wait for any processing frames to complete
-	while (processing_video_frames_size + processing_audio_frames_size > 0) {
-		std::this_thread::sleep_for(std::chrono::milliseconds(3));
-		const std::lock_guard<std::recursive_mutex> lock(processingMutex);
-		processing_video_frames_size = processing_video_frames.size();
-		processing_audio_frames_size = processing_audio_frames.size();
-	}
+	ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::Seek", "requested_frame", requested_frame, "seek_count", seek_count, "last_frame", last_frame);
 
 	// Clear working cache (since we are seeking to another location in the file)
 	working_cache.Clear();
-	missing_frames.Clear();
-
-	// Clear processed lists
-	{
-		const std::lock_guard<std::recursive_mutex> lock(processingMutex);
-		processing_audio_frames.clear();
-		processing_video_frames.clear();
-		processed_video_frames.clear();
-		processed_audio_frames.clear();
-		missing_audio_frames.clear();
-		missing_video_frames.clear();
-		missing_audio_frames_source.clear();
-		missing_video_frames_source.clear();
-		checked_frames.clear();
-	}
 
 	// Reset the last frame variable
+    video_pts = 0.0;
+    video_pts_seconds = NO_PTS_OFFSET;
+    audio_pts = 0.0;
+    audio_pts_seconds = NO_PTS_OFFSET;
 	last_frame = 0;
 	current_video_frame = 0;
 	largest_frame_processed = 0;
-	num_checks_since_final = 0;
-	num_packets_since_video_frame = 0;
-	has_missing_frames = false;
+    packets_eof = false;
+	video_eof = false;
+	audio_eof = false;
+	end_of_file = false;
+	packets_read = 0;
+	packets_decoded = 0;
 	bool has_audio_override = info.has_audio;
 	bool has_video_override = info.has_video;
 
@@ -1736,6 +1670,9 @@ void FFmpegReader::Seek(int64_t requested_frame) {
 	// If seeking near frame 1, we need to close and re-open the file (this is more reliable than seeking)
 	int buffer_amount = std::max(max_concurrent_frames, 8);
 	if (requested_frame - buffer_amount < 20) {
+	    // prevent Open() from seeking again
+        is_seeking = true;
+
 		// Close and re-open file (basically seeking to frame 1)
 		Close();
 		Open();
@@ -1813,13 +1750,18 @@ void FFmpegReader::Seek(int64_t requested_frame) {
 			seeking_pts = 0;
 			seeking_frame = 0;
 
-			// dislable seeking for this reader (since it failed)
-			// TODO: Find a safer way to do this... not sure how common it is for a seek to fail.
-			enable_seek = false;
+            // prevent Open() from seeking again
+            is_seeking = true;
 
 			// Close and re-open file (basically seeking to frame 1)
 			Close();
 			Open();
+
+            // Not actually seeking, so clear these flags
+            is_seeking = false;
+
+            // disable seeking for this reader (since it failed)
+            enable_seek = false;
 
 			// Update overrides (since closing and re-opening might update these)
 			info.has_audio = has_audio_override;
@@ -1829,9 +1771,9 @@ void FFmpegReader::Seek(int64_t requested_frame) {
 }
 
 // Get the PTS for the current video packet
-int64_t FFmpegReader::GetVideoPTS() {
-	int64_t current_pts = 0;
-	if (packet->dts != AV_NOPTS_VALUE)
+int64_t FFmpegReader::GetPacketPTS() {
+	int64_t current_pts = packet->pts;
+	if (current_pts == AV_NOPTS_VALUE && packet->dts != AV_NOPTS_VALUE)
 		current_pts = packet->dts;
 
 	// Return adjusted PTS
@@ -1839,74 +1781,84 @@ int64_t FFmpegReader::GetVideoPTS() {
 }
 
 // Update PTS Offset (if any)
-void FFmpegReader::UpdatePTSOffset(bool is_video) {
-	// Determine the offset between the PTS and Frame number (only for 1st frame)
-	if (is_video) {
-		// VIDEO PACKET
-		if (video_pts_offset == 99999) // Has the offset been set yet?
-		{
-            if (pStream->start_time != AV_NOPTS_VALUE && pStream->start_time > 0) {
-                // Adjust all PTS by start_time (if available)
-                video_pts_offset = 0 - pStream->start_time;
-            } else {
-                // Find the difference between PTS and frame number
-                video_pts_offset = 0 - GetVideoPTS();
-
-                // Find the difference between PTS and frame number
-                // Also, determine if PTS is invalid (too far away from zero)
-                // We compare the PTS to the timebase value equal to 1 second (which means the PTS
-                // must be within the -1 second to +1 second of zero, otherwise we ignore it)
-                // TODO: Please see https://github.com/OpenShot/libopenshot/pull/565#issuecomment-690985272
-                // for ideas to improve this logic.
-                int64_t max_offset = info.video_timebase.Reciprocal().ToFloat();
-                if (video_pts_offset < -max_offset || video_pts_offset > max_offset) {
-                    // Ignore PTS, it seems invalid
-                    video_pts_offset = 0;
-                }
-            }
-
-			// debug output
-			ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::UpdatePTSOffset (Video)", "video_pts_offset", video_pts_offset, "is_video", is_video);
-		}
-	} else {
-		// AUDIO PACKET
-		if (audio_pts_offset == 99999) // Has the offset been set yet?
-		{
-			// Find the difference between PTS and frame number
-			// Also, determine if PTS is invalid (too far away from zero)
-			// We compare the PTS to the timebase value equal to 1 second (which means the PTS
-			// must be within the -1 second to +1 second of zero, otherwise we ignore it)
-			// TODO: Please see https://github.com/OpenShot/libopenshot/pull/565#issuecomment-690985272
-			// for ideas to improve this logic.
-			if (aStream->start_time != AV_NOPTS_VALUE && aStream->start_time > 0) {
-			    // Adjust all PTS by start_time (if available)
-                audio_pts_offset = 0 - aStream->start_time;
-			} else {
-			    // Determine if PTS is sane
-                audio_pts_offset = 0 - packet->pts;
-                int64_t max_offset = info.audio_timebase.Reciprocal().ToFloat();
-                if (audio_pts_offset < -max_offset || audio_pts_offset > max_offset) {
-                    // Ignore PTS, it seems invalid
-                    // Assuming the start_time is not set or not valid, then the PTS should be near the
-                    // beginning of the stream
-                    audio_pts_offset = 0;
-                }
-			}
-
-			// debug output
-			ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::UpdatePTSOffset (Audio)", "audio_pts_offset", audio_pts_offset, "is_video", is_video);
-		}
+void FFmpegReader::UpdatePTSOffset() {
+	if (pts_offset_seconds != NO_PTS_OFFSET) {
+	    // Skip this method if we have already set PTS offset
+	    return;
 	}
+    pts_offset_seconds = 0.0;
+    double video_pts_offset_seconds = 0.0;
+    double audio_pts_offset_seconds = 0.0;
+
+    bool has_video_pts = false;
+    if (!info.has_video) {
+        // Mark as checked
+        has_video_pts = true;
+    }
+    bool has_audio_pts = false;
+    if (!info.has_audio) {
+        // Mark as checked
+        has_audio_pts = true;
+    }
+
+    // Loop through the stream (until a packet from all streams is found)
+    int64_t pts = 0;
+    while (!has_video_pts || !has_audio_pts) {
+        // Get the next packet (if any)
+        if (GetNextPacket() < 0)
+            // Break loop when no more packets found
+            break;
+
+        // Get PTS of this packet
+        pts = GetPacketPTS();
+
+        // Video packet
+        if (!has_video_pts && packet->stream_index == videoStream) {
+            // Get the video packet start time (in seconds)
+            video_pts_offset_seconds = 0.0 - (video_pts * info.video_timebase.ToDouble());
+
+            // Is timestamp close to zero (within X seconds)
+            // Ignore wildly invalid timestamps (i.e. -234923423423)
+            if (std::abs(video_pts_offset_seconds) <= 10.0) {
+                has_video_pts = true;
+            }
+        }
+        else if (!has_audio_pts && packet->stream_index == audioStream) {
+            // Get the audio packet start time (in seconds)
+            audio_pts_offset_seconds = 0.0 - (pts * info.audio_timebase.ToDouble());
+
+            // Is timestamp close to zero (within X seconds)
+            // Ignore wildly invalid timestamps (i.e. -234923423423)
+            if (std::abs(audio_pts_offset_seconds) <= 10.0) {
+                has_audio_pts = true;
+            }
+        }
+    }
+
+    // Do we have all valid timestamps to determine PTS offset?
+    if (has_video_pts && has_audio_pts) {
+        // Set PTS Offset to the smallest offset
+        //     [  video timestamp  ]
+        //           [  audio timestamp  ]
+        //
+        //     ** SHIFT TIMESTAMPS TO ZERO **
+        //
+        //[  video timestamp  ]
+        //      [  audio timestamp  ]
+        //
+        // Since all offsets are negative at this point, we want the max value, which
+        // represents the closest to zero
+        pts_offset_seconds = std::max(video_pts_offset_seconds, audio_pts_offset_seconds);
+    }
 }
 
 // Convert PTS into Frame Number
 int64_t FFmpegReader::ConvertVideoPTStoFrame(int64_t pts) {
 	// Apply PTS offset
-	pts = pts + video_pts_offset;
 	int64_t previous_video_frame = current_video_frame;
 
 	// Get the video packet start time (in seconds)
-	double video_seconds = double(pts) * info.video_timebase.ToDouble();
+	double video_seconds = (double(pts) * info.video_timebase.ToDouble()) + pts_offset_seconds;
 
 	// Divide by the video timebase, to get the video frame number (frame # is decimal at this point)
 	int64_t frame = round(video_seconds * info.fps.ToDouble()) + 1;
@@ -1924,27 +1876,6 @@ int64_t FFmpegReader::ConvertVideoPTStoFrame(int64_t pts) {
 			// Increment expected frame
 			current_video_frame++;
 		}
-
-		if (current_video_frame < frame)
-			// has missing frames
-			ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::ConvertVideoPTStoFrame (detected missing frame)", "calculated frame", frame, "previous_video_frame", previous_video_frame, "current_video_frame", current_video_frame);
-
-		// Sometimes frames are missing due to varying timestamps, or they were dropped. Determine
-		// if we are missing a video frame.
-		const std::lock_guard<std::recursive_mutex> lock(processingMutex);
-		while (current_video_frame < frame) {
-			if (!missing_video_frames.count(current_video_frame)) {
-				ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::ConvertVideoPTStoFrame (tracking missing frame)", "current_video_frame", current_video_frame, "previous_video_frame", previous_video_frame);
-				missing_video_frames.insert(std::pair<int64_t, int64_t>(current_video_frame, previous_video_frame));
-				missing_video_frames_source.insert(std::pair<int64_t, int64_t>(previous_video_frame, current_video_frame));
-			}
-
-			// Mark this reader as containing missing frames
-			has_missing_frames = true;
-
-			// Increment current frame
-			current_video_frame++;
-		}
 	}
 
 	// Return frame #
@@ -1954,34 +1885,31 @@ int64_t FFmpegReader::ConvertVideoPTStoFrame(int64_t pts) {
 // Convert Frame Number into Video PTS
 int64_t FFmpegReader::ConvertFrameToVideoPTS(int64_t frame_number) {
 	// Get timestamp of this frame (in seconds)
-	double seconds = double(frame_number) / info.fps.ToDouble();
+	double seconds = (double(frame_number - 1) / info.fps.ToDouble()) + pts_offset_seconds;
 
 	// Calculate the # of video packets in this timestamp
 	int64_t video_pts = round(seconds / info.video_timebase.ToDouble());
 
 	// Apply PTS offset (opposite)
-	return video_pts - video_pts_offset;
+	return video_pts;
 }
 
 // Convert Frame Number into Video PTS
 int64_t FFmpegReader::ConvertFrameToAudioPTS(int64_t frame_number) {
 	// Get timestamp of this frame (in seconds)
-	double seconds = double(frame_number) / info.fps.ToDouble();
+    double seconds = (double(frame_number - 1) / info.fps.ToDouble()) + pts_offset_seconds;
 
 	// Calculate the # of audio packets in this timestamp
 	int64_t audio_pts = round(seconds / info.audio_timebase.ToDouble());
 
 	// Apply PTS offset (opposite)
-	return audio_pts - audio_pts_offset;
+	return audio_pts;
 }
 
 // Calculate Starting video frame and sample # for an audio PTS
 AudioLocation FFmpegReader::GetAudioPTSLocation(int64_t pts) {
-	// Apply PTS offset
-	pts = pts + audio_pts_offset;
-
 	// Get the audio packet start time (in seconds)
-	double audio_seconds = double(pts) * info.audio_timebase.ToDouble();
+	double audio_seconds = (double(pts) * info.audio_timebase.ToDouble()) + pts_offset_seconds;
 
 	// Divide by the video timebase, to get the video frame number (frame # is decimal at this point)
 	double frame = (audio_seconds * info.fps.ToDouble()) + 1;
@@ -2023,14 +1951,6 @@ AudioLocation FFmpegReader::GetAudioPTSLocation(int64_t pts) {
 		} else {
 			// Debug output
 			ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::GetAudioPTSLocation (Audio Gap Ignored - too big)", "Previous location frame", previous_packet_location.frame, "Target Frame", location.frame, "Target Audio Sample", location.sample_start, "pts", pts);
-
-			const std::lock_guard<std::recursive_mutex> lock(processingMutex);
-			for (int64_t audio_frame = previous_packet_location.frame; audio_frame < location.frame; audio_frame++) {
-				if (!missing_audio_frames.count(audio_frame)) {
-					ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::GetAudioPTSLocation (tracking missing frame)", "missing_audio_frame", audio_frame, "previous_audio_frame", previous_packet_location.frame, "new location frame", location.frame);
-					missing_audio_frames.insert(std::pair<int64_t, int64_t>(audio_frame, previous_packet_location.frame - 1));
-				}
-			}
 		}
 	}
 
@@ -2087,229 +2007,118 @@ bool FFmpegReader::IsPartialFrame(int64_t requested_frame) {
 	return seek_trash;
 }
 
-// Check if a frame is missing and attempt to replace its frame image (and
-bool FFmpegReader::CheckMissingFrame(int64_t requested_frame) {
-	// Lock
-	const std::lock_guard<std::recursive_mutex> lock(processingMutex);
-
-	// Increment check count for this frame (or init to 1)
-	++checked_frames[requested_frame];
-
-	// Debug output
-	ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::CheckMissingFrame", "requested_frame", requested_frame, "has_missing_frames", has_missing_frames, "missing_video_frames.size()", missing_video_frames.size(), "checked_count", checked_frames[requested_frame]);
-
-	// Missing frames (sometimes frame #'s are skipped due to invalid or missing timestamps)
-	std::map<int64_t, int64_t>::iterator itr;
-	bool found_missing_frame = false;
-
-	// Special MP3 Handling (ignore more than 1 video frame)
-	if (info.has_audio and info.has_video) {
-		// If MP3 with single video frame, handle this special case by copying the previously
-		// decoded image to the new frame. Otherwise, it will spend a huge amount of
-		// CPU time looking for missing images for all the audio-only frames.
-		if (checked_frames[requested_frame] > 8 && !missing_video_frames.count(requested_frame) &&
-			!processing_audio_frames.count(requested_frame) && processed_audio_frames.count(requested_frame) &&
-			last_video_frame && last_video_frame->has_image_data && HasAlbumArt()) {
-			missing_video_frames.insert(std::pair<int64_t, int64_t>(requested_frame, last_video_frame->number));
-			missing_video_frames_source.insert(std::pair<int64_t, int64_t>(last_video_frame->number, requested_frame));
-			missing_frames.Add(last_video_frame);
-		}
-	}
-
-	// Check if requested video frame is a missing
-	if (missing_video_frames.count(requested_frame)) {
-		int64_t missing_source_frame = missing_video_frames.find(requested_frame)->second;
-
-		// Increment missing source frame check count (or init to 1)
-		++checked_frames[missing_source_frame];
-
-		// Get the previous frame of this missing frame (if it's available in missing cache)
-		std::shared_ptr<Frame> parent_frame = missing_frames.GetFrame(missing_source_frame);
-		if (parent_frame == NULL) {
-			parent_frame = final_cache.GetFrame(missing_source_frame);
-			if (parent_frame != NULL) {
-				// Add missing final frame to missing cache
-				missing_frames.Add(parent_frame);
-			}
-		}
-
-		// Create blank missing frame
-		std::shared_ptr<Frame> missing_frame = CreateFrame(requested_frame);
-
-		// Debug output
-		ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::CheckMissingFrame (Is Previous Video Frame Final)", "requested_frame", requested_frame, "missing_frame->number", missing_frame->number, "missing_source_frame", missing_source_frame);
-
-		// If previous frame found, copy image from previous to missing frame (else we'll just wait a bit and try again later)
-		if (parent_frame != NULL) {
-			// Debug output
-			ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::CheckMissingFrame (AddImage from Previous Video Frame)", "requested_frame", requested_frame, "missing_frame->number", missing_frame->number, "missing_source_frame", missing_source_frame);
-
-			// Add this frame to the processed map (since it's already done)
-			std::shared_ptr<QImage> parent_image = parent_frame->GetImage();
-			if (parent_image) {
-				missing_frame->AddImage(std::make_shared<QImage>(*parent_image));
-				processed_video_frames[missing_frame->number] = missing_frame->number;
-			}
-		}
-	}
-
-	// Check if requested audio frame is a missing
-	if (missing_audio_frames.count(requested_frame)) {
-
-		// Create blank missing frame
-		std::shared_ptr<Frame> missing_frame = CreateFrame(requested_frame);
-
-		// Get Samples per frame (for this frame number)
-		int samples_per_frame = Frame::GetSamplesPerFrame(missing_frame->number, info.fps, info.sample_rate, info.channels);
-
-		// Debug output
-		ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::CheckMissingFrame (Add Silence for Missing Audio Frame)", "requested_frame", requested_frame, "missing_frame->number", missing_frame->number, "samples_per_frame", samples_per_frame);
-
-		// Add this frame to the processed map (since it's already done)
-		missing_frame->AddAudioSilence(samples_per_frame);
-		processed_audio_frames[missing_frame->number] = missing_frame->number;
-	}
-
-	return found_missing_frame;
-}
-
 // Check the working queue, and move finished frames to the finished queue
-void FFmpegReader::CheckWorkingFrames(bool end_of_stream, int64_t requested_frame) {
-	// Loop through all working queue frames
-	bool checked_count_tripped = false;
-	int max_checked_count = 80;
+void FFmpegReader::CheckWorkingFrames(int64_t requested_frame) {
 
-	// Check if requested frame is 'missing'
-	CheckMissingFrame(requested_frame);
+	// Get a list of current working queue frames in the cache (in-progress frames)
+    std::vector<std::shared_ptr<openshot::Frame>> working_frames = working_cache.GetFrames();
+    std::vector<std::shared_ptr<openshot::Frame>>::iterator working_itr;
 
-	while (true) {
-		// Get the front frame of working cache
-		std::shared_ptr<Frame> f(working_cache.GetSmallestFrame());
+    // Loop through all working queue frames (sorted by frame #)
+    for(working_itr = working_frames.begin(); working_itr != working_frames.end(); ++working_itr)
+    {
+        // Get working frame
+        std::shared_ptr<Frame> f = *working_itr;
 
-		// Was a frame found?
-		if (!f)
-			// No frames found
-			break;
+		// Was a frame found? Is frame requested yet?
+		if (!f || (f && f->number > requested_frame)) {
+		    // If not, skip to next one
+            continue;
+        }
 
-		// Remove frames which are too old
-		if (f->number < (requested_frame - (max_concurrent_frames * 2))) {
-			working_cache.Remove(f->number);
-		}
+		// Calculate PTS in seconds (of working frame), and the most recent processed pts value
+		double frame_pts_seconds = (double(f->number - 1) / info.fps.ToDouble()) + pts_offset_seconds;
+        double recent_pts_seconds = std::max(video_pts_seconds, audio_pts_seconds);
 
-		// Check if this frame is 'missing'
-		CheckMissingFrame(f->number);
-
-		// Init # of times this frame has been checked so far
-		int checked_count = 0;
-		int checked_frames_size = 0;
-
+        // Determine if video and audio are ready (based on timestamps)
 		bool is_video_ready = false;
 		bool is_audio_ready = false;
-		{ // limit scope of next few lines
-			const std::lock_guard<std::recursive_mutex> lock(processingMutex);
-			is_video_ready = processed_video_frames.count(f->number);
-			is_audio_ready = processed_audio_frames.count(f->number);
-
-			// Get check count for this frame
-			checked_frames_size = checked_frames.size();
-			if (!checked_count_tripped || f->number >= requested_frame)
-				checked_count = checked_frames[f->number];
-			else
-				// Force checked count over the limit
-				checked_count = max_checked_count;
+        double recent_pts_diff = recent_pts_seconds - frame_pts_seconds;
+		if ((video_pts_seconds != NO_PTS_OFFSET && frame_pts_seconds <= video_pts_seconds)
+		    || (video_pts_seconds != NO_PTS_OFFSET && recent_pts_diff > 1.5)
+		    || video_eof || end_of_file) {
+		    // Video stream is past this frame (so it must be done)
+		    // OR video stream is too far behind, missing, or end-of-file
+            is_video_ready = true;
+            ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::CheckWorkingFrames (video ready)", "frame_number", f->number, "frame_pts_seconds", frame_pts_seconds, "video_pts_seconds", video_pts_seconds, "recent_pts_diff", recent_pts_diff);
+			if (info.has_video && !f->has_image_data) {
+                // Frame has no image data (copy from previous frame)
+                // Loop backwards through final frames (looking for the nearest, previous frame image)
+                for (int64_t previous_frame = requested_frame - 1; previous_frame > 0; previous_frame--) {
+                    std::shared_ptr<Frame> previous_frame_instance = final_cache.GetFrame(previous_frame);
+                    if (previous_frame_instance && previous_frame_instance->has_image_data) {
+                        // Copy image from last decoded frame
+                        f->AddImage(std::make_shared<QImage>(*previous_frame_instance->GetImage()));
+                        break;
+                    }
+                }
+                
+                if (last_video_frame && !f->has_image_data) {
+                    // Copy image from last decoded frame
+                    f->AddImage(std::make_shared<QImage>(*last_video_frame->GetImage()));
+                } else if (!f->has_image_data) {
+                    f->AddColor("#000000");
+                }
+			}
 		}
 
-		if (previous_packet_location.frame == f->number && !end_of_stream)
-			is_audio_ready = false; // don't finalize the last processed audio frame
+        double audio_pts_diff = audio_pts_seconds - frame_pts_seconds;
+		if ((audio_pts_seconds != NO_PTS_OFFSET && frame_pts_seconds < audio_pts_seconds && audio_pts_diff > 1.0)
+		   || (audio_pts_seconds != NO_PTS_OFFSET && recent_pts_diff > 1.5)
+		   || audio_eof || end_of_file) {
+		    // Audio stream is past this frame (so it must be done)
+            // OR audio stream is too far behind, missing, or end-of-file
+            // Adding a bit of margin here, to allow for partial audio packets
+            is_audio_ready = true;
+            ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::CheckWorkingFrames (audio ready)", "frame_number", f->number, "frame_pts_seconds", frame_pts_seconds, "audio_pts_seconds", audio_pts_seconds, "audio_pts_diff", audio_pts_diff, "recent_pts_diff", recent_pts_diff);
+		}
 		bool is_seek_trash = IsPartialFrame(f->number);
 
 		// Adjust for available streams
 		if (!info.has_video) is_video_ready = true;
 		if (!info.has_audio) is_audio_ready = true;
 
-		// Make final any frames that get stuck (for whatever reason)
-		if (checked_count >= max_checked_count && (!is_video_ready || !is_audio_ready)) {
-			// Debug output
-			ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::CheckWorkingFrames (exceeded checked_count)", "requested_frame", requested_frame, "frame_number", f->number, "is_video_ready", is_video_ready, "is_audio_ready", is_audio_ready, "checked_count", checked_count, "checked_frames_size", checked_frames_size);
-
-			// Trigger checked count tripped mode (clear out all frames before requested frame)
-			checked_count_tripped = true;
-
-			if (info.has_video && !is_video_ready && last_video_frame) {
-				// Copy image from last frame
-				f->AddImage(std::make_shared<QImage>(*last_video_frame->GetImage()));
-				is_video_ready = true;
-			}
-
-			if (info.has_audio && !is_audio_ready) {
-				// Mark audio as processed, and indicate the frame has audio data
-				is_audio_ready = true;
-			}
-		}
-
 		// Debug output
-		ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::CheckWorkingFrames", "requested_frame", requested_frame, "frame_number", f->number, "is_video_ready", is_video_ready, "is_audio_ready", is_audio_ready, "checked_count", checked_count, "checked_frames_size", checked_frames_size);
+		ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::CheckWorkingFrames", "frame_number", f->number, "is_video_ready", is_video_ready, "is_audio_ready", is_audio_ready, "video_eof", video_eof, "audio_eof", audio_eof, "end_of_file", end_of_file);
 
 		// Check if working frame is final
-		if ((!end_of_stream && is_video_ready && is_audio_ready) || end_of_stream || is_seek_trash) {
+		if ((!end_of_file && is_video_ready && is_audio_ready) || end_of_file || is_seek_trash) {
 			// Debug output
-			ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::CheckWorkingFrames (mark frame as final)", "requested_frame", requested_frame, "f->number", f->number, "is_seek_trash", is_seek_trash, "Working Cache Count", working_cache.Count(), "Final Cache Count", final_cache.Count(), "end_of_stream", end_of_stream);
+			ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::CheckWorkingFrames (mark frame as final)", "requested_frame", requested_frame, "f->number", f->number, "is_seek_trash", is_seek_trash, "Working Cache Count", working_cache.Count(), "Final Cache Count", final_cache.Count(), "end_of_file", end_of_file);
 
 			if (!is_seek_trash) {
-				// Add missing image (if needed - sometimes end_of_stream causes frames with only audio)
-				if (info.has_video && !is_video_ready && last_video_frame)
-					// Copy image from last frame
-					f->AddImage(std::make_shared<QImage>(*last_video_frame->GetImage()));
-
-				// Reset counter since last 'final' frame
-				num_checks_since_final = 0;
-
 				// Move frame to final cache
 				final_cache.Add(f);
-
-				// Add to missing cache (if another frame depends on it)
-				{
-					const std::lock_guard<std::recursive_mutex> lock(processingMutex);
-					if (missing_video_frames_source.count(f->number)) {
-						// Debug output
-						ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::CheckWorkingFrames (add frame to missing cache)", "f->number", f->number, "is_seek_trash", is_seek_trash, "Missing Cache Count", missing_frames.Count(), "Working Cache Count", working_cache.Count(), "Final Cache Count", final_cache.Count());
-						missing_frames.Add(f);
-					}
-
-					// Remove from 'checked' count
-					checked_frames.erase(f->number);
-				}
 
 				// Remove frame from working cache
 				working_cache.Remove(f->number);
 
 				// Update last frame processed
 				last_frame = f->number;
-
 			} else {
 				// Seek trash, so delete the frame from the working cache, and never add it to the final cache.
 				working_cache.Remove(f->number);
 			}
 
-		} else {
-			// Stop looping
-			break;
 		}
 	}
 }
 
 // Check for the correct frames per second (FPS) value by scanning the 1st few seconds of video packets.
 void FFmpegReader::CheckFPS() {
-	check_fps = true;
+    if (check_fps) {
+        // Do not check FPS more than 1 time
+        return;
+    } else {
+        check_fps = true;
+    }
 
+	int frames_per_second[3] = {0,0,0};
+    int max_fps_index = sizeof(frames_per_second) / sizeof(frames_per_second[0]);
+    int fps_index = 0;
 
-	int first_second_counter = 0;
-	int second_second_counter = 0;
-	int third_second_counter = 0;
-	int forth_second_counter = 0;
-	int fifth_second_counter = 0;
-	int frames_detected = 0;
-	int64_t pts = 0;
+    int all_frames_detected = 0;
+	int starting_frames_detected = 0;
 
 	// Loop through the stream
 	while (true) {
@@ -2320,79 +2129,49 @@ void FFmpegReader::CheckFPS() {
 
 		// Video packet
 		if (packet->stream_index == videoStream) {
-			// Check if the AVFrame is finished and set it
-			if (GetAVFrame()) {
-				// Update PTS / Frame Offset (if any)
-				UpdatePTSOffset(true);
+            // Get the video packet start time (in seconds)
+            double video_seconds = (double(GetPacketPTS()) * info.video_timebase.ToDouble()) + pts_offset_seconds;
+            fps_index = int(video_seconds); // truncate float timestamp to int (second 1, second 2, second 3)
 
-				// Get PTS of this packet
-				pts = GetVideoPTS();
+            // Is this video packet from the first few seconds?
+            if (fps_index >= 0 && fps_index < max_fps_index) {
+                // Yes, keep track of how many frames per second (over the first few seconds)
+                starting_frames_detected++;
+                frames_per_second[fps_index]++;
+            }
 
-				// Remove pFrame
-				RemoveAVFrame(pFrame);
-
-				// Apply PTS offset
-				pts += video_pts_offset;
-
-				// Get the video packet start time (in seconds)
-				double video_seconds = double(pts) * info.video_timebase.ToDouble();
-
-				// Increment the correct counter
-				if (video_seconds <= 1.0)
-					first_second_counter++;
-				else if (video_seconds > 1.0 && video_seconds <= 2.0)
-					second_second_counter++;
-				else if (video_seconds > 2.0 && video_seconds <= 3.0)
-					third_second_counter++;
-				else if (video_seconds > 3.0 && video_seconds <= 4.0)
-					forth_second_counter++;
-				else if (video_seconds > 4.0 && video_seconds <= 5.0)
-					fifth_second_counter++;
-
-				// Increment counters
-				frames_detected++;
-			}
+            // Track all video packets detected
+            all_frames_detected++;
 		}
 	}
 
-	// Double check that all counters have greater than zero (or give up)
-	if (second_second_counter != 0 && third_second_counter != 0 && forth_second_counter != 0 && fifth_second_counter != 0) {
-		// Calculate average FPS (average of first few seconds)
-		int sum_fps = second_second_counter + third_second_counter + forth_second_counter + fifth_second_counter;
-		int avg_fps = round(sum_fps / 4.0f);
+	// Calculate FPS (based on the first few seconds of video packets)
+	float avg_fps = 30.0;
+	if (starting_frames_detected > 0 && fps_index > 0 && max_fps_index > 0) {
+        avg_fps = float(starting_frames_detected) / std::min(fps_index, max_fps_index);
+    }
 
-		// Update FPS
-		info.fps = Fraction(avg_fps, 1);
-
-		// Update Duration and Length
-		info.video_length = frames_detected;
-		info.duration = frames_detected / (sum_fps / 4.0f);
-
-		// Update video bit rate
-		info.video_bit_rate = info.file_size / info.duration;
-	} else if (second_second_counter != 0 && third_second_counter != 0) {
-		// Calculate average FPS (only on second 2)
-		int sum_fps = second_second_counter;
-
-		// Update FPS
-		info.fps = Fraction(sum_fps, 1);
-
-		// Update Duration and Length
-		info.video_length = frames_detected;
-		info.duration = frames_detected / float(sum_fps);
-
-		// Update video bit rate
-		info.video_bit_rate = info.file_size / info.duration;
-	} else {
-		// Too short to determine framerate, just default FPS
-		// Set a few important default video settings (so audio can be divided into frames)
-		info.fps.num = 30;
-		info.fps.den = 1;
-
-		// Calculate number of frames
-		info.video_length = frames_detected;
-		info.duration = frames_detected / info.fps.ToFloat();
+	// Verify average FPS is a reasonable value
+	if (avg_fps < 8.0) {
+		// Invalid FPS assumed, so switching to a sane default FPS instead
+		avg_fps = 30.0;
 	}
+
+    // Update FPS (truncate average FPS to Integer)
+    info.fps = Fraction(int(avg_fps), 1);
+
+    // Update Duration and Length
+    if (all_frames_detected > 0) {
+        // Use all video frames detected to calculate # of frames
+        info.video_length = all_frames_detected;
+        info.duration = all_frames_detected / avg_fps;
+    } else {
+        // Use previous duration to calculate # of frames
+        info.video_length = info.duration * avg_fps;
+    }
+
+    // Update video bit rate
+    info.video_bit_rate = info.file_size / info.duration;
 }
 
 // Remove AVFrame from cache (and deallocate its memory)
@@ -2414,36 +2193,6 @@ void FFmpegReader::RemoveAVPacket(AVPacket *remove_packet) {
 
 	// Delete the object
 	delete remove_packet;
-}
-
-/// Get the smallest video frame that is still being processed
-int64_t FFmpegReader::GetSmallestVideoFrame() {
-	// Loop through frame numbers
-	std::map<int64_t, int64_t>::iterator itr;
-	int64_t smallest_frame = -1;
-	const std::lock_guard<std::recursive_mutex> lock(processingMutex);
-	for (itr = processing_video_frames.begin(); itr != processing_video_frames.end(); ++itr) {
-		if (itr->first < smallest_frame || smallest_frame == -1)
-			smallest_frame = itr->first;
-	}
-
-	// Return frame number
-	return smallest_frame;
-}
-
-/// Get the smallest audio frame that is still being processed
-int64_t FFmpegReader::GetSmallestAudioFrame() {
-	// Loop through frame numbers
-	std::map<int64_t, int64_t>::iterator itr;
-	int64_t smallest_frame = -1;
-	const std::lock_guard<std::recursive_mutex> lock(processingMutex);
-	for (itr = processing_audio_frames.begin(); itr != processing_audio_frames.end(); ++itr) {
-		if (itr->first < smallest_frame || smallest_frame == -1)
-			smallest_frame = itr->first;
-	}
-
-	// Return frame number
-	return smallest_frame;
 }
 
 // Generate JSON string of this object

--- a/src/FFmpegReader.cpp
+++ b/src/FFmpegReader.cpp
@@ -591,8 +591,11 @@ void FFmpegReader::Close() {
 
 		// Close the codec
 		if (info.has_video) {
-            ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::Close (Flush video context)");
-			avcodec_flush_buffers(pCodecCtx);
+            //ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::Close (Flush video context)");
+            if(avcodec_is_open(pCodecCtx)) {
+                ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::Close (Skipping flush video context)");
+                //avcodec_flush_buffers(pCodecCtx);
+            }
 
             ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::Close (Free video context)");
 			AV_FREE_CONTEXT(pCodecCtx);
@@ -607,8 +610,11 @@ void FFmpegReader::Close() {
 #endif // USE_HW_ACCEL
 		}
 		if (info.has_audio) {
-            ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::Close (Flush audio context)");
-			avcodec_flush_buffers(aCodecCtx);
+            //ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::Close (Flush audio context)");
+            if(avcodec_is_open(aCodecCtx)) {
+                ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::Close (Skipping flush audio context)");
+                //avcodec_flush_buffers(aCodecCtx);
+            }
 
             ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::Close (Free audio context)");
 			AV_FREE_CONTEXT(aCodecCtx);

--- a/src/FFmpegReader.cpp
+++ b/src/FFmpegReader.cpp
@@ -590,6 +590,8 @@ void FFmpegReader::Close() {
 		ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::Close");
 
 		if (packet) {
+            ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::Close (Remove Packet)");
+
 			// Remove previous packet before getting next one
 			RemoveAVPacket(packet);
 			packet = NULL;
@@ -597,17 +599,20 @@ void FFmpegReader::Close() {
 
 		// Close the codec
 		if (info.has_video) {
+            ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::Close (Flush video context)");
 			avcodec_flush_buffers(pCodecCtx);
 
 			// Delete video stream
-			pStream->discard = AVDISCARD_ALL;
+            ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::Close (Clear video stream)");
 			pStream = NULL;
 			videoStream = -1;
 
+            ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::Close (Free video context)");
 			AV_FREE_CONTEXT(pCodecCtx);
 #if USE_HW_ACCEL
 			if (hw_de_on) {
 				if (hw_device_ctx) {
+                    ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::Close (Free hw context)");
 					av_buffer_unref(&hw_device_ctx);
 					hw_device_ctx = NULL;
 				}
@@ -615,25 +620,30 @@ void FFmpegReader::Close() {
 #endif // USE_HW_ACCEL
 		}
 		if (info.has_audio) {
+            ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::Close (Flush audio context)");
 			avcodec_flush_buffers(aCodecCtx);
 
 			// Delete audio stream
-			aStream->discard = AVDISCARD_ALL;
+            ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::Close (Clear audio stream)");
 			aStream = NULL;
 			audioStream = -1;
 
+            ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::Close (Free audio context)");
 			AV_FREE_CONTEXT(aCodecCtx);
 		}
 
 		// Clear final cache
+        ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::Close (Clear cache)");
 		final_cache.Clear();
 		working_cache.Clear();
 
 		// Close the video file
+        ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::Close (Close format context)");
 		avformat_close_input(&pFormatCtx);
 		av_freep(&pFormatCtx);
 
 		// Reset some variables
+        ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::Close (Clear variables)");
 		last_frame = 0;
 		largest_frame_processed = 0;
 		seek_audio_frame_found = 0;
@@ -641,6 +651,7 @@ void FFmpegReader::Close() {
 		current_video_frame = 0;
 		last_video_frame.reset();
 	}
+    ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::Close (End)");
 }
 
 bool FFmpegReader::HasAlbumArt() {

--- a/src/FFmpegReader.cpp
+++ b/src/FFmpegReader.cpp
@@ -34,27 +34,27 @@
 #include "libavutil/hwcontext_vaapi.h"
 
 typedef struct VAAPIDecodeContext {
-	 VAProfile			 va_profile;
-	 VAEntrypoint		  va_entrypoint;
-	 VAConfigID			va_config;
-	 VAContextID		   va_context;
+	 VAProfile va_profile;
+	 VAEntrypoint va_entrypoint;
+	 VAConfigID va_config;
+	 VAContextID va_context;
 
 #if FF_API_STRUCT_VAAPI_CONTEXT
 	 // FF_DISABLE_DEPRECATION_WARNINGS
-		 int				   have_old_context;
+		 int have_old_context;
 		 struct vaapi_context *old_context;
-		 AVBufferRef		  *device_ref;
+		 AVBufferRef *device_ref;
 	 // FF_ENABLE_DEPRECATION_WARNINGS
 #endif
 
-	 AVHWDeviceContext	*device;
+	 AVHWDeviceContext *device;
 	 AVVAAPIDeviceContext *hwctx;
 
-	 AVHWFramesContext	*frames;
+	 AVHWFramesContext *frames;
 	 AVVAAPIFramesContext *hwfc;
 
-	 enum AVPixelFormat	surface_format;
-	 int				   surface_count;
+	 enum AVPixelFormat surface_format;
+	 int surface_count;
  } VAAPIDecodeContext;
 #endif // ENABLE_VAAPI
 #endif // USE_HW_ACCEL
@@ -2032,8 +2032,8 @@ void FFmpegReader::CheckWorkingFrames(int64_t requested_frame) {
 		bool is_video_ready = false;
 		bool is_audio_ready = false;
 		double recent_pts_diff = recent_pts_seconds - frame_pts_seconds;
-		if ((video_pts_seconds != NO_PTS_OFFSET && frame_pts_seconds <= video_pts_seconds)
-			|| (video_pts_seconds != NO_PTS_OFFSET && recent_pts_diff > 1.5)
+		if ((frame_pts_seconds <= video_pts_seconds)
+			|| (recent_pts_diff > 1.5)
 			|| video_eof || end_of_file) {
 			// Video stream is past this frame (so it must be done)
 			// OR video stream is too far behind, missing, or end-of-file
@@ -2061,8 +2061,8 @@ void FFmpegReader::CheckWorkingFrames(int64_t requested_frame) {
 		}
 
 		double audio_pts_diff = audio_pts_seconds - frame_pts_seconds;
-		if ((audio_pts_seconds != NO_PTS_OFFSET && frame_pts_seconds < audio_pts_seconds && audio_pts_diff > 1.0)
-		   || (audio_pts_seconds != NO_PTS_OFFSET && recent_pts_diff > 1.5)
+		if ((frame_pts_seconds < audio_pts_seconds && audio_pts_diff > 1.0)
+		   || (recent_pts_diff > 1.5)
 		   || audio_eof || end_of_file) {
 			// Audio stream is past this frame (so it must be done)
 			// OR audio stream is too far behind, missing, or end-of-file

--- a/src/FFmpegReader.cpp
+++ b/src/FFmpegReader.cpp
@@ -13,8 +13,8 @@
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
-#include <thread>    // for std::this_thread::sleep_for
-#include <chrono>    // for std::chrono::milliseconds
+#include <thread>	// for std::this_thread::sleep_for
+#include <chrono>	// for std::chrono::milliseconds
 #include <unistd.h>
 
 #include "FFmpegUtilities.h"
@@ -34,27 +34,27 @@
 #include "libavutil/hwcontext_vaapi.h"
 
 typedef struct VAAPIDecodeContext {
-	 VAProfile             va_profile;
-	 VAEntrypoint          va_entrypoint;
-	 VAConfigID            va_config;
-	 VAContextID           va_context;
+	 VAProfile			 va_profile;
+	 VAEntrypoint		  va_entrypoint;
+	 VAConfigID			va_config;
+	 VAContextID		   va_context;
 
 #if FF_API_STRUCT_VAAPI_CONTEXT
 	 // FF_DISABLE_DEPRECATION_WARNINGS
-		 int                   have_old_context;
+		 int				   have_old_context;
 		 struct vaapi_context *old_context;
-		 AVBufferRef          *device_ref;
+		 AVBufferRef		  *device_ref;
 	 // FF_ENABLE_DEPRECATION_WARNINGS
 #endif
 
-	 AVHWDeviceContext    *device;
+	 AVHWDeviceContext	*device;
 	 AVVAAPIDeviceContext *hwctx;
 
-	 AVHWFramesContext    *frames;
+	 AVHWFramesContext	*frames;
 	 AVVAAPIFramesContext *hwfc;
 
-	 enum AVPixelFormat    surface_format;
-	 int                   surface_count;
+	 enum AVPixelFormat	surface_format;
+	 int				   surface_count;
  } VAAPIDecodeContext;
 #endif // ENABLE_VAAPI
 #endif // USE_HW_ACCEL
@@ -69,23 +69,23 @@ int hw_de_on = 0;
 #endif
 
 FFmpegReader::FFmpegReader(const std::string &path, bool inspect_reader)
-        : last_frame(0), is_seeking(0), seeking_pts(0), seeking_frame(0), seek_count(0), NO_PTS_OFFSET(-99999),
-          path(path), is_video_seek(true), check_interlace(false), check_fps(false), enable_seek(true), is_open(false),
-          seek_audio_frame_found(0), seek_video_frame_found(0), prev_samples(0), prev_pts(0), pts_total(0),
-          pts_counter(0), is_duration_known(false), largest_frame_processed(0), current_video_frame(0), packet(NULL),
-          max_concurrent_frames(OPEN_MP_NUM_PROCESSORS), audio_pts(0), video_pts(0), pFormatCtx(NULL), packets_read(0),
-          packets_decoded(0), videoStream(-1), audioStream(-1), pCodecCtx(NULL), aCodecCtx(NULL), pStream(NULL),
-          aStream(NULL), pFrame(NULL), previous_packet_location{-1,0}, video_eof(false), audio_eof(false),
-          packets_eof(false), end_of_file(false) {
+		: last_frame(0), is_seeking(0), seeking_pts(0), seeking_frame(0), seek_count(0), NO_PTS_OFFSET(-99999),
+		  path(path), is_video_seek(true), check_interlace(false), check_fps(false), enable_seek(true), is_open(false),
+		  seek_audio_frame_found(0), seek_video_frame_found(0), prev_samples(0), prev_pts(0), pts_total(0),
+		  pts_counter(0), is_duration_known(false), largest_frame_processed(0), current_video_frame(0), packet(NULL),
+		  max_concurrent_frames(OPEN_MP_NUM_PROCESSORS), audio_pts(0), video_pts(0), pFormatCtx(NULL), packets_read(0),
+		  packets_decoded(0), videoStream(-1), audioStream(-1), pCodecCtx(NULL), aCodecCtx(NULL), pStream(NULL),
+		  aStream(NULL), pFrame(NULL), previous_packet_location{-1,0}, video_eof(false), audio_eof(false),
+		  packets_eof(false), end_of_file(false) {
 
 	// Initialize FFMpeg, and register all formats and codecs
 	AV_REGISTER_ALL
 	AVCODEC_REGISTER_ALL
 
 	// Init timestamp offsets
-    pts_offset_seconds = NO_PTS_OFFSET;
-    video_pts_seconds = NO_PTS_OFFSET;
-    audio_pts_seconds = NO_PTS_OFFSET;
+	pts_offset_seconds = NO_PTS_OFFSET;
+	video_pts_seconds = NO_PTS_OFFSET;
+	audio_pts_seconds = NO_PTS_OFFSET;
 
 	// Init cache
 	working_cache.SetMaxBytesFromInfo(max_concurrent_frames * info.fps.ToDouble() * 2, info.width, info.height, info.sample_rate, info.channels);
@@ -228,26 +228,26 @@ void FFmpegReader::Open() {
 		// Init end-of-file detection variables
 		video_eof = true;
 		audio_eof = true;
-        packets_eof = true;
-        end_of_file = true;
-        packets_read = 0;
-        packets_decoded = 0;
+		packets_eof = true;
+		end_of_file = true;
+		packets_read = 0;
+		packets_decoded = 0;
 
 		// Loop through each stream, and identify the video and audio stream index
 		for (unsigned int i = 0; i < pFormatCtx->nb_streams; i++) {
 			// Is this a video stream?
 			if (AV_GET_CODEC_TYPE(pFormatCtx->streams[i]) == AVMEDIA_TYPE_VIDEO && videoStream < 0) {
 				videoStream = i;
-                video_eof = false;
-                packets_eof = false;
-                end_of_file = false;
-            }
+				video_eof = false;
+				packets_eof = false;
+				end_of_file = false;
+			}
 			// Is this an audio stream?
 			if (AV_GET_CODEC_TYPE(pFormatCtx->streams[i]) == AVMEDIA_TYPE_AUDIO && audioStream < 0) {
 				audioStream = i;
-                audio_eof = false;
-                packets_eof = false;
-                end_of_file = false;
+				audio_eof = false;
+				packets_eof = false;
+				end_of_file = false;
 			}
 		}
 		if (videoStream == -1 && audioStream == -1)
@@ -560,23 +560,23 @@ void FFmpegReader::Open() {
 		working_cache.SetMaxBytesFromInfo(max_concurrent_frames * info.fps.ToDouble() * 2, info.width, info.height, info.sample_rate, info.channels);
 		final_cache.SetMaxBytesFromInfo(max_concurrent_frames * 2, info.width, info.height, info.sample_rate, info.channels);
 
-        // Scan PTS for any offsets (i.e. non-zero starting streams). At least 1 stream must start at zero timestamp.
-        // This method allows us to shift timestamps to ensure at least 1 stream is starting at zero.
-        UpdatePTSOffset();
+		// Scan PTS for any offsets (i.e. non-zero starting streams). At least 1 stream must start at zero timestamp.
+		// This method allows us to shift timestamps to ensure at least 1 stream is starting at zero.
+		UpdatePTSOffset();
 
-        // Override an invalid framerate
-        if (info.fps.ToFloat() > 240.0f || (info.fps.num <= 0 || info.fps.den <= 0) || info.video_length <= 0) {
-            // Calculate FPS, duration, video bit rate, and video length manually
-            // by scanning through all the video stream packets
-            CheckFPS();
-        }
+		// Override an invalid framerate
+		if (info.fps.ToFloat() > 240.0f || (info.fps.num <= 0 || info.fps.den <= 0) || info.video_length <= 0) {
+			// Calculate FPS, duration, video bit rate, and video length manually
+			// by scanning through all the video stream packets
+			CheckFPS();
+		}
 
-        // Seek back to beginning of file (if not already seeking)
-        if (!is_seeking) {
-            Seek(1);
-        }
+		// Seek back to beginning of file (if not already seeking)
+		if (!is_seeking) {
+			Seek(1);
+		}
 
-        // Mark as "open"
+		// Mark as "open"
 		is_open = true;
 	}
 }
@@ -600,9 +600,9 @@ void FFmpegReader::Close() {
 			avcodec_flush_buffers(pCodecCtx);
 
 			// Delete video stream
-            pStream->discard = AVDISCARD_ALL;
-            pStream = NULL;
-            videoStream = -1;
+			pStream->discard = AVDISCARD_ALL;
+			pStream = NULL;
+			videoStream = -1;
 
 			AV_FREE_CONTEXT(pCodecCtx);
 #if USE_HW_ACCEL
@@ -617,10 +617,10 @@ void FFmpegReader::Close() {
 		if (info.has_audio) {
 			avcodec_flush_buffers(aCodecCtx);
 
-            // Delete audio stream
-            aStream->discard = AVDISCARD_ALL;
-            aStream = NULL;
-            audioStream = -1;
+			// Delete audio stream
+			aStream->discard = AVDISCARD_ALL;
+			aStream = NULL;
+			audioStream = -1;
 
 			AV_FREE_CONTEXT(aCodecCtx);
 		}
@@ -663,8 +663,8 @@ void FFmpegReader::UpdateAudioInfo() {
 	info.sample_rate = AV_GET_CODEC_ATTRIBUTES(aStream, aCodecCtx)->sample_rate;
 	info.audio_bit_rate = AV_GET_CODEC_ATTRIBUTES(aStream, aCodecCtx)->bit_rate;
 	if (info.audio_bit_rate <= 0) {
-	    // Get bitrate from format
-        info.audio_bit_rate = pFormatCtx->bit_rate;
+		// Get bitrate from format
+		info.audio_bit_rate = pFormatCtx->bit_rate;
 	}
 
 	// Set audio timebase
@@ -673,18 +673,18 @@ void FFmpegReader::UpdateAudioInfo() {
 
 	// Get timebase of audio stream (if valid) and greater than the current duration
 	if (aStream->duration > 0 && aStream->duration > info.duration) {
-	    // Get duration from audio stream
-        info.duration = aStream->duration * info.audio_timebase.ToDouble();
-    } else if (pFormatCtx->duration > 0 && info.duration <= 0.0f) {
-        // Use the format's duration
-        info.duration = float(pFormatCtx->duration) / AV_TIME_BASE;
-    }
+		// Get duration from audio stream
+		info.duration = aStream->duration * info.audio_timebase.ToDouble();
+	} else if (pFormatCtx->duration > 0 && info.duration <= 0.0f) {
+		// Use the format's duration
+		info.duration = float(pFormatCtx->duration) / AV_TIME_BASE;
+	}
 
-    // Calculate duration from filesize and bitrate (if any)
-    if (info.duration <= 0.0f && info.video_bit_rate > 0 && info.file_size > 0) {
-        // Estimate from bitrate, total bytes, and framerate
-        info.duration = float(info.file_size) / info.video_bit_rate;
-    }
+	// Calculate duration from filesize and bitrate (if any)
+	if (info.duration <= 0.0f && info.video_bit_rate > 0 && info.file_size > 0) {
+		// Estimate from bitrate, total bytes, and framerate
+		info.duration = float(info.file_size) / info.video_bit_rate;
+	}
 
 	// Check for an invalid video length
 	if (info.has_video && info.video_length <= 0) {
@@ -730,9 +730,9 @@ void FFmpegReader::UpdateVideoInfo() {
 	// Frame rate from the container and codec
 	AVRational framerate = av_guess_frame_rate(pFormatCtx, pStream, NULL);
 	if (!check_fps) {
-        info.fps.num = framerate.num;
-        info.fps.den = framerate.den;
-    }
+		info.fps.num = framerate.num;
+		info.fps.den = framerate.den;
+	}
 
 	ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::UpdateVideoInfo", "info.fps.num", info.fps.num, "info.fps.den", info.fps.den);
 
@@ -798,15 +798,15 @@ void FFmpegReader::UpdateVideoInfo() {
 
 	// Check for valid duration (if found)
 	if (info.duration <= 0.0f && pFormatCtx->duration >= 0) {
-        // Use the format's duration
-        info.duration = float(pFormatCtx->duration) / AV_TIME_BASE;
-    }
+		// Use the format's duration
+		info.duration = float(pFormatCtx->duration) / AV_TIME_BASE;
+	}
 
 	// Calculate duration from filesize and bitrate (if any)
 	if (info.duration <= 0.0f && info.video_bit_rate > 0 && info.file_size > 0) {
-        // Estimate from bitrate, total bytes, and framerate
-        info.duration = float(info.file_size) / info.video_bit_rate;
-    }
+		// Estimate from bitrate, total bytes, and framerate
+		info.duration = float(info.file_size) / info.video_bit_rate;
+	}
 
 	// No duration found in stream of file
 	if (info.duration <= 0.0f) {
@@ -861,39 +861,39 @@ std::shared_ptr<Frame> FFmpegReader::GetFrame(int64_t requested_frame) {
 		// Return the cached frame
 		return frame;
 	} else {
-        // Check the cache a 2nd time (due to a potential previous lock)
-        frame = final_cache.GetFrame(requested_frame);
-        if (frame) {
-            // Debug output
-            ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::GetFrame", "returned cached frame on 2nd look", requested_frame);
+		// Check the cache a 2nd time (due to a potential previous lock)
+		frame = final_cache.GetFrame(requested_frame);
+		if (frame) {
+			// Debug output
+			ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::GetFrame", "returned cached frame on 2nd look", requested_frame);
 
-            // Return the cached frame
-        } else {
-            // Frame is not in cache
-            // Reset seek count
-            seek_count = 0;
+			// Return the cached frame
+		} else {
+			// Frame is not in cache
+			// Reset seek count
+			seek_count = 0;
 
-            // Are we within X frames of the requested frame?
-            int64_t diff = requested_frame - last_frame;
-            if (diff >= 1 && diff <= 20) {
-                // Continue walking the stream
-                frame = ReadStream(requested_frame);
-            } else {
-                // Greater than 30 frames away, or backwards, we need to seek to the nearest key frame
-                if (enable_seek) {
-                    // Only seek if enabled
-                    Seek(requested_frame);
+			// Are we within X frames of the requested frame?
+			int64_t diff = requested_frame - last_frame;
+			if (diff >= 1 && diff <= 20) {
+				// Continue walking the stream
+				frame = ReadStream(requested_frame);
+			} else {
+				// Greater than 30 frames away, or backwards, we need to seek to the nearest key frame
+				if (enable_seek) {
+					// Only seek if enabled
+					Seek(requested_frame);
 
-                } else if (!enable_seek && diff < 0) {
-                    // Start over, since we can't seek, and the requested frame is smaller than our position
-                    // Since we are seeking to frame 1, this actually just closes/re-opens the reader
-                    Seek(1);
-                }
+				} else if (!enable_seek && diff < 0) {
+					// Start over, since we can't seek, and the requested frame is smaller than our position
+					// Since we are seeking to frame 1, this actually just closes/re-opens the reader
+					Seek(1);
+				}
 
-                // Then continue walking the stream
-                frame = ReadStream(requested_frame);
-            }
-        }
+				// Then continue walking the stream
+				frame = ReadStream(requested_frame);
+			}
+		}
 		return frame;
 	}
 }
@@ -909,70 +909,70 @@ std::shared_ptr<Frame> FFmpegReader::ReadStream(int64_t requested_frame) {
 
 	// Loop through the stream until the correct frame is found
 	while (true) {
-        // Check if working frames are 'finished'
-        if (!is_seeking) {
-            // Check for final frames
-            CheckWorkingFrames(requested_frame);
-        }
+		// Check if working frames are 'finished'
+		if (!is_seeking) {
+			// Check for final frames
+			CheckWorkingFrames(requested_frame);
+		}
 
-        // Check if requested 'final' frame is available (and break out of loop if found)
-        bool is_cache_found = (final_cache.GetFrame(requested_frame) != NULL);
-        if (is_cache_found) {
-            break;
-        }
+		// Check if requested 'final' frame is available (and break out of loop if found)
+		bool is_cache_found = (final_cache.GetFrame(requested_frame) != NULL);
+		if (is_cache_found) {
+			break;
+		}
 
 		// Get the next packet
 		packet_error = GetNextPacket();
 		if (packet_error < 0 && !packet) {
 			// No more packets to be found
-            packets_eof = true;
+			packets_eof = true;
 		}
 
 		// Debug output
 		ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::ReadStream (GetNextPacket)", "requested_frame", requested_frame,"packets_read", packets_read, "packets_decoded", packets_decoded, "is_seeking", is_seeking);
 
-        // Check the status of a seek (if any)
-        if (is_seeking) {
-            check_seek = CheckSeek(false);
-        } else {
-            check_seek = false;
-        }
+		// Check the status of a seek (if any)
+		if (is_seeking) {
+			check_seek = CheckSeek(false);
+		} else {
+			check_seek = false;
+		}
 
-        if (check_seek) {
-            // Packet may become NULL on Close inside Seek if CheckSeek returns false
-            // Jump to the next iteration of this loop
-            continue;
-        }
+		if (check_seek) {
+			// Packet may become NULL on Close inside Seek if CheckSeek returns false
+			// Jump to the next iteration of this loop
+			continue;
+		}
 
 		// Video packet
 		if ((info.has_video && packet && packet->stream_index == videoStream) ||
-		    (info.has_video && !packet && !video_eof)) {
-            // Process Video Packet
-            ProcessVideoPacket(requested_frame);
+			(info.has_video && !packet && !video_eof)) {
+			// Process Video Packet
+			ProcessVideoPacket(requested_frame);
 		}
 		// Audio packet
 		else if ((info.has_audio && packet && packet->stream_index == audioStream) ||
-		    (info.has_audio && !packet && !audio_eof)) {
+			(info.has_audio && !packet && !audio_eof)) {
 			// Process Audio Packet
 			ProcessAudioPacket(requested_frame);
 		}
-        
-        // Determine end-of-stream (waiting until final decoder threads finish)
-        // Force end-of-stream in some situations
-        end_of_file = packets_eof && video_eof && audio_eof;
-        if ((packets_eof && packets_read == packets_decoded) || end_of_file) {
-            // Force EOF (end of file) variables to true, if decoder does not support EOF detection.
-            // If we have no more packets, and all known packets have been decoded
-            ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::ReadStream (force EOF)", "packets_read", packets_read, "packets_decoded", packets_decoded, "packets_eof", packets_eof, "video_eof", video_eof, "audio_eof", audio_eof, "end_of_file", end_of_file);
-            if (!video_eof) {
-                video_eof = true;
-            }
-            if (!audio_eof) {
-                audio_eof = true;
-            }
-            end_of_file = true;
-            break;
-        }
+		
+		// Determine end-of-stream (waiting until final decoder threads finish)
+		// Force end-of-stream in some situations
+		end_of_file = packets_eof && video_eof && audio_eof;
+		if ((packets_eof && packets_read == packets_decoded) || end_of_file) {
+			// Force EOF (end of file) variables to true, if decoder does not support EOF detection.
+			// If we have no more packets, and all known packets have been decoded
+			ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::ReadStream (force EOF)", "packets_read", packets_read, "packets_decoded", packets_decoded, "packets_eof", packets_eof, "video_eof", video_eof, "audio_eof", audio_eof, "end_of_file", end_of_file);
+			if (!video_eof) {
+				video_eof = true;
+			}
+			if (!audio_eof) {
+				audio_eof = true;
+			}
+			end_of_file = true;
+			break;
+		}
 	} // end while
 
 	// Debug output
@@ -980,13 +980,13 @@ std::shared_ptr<Frame> FFmpegReader::ReadStream(int64_t requested_frame) {
 
 	// Have we reached end-of-stream (or the final frame)?
 	if (!end_of_file && requested_frame >= info.video_length) {
-	    // Force end-of-stream
-	    end_of_file = true;
+		// Force end-of-stream
+		end_of_file = true;
 	}
 	if (end_of_file) {
 		// Mark any other working frames as 'finished'
 		CheckWorkingFrames(requested_frame);
-    }
+	}
 
 	// Return requested frame (if found)
 	std::shared_ptr<Frame> frame = final_cache.GetFrame(requested_frame);
@@ -1027,9 +1027,9 @@ int FFmpegReader::GetNextPacket() {
 		packet = next_packet;
 		packets_read++;
 	} else {
-        // No more packets found
+		// No more packets found
 		delete next_packet;
-        packet = NULL;
+		packet = NULL;
 	}
 	// Return if packet was found (or error number)
 	return found_packet;
@@ -1043,7 +1043,7 @@ bool FFmpegReader::GetAVFrame() {
 	AVFrame *next_frame = AV_ALLOCATE_FRAME();
 
 #if IS_FFMPEG_3_2
-    int send_packet_err = avcodec_send_packet(pCodecCtx, packet);
+	int send_packet_err = avcodec_send_packet(pCodecCtx, packet);
 
 	#if USE_HW_ACCEL
 		// Get the format from the variables set in get_hw_dec_format
@@ -1054,7 +1054,7 @@ bool FFmpegReader::GetAVFrame() {
 			ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::GetAVFrame (Packet not sent)", "send_packet_err", send_packet_err);
 		}
 		else {
-            int receive_frame_err = 0;
+			int receive_frame_err = 0;
 			AVFrame *next_frame2;
 	#if USE_HW_ACCEL
 			if (hw_de_on && hw_de_supported) {
@@ -1067,20 +1067,20 @@ bool FFmpegReader::GetAVFrame() {
 			}
 			pFrame = AV_ALLOCATE_FRAME();
 			while (receive_frame_err >= 0) {
-                receive_frame_err = avcodec_receive_frame(pCodecCtx, next_frame2);
+				receive_frame_err = avcodec_receive_frame(pCodecCtx, next_frame2);
 
-                if (receive_frame_err == AVERROR_EOF) {
-                    ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::GetAVFrame (EOF - end of file detected from decoder)");
-                    video_eof = true;
-                }
-                if (receive_frame_err == AVERROR(EINVAL) || receive_frame_err == AVERROR_EOF) {
-                    ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::GetAVFrame (invalid frame received or EOF from decoder)");
-                    avcodec_flush_buffers(pCodecCtx);
-                }
-                if (receive_frame_err != 0) {
-                    ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::GetAVFrame (frame not ready yet from decoder)");
-                    break;
-                }
+				if (receive_frame_err == AVERROR_EOF) {
+					ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::GetAVFrame (EOF - end of file detected from decoder)");
+					video_eof = true;
+				}
+				if (receive_frame_err == AVERROR(EINVAL) || receive_frame_err == AVERROR_EOF) {
+					ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::GetAVFrame (invalid frame received or EOF from decoder)");
+					avcodec_flush_buffers(pCodecCtx);
+				}
+				if (receive_frame_err != 0) {
+					ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::GetAVFrame (frame not ready yet from decoder)");
+					break;
+				}
 
 	#if USE_HW_ACCEL
 				if (hw_de_on && hw_de_supported) {
@@ -1103,25 +1103,25 @@ bool FFmpegReader::GetAVFrame() {
 
 				// TODO also handle possible further frames
 				// Use only the first frame like avcodec_decode_video2
-                frameFinished = 1;
-                packets_decoded++;
+				frameFinished = 1;
+				packets_decoded++;
 
-                av_image_alloc(pFrame->data, pFrame->linesize, info.width, info.height, (AVPixelFormat)(pStream->codecpar->format), 1);
-                av_image_copy(pFrame->data, pFrame->linesize, (const uint8_t**)next_frame->data, next_frame->linesize,
-                                            (AVPixelFormat)(pStream->codecpar->format), info.width, info.height);
+				av_image_alloc(pFrame->data, pFrame->linesize, info.width, info.height, (AVPixelFormat)(pStream->codecpar->format), 1);
+				av_image_copy(pFrame->data, pFrame->linesize, (const uint8_t**)next_frame->data, next_frame->linesize,
+											(AVPixelFormat)(pStream->codecpar->format), info.width, info.height);
 
-                // Get display PTS from video frame, often different than packet->pts.
-                // Sending packets to the decoder (i.e. packet->pts) is async,
-                // and retrieving packets from the decoder (frame->pts) is async. In most decoders
-                // sending and retrieving are separated by multiple calls to this method.
-                if (next_frame->pts != AV_NOPTS_VALUE) {
-                    // This is the current decoded frame (and should be the pts used) for
-                    // processing this data
-                    video_pts = next_frame->pts;
-                }
+				// Get display PTS from video frame, often different than packet->pts.
+				// Sending packets to the decoder (i.e. packet->pts) is async,
+				// and retrieving packets from the decoder (frame->pts) is async. In most decoders
+				// sending and retrieving are separated by multiple calls to this method.
+				if (next_frame->pts != AV_NOPTS_VALUE) {
+					// This is the current decoded frame (and should be the pts used) for
+					// processing this data
+					video_pts = next_frame->pts;
+				}
 
-                // break out of loop after each successful image returned
-                break;
+				// break out of loop after each successful image returned
+				break;
 			}
 	#if USE_HW_ACCEL
 			if (hw_de_on && hw_de_supported) {
@@ -1192,15 +1192,15 @@ bool FFmpegReader::CheckSeek(bool is_video) {
 
 // Process a video packet
 void FFmpegReader::ProcessVideoPacket(int64_t requested_frame) {
-    // Get the AVFrame from the current packet
-    // This sets the video_pts to the correct timestamp
-    int frame_finished = GetAVFrame();
+	// Get the AVFrame from the current packet
+	// This sets the video_pts to the correct timestamp
+	int frame_finished = GetAVFrame();
 
-    // Check if the AVFrame is finished and set it
-    if (!frame_finished) {
-        // No AVFrame decoded yet, bail out
-        return;
-    }
+	// Check if the AVFrame is finished and set it
+	if (!frame_finished) {
+		// No AVFrame decoded yet, bail out
+		return;
+	}
 
 	// Calculate current frame #
 	int64_t current_frame = ConvertVideoPTStoFrame(video_pts);
@@ -1209,11 +1209,11 @@ void FFmpegReader::ProcessVideoPacket(int64_t requested_frame) {
 	if (!seek_video_frame_found && is_seeking)
 		seek_video_frame_found = current_frame;
 
-    // Create or get the existing frame object. Requested frame needs to be created
-    // in working_cache at least once. Seek can clear the working_cache, so we must
-    // add the requested frame back to the working_cache here. If it already exists,
-    // it will be moved to the top of the working_cache.
-    working_cache.Add(CreateFrame(requested_frame));
+	// Create or get the existing frame object. Requested frame needs to be created
+	// in working_cache at least once. Seek can clear the working_cache, so we must
+	// add the requested frame back to the working_cache here. If it already exists,
+	// it will be moved to the top of the working_cache.
+	working_cache.Add(CreateFrame(requested_frame));
 
 	// Debug output
 	ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::ProcessVideoPacket (Before)", "requested_frame", requested_frame, "current_frame", current_frame);
@@ -1257,7 +1257,7 @@ void FFmpegReader::ProcessVideoPacket(int64_t requested_frame) {
 			max_width = std::max(float(max_width), max_width * max_scale_x);
 			max_height = std::max(float(max_height), max_height * max_scale_y);
 
-        } else if (parent->scale == SCALE_CROP) {
+		} else if (parent->scale == SCALE_CROP) {
 			// Cropping scale mode (based on max timeline size * cropped size * scaling keyframes)
 			float max_scale_x = parent->scale_x.GetMaxPoint().co.Y;
 			float max_scale_y = parent->scale_y.GetMaxPoint().co.Y;
@@ -1275,18 +1275,18 @@ void FFmpegReader::ProcessVideoPacket(int64_t requested_frame) {
 			}
 
 		} else {
-            // Scale video to equivalent unscaled size
-            // Since the preview window can change sizes, we want to always
-            // scale against the ratio of original video size to timeline size
-            float preview_ratio = 1.0;
-            if (parent->ParentTimeline()) {
-                Timeline *t = (Timeline *) parent->ParentTimeline();
-                preview_ratio = t->preview_width / float(t->info.width);
-            }
-            float max_scale_x = parent->scale_x.GetMaxPoint().co.Y;
-            float max_scale_y = parent->scale_y.GetMaxPoint().co.Y;
-            max_width = info.width * max_scale_x * preview_ratio;
-            max_height = info.height * max_scale_y * preview_ratio;
+			// Scale video to equivalent unscaled size
+			// Since the preview window can change sizes, we want to always
+			// scale against the ratio of original video size to timeline size
+			float preview_ratio = 1.0;
+			if (parent->ParentTimeline()) {
+				Timeline *t = (Timeline *) parent->ParentTimeline();
+				preview_ratio = t->preview_width / float(t->info.width);
+			}
+			float max_scale_x = parent->scale_x.GetMaxPoint().co.Y;
+			float max_scale_y = parent->scale_y.GetMaxPoint().co.Y;
+			max_width = info.width * max_scale_x * preview_ratio;
+			max_height = info.height * max_scale_y * preview_ratio;
 		}
 	}
 
@@ -1353,31 +1353,31 @@ void FFmpegReader::ProcessVideoPacket(int64_t requested_frame) {
 	RemoveAVFrame(my_frame);
 	sws_freeContext(img_convert_ctx);
 
-    // Get video PTS in seconds
-    video_pts_seconds = (double(video_pts) * info.video_timebase.ToDouble()) + pts_offset_seconds;
+	// Get video PTS in seconds
+	video_pts_seconds = (double(video_pts) * info.video_timebase.ToDouble()) + pts_offset_seconds;
 
-    // Debug output
+	// Debug output
 	ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::ProcessVideoPacket (After)", "requested_frame", requested_frame, "current_frame", current_frame, "f->number", f->number, "video_pts_seconds", video_pts_seconds);
 }
 
 // Process an audio packet
 void FFmpegReader::ProcessAudioPacket(int64_t requested_frame) {
-    AudioLocation location;
-    // Calculate location of current audio packet
+	AudioLocation location;
+	// Calculate location of current audio packet
 	if (packet && packet->pts != AV_NOPTS_VALUE) {
-        // Determine related video frame and starting sample # from audio PTS
-        location = GetAudioPTSLocation(packet->pts);
+		// Determine related video frame and starting sample # from audio PTS
+		location = GetAudioPTSLocation(packet->pts);
 
-        // Track 1st audio packet after a successful seek
-        if (!seek_audio_frame_found && is_seeking)
-            seek_audio_frame_found = location.frame;
+		// Track 1st audio packet after a successful seek
+		if (!seek_audio_frame_found && is_seeking)
+			seek_audio_frame_found = location.frame;
 	}
 
-    // Create or get the existing frame object. Requested frame needs to be created
-    // in working_cache at least once. Seek can clear the working_cache, so we must
-    // add the requested frame back to the working_cache here. If it already exists,
-    // it will be moved to the top of the working_cache.
-    working_cache.Add(CreateFrame(requested_frame));
+	// Create or get the existing frame object. Requested frame needs to be created
+	// in working_cache at least once. Seek can clear the working_cache, so we must
+	// add the requested frame back to the working_cache here. If it already exists,
+	// it will be moved to the top of the working_cache.
+	working_cache.Add(CreateFrame(requested_frame));
 
 	// Debug output
 	ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::ProcessAudioPacket (Before)", "requested_frame", requested_frame, "target_frame", location.frame, "starting_sample", location.sample_start);
@@ -1391,41 +1391,41 @@ void FFmpegReader::ProcessAudioPacket(int64_t requested_frame) {
 	int data_size = 0;
 
 #if IS_FFMPEG_3_2
-        int send_packet_err =  avcodec_send_packet(aCodecCtx, packet);
-        if (send_packet_err < 0 && send_packet_err != AVERROR_EOF) {
-            ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::ProcessAudioPacket (Packet not sent)");
-        }
-        else {
-            int receive_frame_err = avcodec_receive_frame(aCodecCtx, audio_frame);
-            if (receive_frame_err >= 0) {
-                frame_finished = 1;
-            }
-            if (receive_frame_err == AVERROR_EOF) {
-                ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::ProcessAudioPacket (EOF - end of file detected from decoder)");
-                audio_eof = true;
-            }
-            if (receive_frame_err == AVERROR(EINVAL) || receive_frame_err == AVERROR_EOF) {
-                ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::ProcessAudioPacket (invalid frame received or EOF from decoder)");
-                avcodec_flush_buffers(aCodecCtx);
-            }
-            if (receive_frame_err != 0) {
-                ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::ProcessAudioPacket (frame not ready yet from decoder)");
-            }
-        }
+		int send_packet_err =  avcodec_send_packet(aCodecCtx, packet);
+		if (send_packet_err < 0 && send_packet_err != AVERROR_EOF) {
+			ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::ProcessAudioPacket (Packet not sent)");
+		}
+		else {
+			int receive_frame_err = avcodec_receive_frame(aCodecCtx, audio_frame);
+			if (receive_frame_err >= 0) {
+				frame_finished = 1;
+			}
+			if (receive_frame_err == AVERROR_EOF) {
+				ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::ProcessAudioPacket (EOF - end of file detected from decoder)");
+				audio_eof = true;
+			}
+			if (receive_frame_err == AVERROR(EINVAL) || receive_frame_err == AVERROR_EOF) {
+				ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::ProcessAudioPacket (invalid frame received or EOF from decoder)");
+				avcodec_flush_buffers(aCodecCtx);
+			}
+			if (receive_frame_err != 0) {
+				ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::ProcessAudioPacket (frame not ready yet from decoder)");
+			}
+		}
 #else
 		int used = avcodec_decode_audio4(aCodecCtx, audio_frame, &frame_finished, packet);
 #endif
 
 	if (frame_finished) {
-        packets_decoded++;
+		packets_decoded++;
 
-        // This can be different than the current packet, so we need to look
-        // at the current AVFrame from the audio decoder. This timestamp should
-        // be used for the remainder of this function
-        audio_pts = audio_frame->pts;
+		// This can be different than the current packet, so we need to look
+		// at the current AVFrame from the audio decoder. This timestamp should
+		// be used for the remainder of this function
+		audio_pts = audio_frame->pts;
 
-        // Determine related video frame and starting sample # from audio PTS
-        location = GetAudioPTSLocation(audio_pts);
+		// Determine related video frame and starting sample # from audio PTS
+		location = GetAudioPTSLocation(audio_pts);
 
 		// determine how many samples were decoded
 		int plane_size = -1;
@@ -1506,21 +1506,21 @@ void FFmpegReader::ProcessAudioPacket(int64_t requested_frame) {
 	SWR_INIT(avr);
 
 	// Convert audio samples
-	nb_samples = SWR_CONVERT(avr,    // audio resample context
-							 audio_converted->data,          // output data pointers
+	nb_samples = SWR_CONVERT(avr,	// audio resample context
+							 audio_converted->data,		  // output data pointers
 							 audio_converted->linesize[0],   // output plane size, in bytes. (0 if unknown)
-							 audio_converted->nb_samples,    // maximum number of samples that the output buffer can hold
-							 audio_frame->data,              // input data pointers
-							 audio_frame->linesize[0],       // input plane size, in bytes (0 if unknown)
-							 audio_frame->nb_samples);       // number of input samples to convert
+							 audio_converted->nb_samples,	// maximum number of samples that the output buffer can hold
+							 audio_frame->data,			  // input data pointers
+							 audio_frame->linesize[0],	   // input plane size, in bytes (0 if unknown)
+							 audio_frame->nb_samples);	   // number of input samples to convert
 
 	// Copy audio samples over original samples
 	memcpy(audio_buf,
-	       audio_converted->data[0],
-	       static_cast<size_t>(audio_converted->nb_samples)
-	           * av_get_bytes_per_sample(AV_SAMPLE_FMT_S16)
-	           * info.channels
-	      );
+		   audio_converted->data[0],
+		   static_cast<size_t>(audio_converted->nb_samples)
+			   * av_get_bytes_per_sample(AV_SAMPLE_FMT_S16)
+			   * info.channels
+		  );
 
 	// Deallocate resample buffer
 	SWR_CLOSE(avr);
@@ -1569,7 +1569,7 @@ void FFmpegReader::ProcessAudioPacket(int64_t requested_frame) {
 		// Loop through samples, and add them to the correct frames
 		int start = location.sample_start;
 		int remaining_samples = channel_buffer_size;
-		float *iterate_channel_buffer = channel_buffer;    // pointer to channel buffer
+		float *iterate_channel_buffer = channel_buffer;	// pointer to channel buffer
 		while (remaining_samples > 0) {
 			// Get Samples per frame (for this frame number)
 			int samples_per_frame = Frame::GetSamplesPerFrame(starting_frame_number, info.fps, info.sample_rate, info.channels);
@@ -1624,8 +1624,8 @@ void FFmpegReader::ProcessAudioPacket(int64_t requested_frame) {
 	// Free audio frame
 	AV_FREE_FRAME(&audio_frame);
 
-    // Get audio PTS in seconds
-    audio_pts_seconds = (double(audio_pts) * info.audio_timebase.ToDouble()) + pts_offset_seconds;
+	// Get audio PTS in seconds
+	audio_pts_seconds = (double(audio_pts) * info.audio_timebase.ToDouble()) + pts_offset_seconds;
 
 	// Debug output
 	ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::ProcessAudioPacket (After)", "requested_frame", requested_frame, "starting_frame", location.frame, "end_frame", starting_frame_number - 1, "audio_pts_seconds", audio_pts_seconds);
@@ -1648,14 +1648,14 @@ void FFmpegReader::Seek(int64_t requested_frame) {
 	working_cache.Clear();
 
 	// Reset the last frame variable
-    video_pts = 0.0;
-    video_pts_seconds = NO_PTS_OFFSET;
-    audio_pts = 0.0;
-    audio_pts_seconds = NO_PTS_OFFSET;
+	video_pts = 0.0;
+	video_pts_seconds = NO_PTS_OFFSET;
+	audio_pts = 0.0;
+	audio_pts_seconds = NO_PTS_OFFSET;
 	last_frame = 0;
 	current_video_frame = 0;
 	largest_frame_processed = 0;
-    packets_eof = false;
+	packets_eof = false;
 	video_eof = false;
 	audio_eof = false;
 	end_of_file = false;
@@ -1670,8 +1670,8 @@ void FFmpegReader::Seek(int64_t requested_frame) {
 	// If seeking near frame 1, we need to close and re-open the file (this is more reliable than seeking)
 	int buffer_amount = std::max(max_concurrent_frames, 8);
 	if (requested_frame - buffer_amount < 20) {
-	    // prevent Open() from seeking again
-        is_seeking = true;
+		// prevent Open() from seeking again
+		is_seeking = true;
 
 		// Close and re-open file (basically seeking to frame 1)
 		Close();
@@ -1749,18 +1749,18 @@ void FFmpegReader::Seek(int64_t requested_frame) {
 			seeking_pts = 0;
 			seeking_frame = 0;
 
-            // prevent Open() from seeking again
-            is_seeking = true;
+			// prevent Open() from seeking again
+			is_seeking = true;
 
 			// Close and re-open file (basically seeking to frame 1)
 			Close();
 			Open();
 
-            // Not actually seeking, so clear these flags
-            is_seeking = false;
+			// Not actually seeking, so clear these flags
+			is_seeking = false;
 
-            // disable seeking for this reader (since it failed)
-            enable_seek = false;
+			// disable seeking for this reader (since it failed)
+			enable_seek = false;
 
 			// Update overrides (since closing and re-opening might update these)
 			info.has_audio = has_audio_override;
@@ -1782,72 +1782,72 @@ int64_t FFmpegReader::GetPacketPTS() {
 // Update PTS Offset (if any)
 void FFmpegReader::UpdatePTSOffset() {
 	if (pts_offset_seconds != NO_PTS_OFFSET) {
-	    // Skip this method if we have already set PTS offset
-	    return;
+		// Skip this method if we have already set PTS offset
+		return;
 	}
-    pts_offset_seconds = 0.0;
-    double video_pts_offset_seconds = 0.0;
-    double audio_pts_offset_seconds = 0.0;
+	pts_offset_seconds = 0.0;
+	double video_pts_offset_seconds = 0.0;
+	double audio_pts_offset_seconds = 0.0;
 
-    bool has_video_pts = false;
-    if (!info.has_video) {
-        // Mark as checked
-        has_video_pts = true;
-    }
-    bool has_audio_pts = false;
-    if (!info.has_audio) {
-        // Mark as checked
-        has_audio_pts = true;
-    }
+	bool has_video_pts = false;
+	if (!info.has_video) {
+		// Mark as checked
+		has_video_pts = true;
+	}
+	bool has_audio_pts = false;
+	if (!info.has_audio) {
+		// Mark as checked
+		has_audio_pts = true;
+	}
 
-    // Loop through the stream (until a packet from all streams is found)
-    while (!has_video_pts || !has_audio_pts) {
-        // Get the next packet (if any)
-        if (GetNextPacket() < 0)
-            // Break loop when no more packets found
-            break;
+	// Loop through the stream (until a packet from all streams is found)
+	while (!has_video_pts || !has_audio_pts) {
+		// Get the next packet (if any)
+		if (GetNextPacket() < 0)
+			// Break loop when no more packets found
+			break;
 
-        // Get PTS of this packet
-        int64_t pts = GetPacketPTS();
+		// Get PTS of this packet
+		int64_t pts = GetPacketPTS();
 
-        // Video packet
-        if (!has_video_pts && packet->stream_index == videoStream) {
-            // Get the video packet start time (in seconds)
-            video_pts_offset_seconds = 0.0 - (video_pts * info.video_timebase.ToDouble());
+		// Video packet
+		if (!has_video_pts && packet->stream_index == videoStream) {
+			// Get the video packet start time (in seconds)
+			video_pts_offset_seconds = 0.0 - (video_pts * info.video_timebase.ToDouble());
 
-            // Is timestamp close to zero (within X seconds)
-            // Ignore wildly invalid timestamps (i.e. -234923423423)
-            if (std::abs(video_pts_offset_seconds) <= 10.0) {
-                has_video_pts = true;
-            }
-        }
-        else if (!has_audio_pts && packet->stream_index == audioStream) {
-            // Get the audio packet start time (in seconds)
-            audio_pts_offset_seconds = 0.0 - (pts * info.audio_timebase.ToDouble());
+			// Is timestamp close to zero (within X seconds)
+			// Ignore wildly invalid timestamps (i.e. -234923423423)
+			if (std::abs(video_pts_offset_seconds) <= 10.0) {
+				has_video_pts = true;
+			}
+		}
+		else if (!has_audio_pts && packet->stream_index == audioStream) {
+			// Get the audio packet start time (in seconds)
+			audio_pts_offset_seconds = 0.0 - (pts * info.audio_timebase.ToDouble());
 
-            // Is timestamp close to zero (within X seconds)
-            // Ignore wildly invalid timestamps (i.e. -234923423423)
-            if (std::abs(audio_pts_offset_seconds) <= 10.0) {
-                has_audio_pts = true;
-            }
-        }
-    }
+			// Is timestamp close to zero (within X seconds)
+			// Ignore wildly invalid timestamps (i.e. -234923423423)
+			if (std::abs(audio_pts_offset_seconds) <= 10.0) {
+				has_audio_pts = true;
+			}
+		}
+	}
 
-    // Do we have all valid timestamps to determine PTS offset?
-    if (has_video_pts && has_audio_pts) {
-        // Set PTS Offset to the smallest offset
-        //     [  video timestamp  ]
-        //           [  audio timestamp  ]
-        //
-        //     ** SHIFT TIMESTAMPS TO ZERO **
-        //
-        //[  video timestamp  ]
-        //      [  audio timestamp  ]
-        //
-        // Since all offsets are negative at this point, we want the max value, which
-        // represents the closest to zero
-        pts_offset_seconds = std::max(video_pts_offset_seconds, audio_pts_offset_seconds);
-    }
+	// Do we have all valid timestamps to determine PTS offset?
+	if (has_video_pts && has_audio_pts) {
+		// Set PTS Offset to the smallest offset
+		//	 [  video timestamp  ]
+		//		   [  audio timestamp  ]
+		//
+		//	 ** SHIFT TIMESTAMPS TO ZERO **
+		//
+		//[  video timestamp  ]
+		//	  [  audio timestamp  ]
+		//
+		// Since all offsets are negative at this point, we want the max value, which
+		// represents the closest to zero
+		pts_offset_seconds = std::max(video_pts_offset_seconds, audio_pts_offset_seconds);
+	}
 }
 
 // Convert PTS into Frame Number
@@ -1895,7 +1895,7 @@ int64_t FFmpegReader::ConvertFrameToVideoPTS(int64_t frame_number) {
 // Convert Frame Number into Video PTS
 int64_t FFmpegReader::ConvertFrameToAudioPTS(int64_t frame_number) {
 	// Get timestamp of this frame (in seconds)
-    double seconds = (double(frame_number - 1) / info.fps.ToDouble()) + pts_offset_seconds;
+	double seconds = (double(frame_number - 1) / info.fps.ToDouble()) + pts_offset_seconds;
 
 	// Calculate the # of audio packets in this timestamp
 	int64_t audio_pts = round(seconds / info.audio_timebase.ToDouble());
@@ -2009,66 +2009,66 @@ bool FFmpegReader::IsPartialFrame(int64_t requested_frame) {
 void FFmpegReader::CheckWorkingFrames(int64_t requested_frame) {
 
 	// Get a list of current working queue frames in the cache (in-progress frames)
-    std::vector<std::shared_ptr<openshot::Frame>> working_frames = working_cache.GetFrames();
-    std::vector<std::shared_ptr<openshot::Frame>>::iterator working_itr;
+	std::vector<std::shared_ptr<openshot::Frame>> working_frames = working_cache.GetFrames();
+	std::vector<std::shared_ptr<openshot::Frame>>::iterator working_itr;
 
-    // Loop through all working queue frames (sorted by frame #)
-    for(working_itr = working_frames.begin(); working_itr != working_frames.end(); ++working_itr)
-    {
-        // Get working frame
-        std::shared_ptr<Frame> f = *working_itr;
+	// Loop through all working queue frames (sorted by frame #)
+	for(working_itr = working_frames.begin(); working_itr != working_frames.end(); ++working_itr)
+	{
+		// Get working frame
+		std::shared_ptr<Frame> f = *working_itr;
 
 		// Was a frame found? Is frame requested yet?
 		if (!f || f && f->number > requested_frame) {
-		    // If not, skip to next one
-            continue;
-        }
+			// If not, skip to next one
+			continue;
+		}
 
 		// Calculate PTS in seconds (of working frame), and the most recent processed pts value
 		double frame_pts_seconds = (double(f->number - 1) / info.fps.ToDouble()) + pts_offset_seconds;
-        double recent_pts_seconds = std::max(video_pts_seconds, audio_pts_seconds);
+		double recent_pts_seconds = std::max(video_pts_seconds, audio_pts_seconds);
 
-        // Determine if video and audio are ready (based on timestamps)
+		// Determine if video and audio are ready (based on timestamps)
 		bool is_video_ready = false;
 		bool is_audio_ready = false;
-        double recent_pts_diff = recent_pts_seconds - frame_pts_seconds;
+		double recent_pts_diff = recent_pts_seconds - frame_pts_seconds;
 		if ((video_pts_seconds != NO_PTS_OFFSET && frame_pts_seconds <= video_pts_seconds)
-		    || (video_pts_seconds != NO_PTS_OFFSET && recent_pts_diff > 1.5)
-		    || video_eof || end_of_file) {
-		    // Video stream is past this frame (so it must be done)
-		    // OR video stream is too far behind, missing, or end-of-file
-            is_video_ready = true;
-            ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::CheckWorkingFrames (video ready)", "frame_number", f->number, "frame_pts_seconds", frame_pts_seconds, "video_pts_seconds", video_pts_seconds, "recent_pts_diff", recent_pts_diff);
+			|| (video_pts_seconds != NO_PTS_OFFSET && recent_pts_diff > 1.5)
+			|| video_eof || end_of_file) {
+			// Video stream is past this frame (so it must be done)
+			// OR video stream is too far behind, missing, or end-of-file
+			is_video_ready = true;
+			ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::CheckWorkingFrames (video ready)", "frame_number", f->number, "frame_pts_seconds", frame_pts_seconds, "video_pts_seconds", video_pts_seconds, "recent_pts_diff", recent_pts_diff);
 			if (info.has_video && !f->has_image_data) {
-                // Frame has no image data (copy from previous frame)
-                // Loop backwards through final frames (looking for the nearest, previous frame image)
-                for (int64_t previous_frame = requested_frame - 1; previous_frame > 0; previous_frame--) {
-                    std::shared_ptr<Frame> previous_frame_instance = final_cache.GetFrame(previous_frame);
-                    if (previous_frame_instance && previous_frame_instance->has_image_data) {
-                        // Copy image from last decoded frame
-                        f->AddImage(std::make_shared<QImage>(*previous_frame_instance->GetImage()));
-                        break;
-                    }
-                }
-                
-                if (last_video_frame && !f->has_image_data) {
-                    // Copy image from last decoded frame
-                    f->AddImage(std::make_shared<QImage>(*last_video_frame->GetImage()));
-                } else if (!f->has_image_data) {
-                    f->AddColor("#000000");
-                }
+				// Frame has no image data (copy from previous frame)
+				// Loop backwards through final frames (looking for the nearest, previous frame image)
+				for (int64_t previous_frame = requested_frame - 1; previous_frame > 0; previous_frame--) {
+					std::shared_ptr<Frame> previous_frame_instance = final_cache.GetFrame(previous_frame);
+					if (previous_frame_instance && previous_frame_instance->has_image_data) {
+						// Copy image from last decoded frame
+						f->AddImage(std::make_shared<QImage>(*previous_frame_instance->GetImage()));
+						break;
+					}
+				}
+				
+				if (last_video_frame && !f->has_image_data) {
+					// Copy image from last decoded frame
+					f->AddImage(std::make_shared<QImage>(*last_video_frame->GetImage()));
+				} else if (!f->has_image_data) {
+					f->AddColor("#000000");
+				}
 			}
 		}
 
-        double audio_pts_diff = audio_pts_seconds - frame_pts_seconds;
+		double audio_pts_diff = audio_pts_seconds - frame_pts_seconds;
 		if ((audio_pts_seconds != NO_PTS_OFFSET && frame_pts_seconds < audio_pts_seconds && audio_pts_diff > 1.0)
 		   || (audio_pts_seconds != NO_PTS_OFFSET && recent_pts_diff > 1.5)
 		   || audio_eof || end_of_file) {
-		    // Audio stream is past this frame (so it must be done)
-            // OR audio stream is too far behind, missing, or end-of-file
-            // Adding a bit of margin here, to allow for partial audio packets
-            is_audio_ready = true;
-            ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::CheckWorkingFrames (audio ready)", "frame_number", f->number, "frame_pts_seconds", frame_pts_seconds, "audio_pts_seconds", audio_pts_seconds, "audio_pts_diff", audio_pts_diff, "recent_pts_diff", recent_pts_diff);
+			// Audio stream is past this frame (so it must be done)
+			// OR audio stream is too far behind, missing, or end-of-file
+			// Adding a bit of margin here, to allow for partial audio packets
+			is_audio_ready = true;
+			ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::CheckWorkingFrames (audio ready)", "frame_number", f->number, "frame_pts_seconds", frame_pts_seconds, "audio_pts_seconds", audio_pts_seconds, "audio_pts_diff", audio_pts_diff, "recent_pts_diff", recent_pts_diff);
 		}
 		bool is_seek_trash = IsPartialFrame(f->number);
 
@@ -2104,18 +2104,18 @@ void FFmpegReader::CheckWorkingFrames(int64_t requested_frame) {
 
 // Check for the correct frames per second (FPS) value by scanning the 1st few seconds of video packets.
 void FFmpegReader::CheckFPS() {
-    if (check_fps) {
-        // Do not check FPS more than 1 time
-        return;
-    } else {
-        check_fps = true;
-    }
+	if (check_fps) {
+		// Do not check FPS more than 1 time
+		return;
+	} else {
+		check_fps = true;
+	}
 
 	int frames_per_second[3] = {0,0,0};
-    int max_fps_index = sizeof(frames_per_second) / sizeof(frames_per_second[0]);
-    int fps_index = 0;
+	int max_fps_index = sizeof(frames_per_second) / sizeof(frames_per_second[0]);
+	int fps_index = 0;
 
-    int all_frames_detected = 0;
+	int all_frames_detected = 0;
 	int starting_frames_detected = 0;
 
 	// Loop through the stream
@@ -2127,27 +2127,27 @@ void FFmpegReader::CheckFPS() {
 
 		// Video packet
 		if (packet->stream_index == videoStream) {
-            // Get the video packet start time (in seconds)
-            double video_seconds = (double(GetPacketPTS()) * info.video_timebase.ToDouble()) + pts_offset_seconds;
-            fps_index = int(video_seconds); // truncate float timestamp to int (second 1, second 2, second 3)
+			// Get the video packet start time (in seconds)
+			double video_seconds = (double(GetPacketPTS()) * info.video_timebase.ToDouble()) + pts_offset_seconds;
+			fps_index = int(video_seconds); // truncate float timestamp to int (second 1, second 2, second 3)
 
-            // Is this video packet from the first few seconds?
-            if (fps_index >= 0 && fps_index < max_fps_index) {
-                // Yes, keep track of how many frames per second (over the first few seconds)
-                starting_frames_detected++;
-                frames_per_second[fps_index]++;
-            }
+			// Is this video packet from the first few seconds?
+			if (fps_index >= 0 && fps_index < max_fps_index) {
+				// Yes, keep track of how many frames per second (over the first few seconds)
+				starting_frames_detected++;
+				frames_per_second[fps_index]++;
+			}
 
-            // Track all video packets detected
-            all_frames_detected++;
+			// Track all video packets detected
+			all_frames_detected++;
 		}
 	}
 
 	// Calculate FPS (based on the first few seconds of video packets)
 	float avg_fps = 30.0;
 	if (starting_frames_detected > 0 && fps_index > 0) {
-        avg_fps = float(starting_frames_detected) / std::min(fps_index, max_fps_index);
-    }
+		avg_fps = float(starting_frames_detected) / std::min(fps_index, max_fps_index);
+	}
 
 	// Verify average FPS is a reasonable value
 	if (avg_fps < 8.0) {
@@ -2155,21 +2155,21 @@ void FFmpegReader::CheckFPS() {
 		avg_fps = 30.0;
 	}
 
-    // Update FPS (truncate average FPS to Integer)
-    info.fps = Fraction(int(avg_fps), 1);
+	// Update FPS (truncate average FPS to Integer)
+	info.fps = Fraction(int(avg_fps), 1);
 
-    // Update Duration and Length
-    if (all_frames_detected > 0) {
-        // Use all video frames detected to calculate # of frames
-        info.video_length = all_frames_detected;
-        info.duration = all_frames_detected / avg_fps;
-    } else {
-        // Use previous duration to calculate # of frames
-        info.video_length = info.duration * avg_fps;
-    }
+	// Update Duration and Length
+	if (all_frames_detected > 0) {
+		// Use all video frames detected to calculate # of frames
+		info.video_length = all_frames_detected;
+		info.duration = all_frames_detected / avg_fps;
+	} else {
+		// Use previous duration to calculate # of frames
+		info.video_length = info.duration * avg_fps;
+	}
 
-    // Update video bit rate
-    info.video_bit_rate = info.file_size / info.duration;
+	// Update video bit rate
+	info.video_bit_rate = info.file_size / info.duration;
 }
 
 // Remove AVFrame from cache (and deallocate its memory)

--- a/src/FFmpegReader.h
+++ b/src/FFmpegReader.h
@@ -109,24 +109,24 @@ namespace openshot {
 		int64_t seek_audio_frame_found;
 		int64_t seek_video_frame_found;
 
-        int64_t last_frame;
-        int64_t largest_frame_processed;
-        int64_t current_video_frame;
+		int64_t last_frame;
+		int64_t largest_frame_processed;
+		int64_t current_video_frame;
 
 		int64_t audio_pts;
-        int64_t video_pts;
+		int64_t video_pts;
 		double pts_offset_seconds;
 		double audio_pts_seconds;
-        double video_pts_seconds;
+		double video_pts_seconds;
 		int64_t NO_PTS_OFFSET;
 		bool video_eof;
 		bool audio_eof;
-        bool packets_eof;
-        bool end_of_file;
-        int64_t packets_read;
-        int64_t packets_decoded;
+		bool packets_eof;
+		bool end_of_file;
+		int64_t packets_read;
+		int64_t packets_decoded;
 
-        int hw_de_supported = 0;    // Is set by FFmpegReader
+		int hw_de_supported = 0;	// Is set by FFmpegReader
 #if USE_HW_ACCEL
 		AVPixelFormat hw_de_av_pix_fmt = AV_PIX_FMT_NONE;
 		AVHWDeviceType hw_de_av_device_type = AV_HWDEVICE_TYPE_NONE;

--- a/src/FFmpegReader.h
+++ b/src/FFmpegReader.h
@@ -77,7 +77,7 @@ namespace openshot {
 		std::string path;
 
 		AVFormatContext *pFormatCtx;
-		int i, videoStream, audioStream;
+		int videoStream, audioStream;
 		AVCodecContext *pCodecCtx, *aCodecCtx;
 #if USE_HW_ACCEL
 		AVBufferRef *hw_device_ctx = NULL; //PM
@@ -89,20 +89,9 @@ namespace openshot {
 		bool is_duration_known;
 		bool check_interlace;
 		bool check_fps;
-		bool has_missing_frames;
 		int max_concurrent_frames;
 
 		CacheMemory working_cache;
-		CacheMemory missing_frames;
-		std::map<int64_t, int64_t> processing_video_frames;
-		std::multimap<int64_t, int64_t> processing_audio_frames;
-		std::map<int64_t, int64_t> processed_video_frames;
-		std::map<int64_t, int64_t> processed_audio_frames;
-		std::multimap<int64_t, int64_t> missing_video_frames;
-		std::multimap<int64_t, int64_t> missing_video_frames_source;
-		std::multimap<int64_t, int64_t> missing_audio_frames;
-		std::multimap<int64_t, int64_t> missing_audio_frames_source;
-		std::map<int64_t, int> checked_frames;
 		AudioLocation previous_packet_location;
 
 		// DEBUG VARIABLES (FOR AUDIO ISSUES)
@@ -110,8 +99,6 @@ namespace openshot {
 		int64_t prev_pts;
 		int64_t pts_total;
 		int64_t pts_counter;
-		int64_t num_packets_since_video_frame;
-		int64_t num_checks_since_final;
 		std::shared_ptr<openshot::Frame> last_video_frame;
 
 		bool is_seeking;
@@ -122,13 +109,24 @@ namespace openshot {
 		int64_t seek_audio_frame_found;
 		int64_t seek_video_frame_found;
 
-		int64_t audio_pts_offset;
-		int64_t video_pts_offset;
-		int64_t last_frame;
-		int64_t largest_frame_processed;
-		int64_t current_video_frame;    // can't reliably use PTS of video to determine this
+        int64_t last_frame;
+        int64_t largest_frame_processed;
+        int64_t current_video_frame;
 
-		int hw_de_supported = 0;    // Is set by FFmpegReader
+		int64_t audio_pts;
+        int64_t video_pts;
+		double pts_offset_seconds;
+		double audio_pts_seconds;
+        double video_pts_seconds;
+		int64_t NO_PTS_OFFSET;
+		bool video_eof;
+		bool audio_eof;
+        bool packets_eof;
+        bool end_of_file;
+        int64_t packets_read;
+        int64_t packets_decoded;
+
+        int hw_de_supported = 0;    // Is set by FFmpegReader
 #if USE_HW_ACCEL
 		AVPixelFormat hw_de_av_pix_fmt = AV_PIX_FMT_NONE;
 		AVHWDeviceType hw_de_av_device_type = AV_HWDEVICE_TYPE_NONE;
@@ -141,11 +139,8 @@ namespace openshot {
 		/// Check the current seek position and determine if we need to seek again
 		bool CheckSeek(bool is_video);
 
-		/// Check if a frame is missing and attempt to replace its frame image (and
-		bool CheckMissingFrame(int64_t requested_frame);
-
 		/// Check the working queue, and move finished frames to the finished queue
-		void CheckWorkingFrames(bool end_of_stream, int64_t requested_frame);
+		void CheckWorkingFrames(int64_t requested_frame);
 
 		/// Convert Frame Number into Audio PTS
 		int64_t ConvertFrameToAudioPTS(int64_t frame_number);
@@ -168,14 +163,8 @@ namespace openshot {
 		/// Get the next packet (if any)
 		int GetNextPacket();
 
-		/// Get the smallest video frame that is still being processed
-		int64_t GetSmallestVideoFrame();
-
-		/// Get the smallest audio frame that is still being processed
-		int64_t GetSmallestAudioFrame();
-
-		/// Get the PTS for the current video packet
-		int64_t GetVideoPTS();
+		/// Get the PTS for the current packet
+		int64_t GetPacketPTS();
 
 		/// Check if there's an album art
 		bool HasAlbumArt();
@@ -187,7 +176,7 @@ namespace openshot {
 		void ProcessVideoPacket(int64_t requested_frame);
 
 		/// Process an audio packet
-		void ProcessAudioPacket(int64_t requested_frame, int64_t target_frame, int starting_sample);
+		void ProcessAudioPacket(int64_t requested_frame);
 
 		/// Read the stream until we find the requested Frame
 		std::shared_ptr<openshot::Frame> ReadStream(int64_t requested_frame);
@@ -201,8 +190,10 @@ namespace openshot {
 		/// Seek to a specific Frame.  This is not always frame accurate, it's more of an estimation on many codecs.
 		void Seek(int64_t requested_frame);
 
-		/// Update PTS Offset (if any)
-		void UpdatePTSOffset(bool is_video);
+		/// Update PTS Offset (presentation time stamp). This shifts timestamps for all streams, so the first timestamp
+		/// is always zero. If one stream starts first, it will always be zero, and the other streams shifted
+		/// to maintain the correct relative time distance.
+		void UpdatePTSOffset();
 
 		/// Update File Info for audio streams
 		void UpdateAudioInfo();

--- a/src/Frame.cpp
+++ b/src/Frame.cpp
@@ -753,6 +753,10 @@ void Frame::AddImage(
 	int new_width, int new_height, int bytes_per_pixel,
 	QImage::Format type, const unsigned char *pixels_)
 {
+    if (has_image_data) {
+        // Delete the previous QImage
+        image.reset();
+    }
 
   // Create new image object from pixel data
 	auto new_image = std::make_shared<QImage>(

--- a/src/Frame.cpp
+++ b/src/Frame.cpp
@@ -108,8 +108,6 @@ void Frame::DeepCopy(const Frame& other)
 
 // Destructor
 Frame::~Frame() {
-    std::cout << "Frame::~Frame, number: " << number << ", has_image_data: " << has_image_data << std::endl;
-
 	// Clear all pointers
 	image.reset();
 	audio.reset();
@@ -753,12 +751,12 @@ void Frame::AddImage(
 	int new_width, int new_height, int bytes_per_pixel,
 	QImage::Format type, const unsigned char *pixels_)
 {
-    if (has_image_data) {
-        // Delete the previous QImage
-        image.reset();
-    }
+	if (has_image_data) {
+		// Delete the previous QImage
+		image.reset();
+	}
 
-  // Create new image object from pixel data
+	// Create new image object from pixel data
 	auto new_image = std::make_shared<QImage>(
 		pixels_,
 		new_width, new_height,
@@ -767,7 +765,6 @@ void Frame::AddImage(
 		(QImageCleanupFunction) &openshot::cleanUpBuffer,
 		(void*) pixels_
 	);
-	std::cout << "Frame::AddImage, number: " << number << ", Cleanup buffer: " << ( void * )&pixels_[0] << ", width: " << new_width << ", height: " << new_height << std::endl;
 	AddImage(new_image);
 }
 

--- a/src/Frame.cpp
+++ b/src/Frame.cpp
@@ -763,6 +763,7 @@ void Frame::AddImage(
 		(QImageCleanupFunction) &openshot::cleanUpBuffer,
 		(void*) pixels_
 	);
+	std::cout << "Frame::AddImage, number: " << number << ", Cleanup buffer: " << ( void * )&pixels_[0] << ", width: " << new_width << ", height: " << new_height << std::endl;
 	AddImage(new_image);
 }
 

--- a/src/Frame.cpp
+++ b/src/Frame.cpp
@@ -108,6 +108,8 @@ void Frame::DeepCopy(const Frame& other)
 
 // Destructor
 Frame::~Frame() {
+    std::cout << "Frame::~Frame, number: " << number << ", has_image_data: " << has_image_data << std::endl;
+
 	// Clear all pointers
 	image.reset();
 	audio.reset();

--- a/src/FrameMapper.cpp
+++ b/src/FrameMapper.cpp
@@ -773,6 +773,7 @@ void FrameMapper::ChangeMapping(Fraction target_fps, PulldownType target_pulldow
 	info.fps.den = target_fps.den;
 	info.video_timebase.num = target_fps.den;
 	info.video_timebase.den = target_fps.num;
+    info.video_length = round(info.duration * info.fps.ToDouble());
 	pulldown = target_pulldown;
 	info.sample_rate = target_sample_rate;
 	info.channels = target_channels;

--- a/src/FrameMapper.cpp
+++ b/src/FrameMapper.cpp
@@ -219,7 +219,7 @@ void FrameMapper::Init()
 		int64_t new_length = reader->info.video_length * rate_diff;
 
 		// Calculate the value difference
-		double value_increment = (reader->info.video_length + 1) / (double) (new_length);
+		double value_increment = reader->info.video_length / (double) (new_length);
 
 		// Loop through curve, and build list of frames
 		double original_frame_num = 1.0f;

--- a/src/FrameMapper.cpp
+++ b/src/FrameMapper.cpp
@@ -773,7 +773,7 @@ void FrameMapper::ChangeMapping(Fraction target_fps, PulldownType target_pulldow
 	info.fps.den = target_fps.den;
 	info.video_timebase.num = target_fps.den;
 	info.video_timebase.den = target_fps.num;
-    info.video_length = round(info.duration * info.fps.ToDouble());
+	info.video_length = round(info.duration * info.fps.ToDouble());
 	pulldown = target_pulldown;
 	info.sample_rate = target_sample_rate;
 	info.channels = target_channels;

--- a/src/QtUtilities.h
+++ b/src/QtUtilities.h
@@ -11,6 +11,7 @@
 #ifndef OPENSHOT_QT_UTILITIES_H
 #define OPENSHOT_QT_UTILITIES_H
 
+#include <iostream>
 #include <Qt>
 #include <QTextStream>
 
@@ -28,10 +29,13 @@ namespace openshot {
     // Clean up buffer after QImage is deleted
     static inline void cleanUpBuffer(void *info)
     {
+        std::cout << "--> cleanUpBuffer, info: " << info << std::endl;
         if (!info)
             return;
         // Remove buffer since QImage tells us to
+        std::cout << "--> reinterpret cast, info: " << info << std::endl;
         auto* qbuffer = reinterpret_cast<unsigned char*>(info);
+        std::cout << "--> delete pointer, info: " << info << std::endl;
         delete[] qbuffer;
     }
 }  // namespace

--- a/src/QtUtilities.h
+++ b/src/QtUtilities.h
@@ -29,14 +29,14 @@ namespace openshot {
     // Clean up buffer after QImage is deleted
     static inline void cleanUpBuffer(void *info)
     {
-        std::cout << "--> cleanUpBuffer, info: " << info << std::endl;
+        std::cout << "--> cleanUpBuffer" << std::endl;
         if (!info)
             return;
         // Remove buffer since QImage tells us to
-        std::cout << "--> reinterpret cast, info: " << info << std::endl;
-        auto* qbuffer = reinterpret_cast<unsigned char*>(info);
-        std::cout << "--> delete pointer, info: " << info << std::endl;
-        //delete[] qbuffer;
+        std::cout << "--> reinterpret cast" << std::endl;
+        uint8_t *qbuffer = reinterpret_cast<uint8_t *>(info);
+        std::cout << "--> delete pointer, buffer: " << ( void * )&qbuffer[0] << std::endl;
+        delete[] qbuffer;
     }
 }  // namespace
 

--- a/src/QtUtilities.h
+++ b/src/QtUtilities.h
@@ -36,7 +36,7 @@ namespace openshot {
         std::cout << "--> reinterpret cast, info: " << info << std::endl;
         auto* qbuffer = reinterpret_cast<unsigned char*>(info);
         std::cout << "--> delete pointer, info: " << info << std::endl;
-        delete[] qbuffer;
+        //delete[] qbuffer;
     }
 }  // namespace
 

--- a/src/QtUtilities.h
+++ b/src/QtUtilities.h
@@ -29,13 +29,10 @@ namespace openshot {
     // Clean up buffer after QImage is deleted
     static inline void cleanUpBuffer(void *info)
     {
-        std::cout << "--> cleanUpBuffer" << std::endl;
         if (!info)
             return;
         // Remove buffer since QImage tells us to
-        std::cout << "--> reinterpret cast" << std::endl;
         uint8_t *qbuffer = reinterpret_cast<uint8_t *>(info);
-        std::cout << "--> delete pointer, buffer: " << ( void * )&qbuffer[0] << std::endl;
         delete[] qbuffer;
     }
 }  // namespace

--- a/src/Timeline.cpp
+++ b/src/Timeline.cpp
@@ -861,8 +861,7 @@ std::shared_ptr<Frame> Timeline::GetFrame(int64_t requested_frame)
         for (auto clip : nearby_clips)
         {
             long clip_start_position = round(clip->Position() * info.fps.ToDouble()) + 1;
-            long clip_end_position = round((clip->Position() + clip->Duration()) * info.fps.ToDouble()) + 1;
-
+            long clip_end_position = round((clip->Position() + clip->Duration()) * info.fps.ToDouble());
             bool does_clip_intersect = (clip_start_position <= requested_frame && clip_end_position >= requested_frame);
 
             // Debug output

--- a/tests/FrameMapper.cpp
+++ b/tests/FrameMapper.cpp
@@ -188,6 +188,7 @@ TEST_CASE( "resample_audio_48000_to_41000", "[libopenshot][framemapper]" )
 	CHECK(map.GetFrame(1)->GetAudioSamplesCount() == 1470);
 	CHECK(map.GetFrame(2)->GetAudioSamplesCount() == 1470);
 	CHECK(map.GetFrame(50)->GetAudioSamplesCount() == 1470);
+	CHECK(map.info.video_length == 1558);
 
 	// Change mapping data
 	map.ChangeMapping(Fraction(25,1), PULLDOWN_NONE, 22050, 1, LAYOUT_MONO);
@@ -197,6 +198,7 @@ TEST_CASE( "resample_audio_48000_to_41000", "[libopenshot][framemapper]" )
 	CHECK(map.GetFrame(1)->GetAudioSamplesCount() == Approx(882).margin(10.0));
 	CHECK(map.GetFrame(2)->GetAudioSamplesCount() == Approx(882).margin(10.0));
 	CHECK(map.GetFrame(50)->GetAudioSamplesCount() == Approx(882).margin(10.0));
+    CHECK(map.info.video_length == 1299);
 
 	// Close mapper
 	map.Close();

--- a/tests/FrameMapper.cpp
+++ b/tests/FrameMapper.cpp
@@ -198,7 +198,7 @@ TEST_CASE( "resample_audio_48000_to_41000", "[libopenshot][framemapper]" )
 	CHECK(map.GetFrame(1)->GetAudioSamplesCount() == Approx(882).margin(10.0));
 	CHECK(map.GetFrame(2)->GetAudioSamplesCount() == Approx(882).margin(10.0));
 	CHECK(map.GetFrame(50)->GetAudioSamplesCount() == Approx(882).margin(10.0));
-    CHECK(map.info.video_length == 1299);
+	CHECK(map.info.video_length == 1299);
 
 	// Close mapper
 	map.Close();

--- a/tests/Timeline.cpp
+++ b/tests/Timeline.cpp
@@ -152,9 +152,9 @@ TEST_CASE( "two-track video", "[libopenshot][timeline]" )
 	f = t.GetFrame(24);
 
 	// Check image properties
-	CHECK((int)f->GetPixels(pixel_row)[pixel_index] == Approx(186).margin(5));
-	CHECK((int)f->GetPixels(pixel_row)[pixel_index + 1] == Approx(106).margin(5));
-	CHECK((int)f->GetPixels(pixel_row)[pixel_index + 2] == Approx(0).margin(5));
+	CHECK((int)f->GetPixels(pixel_row)[pixel_index] == Approx(176).margin(5));
+	CHECK((int)f->GetPixels(pixel_row)[pixel_index + 1] == Approx(0).margin(5));
+	CHECK((int)f->GetPixels(pixel_row)[pixel_index + 2] == Approx(186).margin(5));
 	CHECK((int)f->GetPixels(pixel_row)[pixel_index + 3] == Approx(255).margin(5));
 
 	f = t.GetFrame(5);
@@ -168,9 +168,9 @@ TEST_CASE( "two-track video", "[libopenshot][timeline]" )
 	f = t.GetFrame(25);
 
 	// Check image properties
-	CHECK((int)f->GetPixels(pixel_row)[pixel_index] == Approx(0).margin(5));
-	CHECK((int)f->GetPixels(pixel_row)[pixel_index + 1] == Approx(94).margin(5));
-	CHECK((int)f->GetPixels(pixel_row)[pixel_index + 2] == Approx(186).margin(5));
+	CHECK((int)f->GetPixels(pixel_row)[pixel_index] == Approx(20).margin(5));
+	CHECK((int)f->GetPixels(pixel_row)[pixel_index + 1] == Approx(190).margin(5));
+	CHECK((int)f->GetPixels(pixel_row)[pixel_index + 2] == Approx(0).margin(5));
 	CHECK((int)f->GetPixels(pixel_row)[pixel_index + 3] == Approx(255).margin(5));
 
 	f = t.GetFrame(4);


### PR DESCRIPTION
This is a large refactor of how FFmpegReader class utilizes the timestamps, to make better/quicker decisions about audio/video data.

**Improvements:**
- Improved PTS offset logic (to offset our streams so that at least one of them starts at position 0.0)
- Removed missing frame detection (not needed anymore)
- Use timestamps to reason about missing frames
- Fixed many async decoding issues (jumbled frames, missing beginning or ending frames)
- Much improved support for video/audio files with missing chunks/gaps (i.e. missing timestamps)
- Improved CheckWorkingFrames() method, to determine when working frames are ready to be finalized
- Improved FPS detection for invalid or missing FPS
- Fixed a crash (only reproducible on Windows), caused by 2 calls to AddImage() for the same frame

**What does all this mean?**
Video/audio files contain packets. Packets have timestamps to help us keep them in order, and know **when** to use them. However, packets must be decoded into actual usable data first (compressed bytes => image/audio data). Modern decoders (FFmpeg v3+) utilize threads to decode this data, and handle things asynchronously. This refactor mainly focuses on this async code, to dramatically improve the reliability, speed, and accuracy of the frame data we are accessing with FFmpegReader. OpenShot still had lots of legacy code, which expected the current packet to be processed synchronously from the decoder, causing all sorts of mis-timing events, or flat out missing frames. 

**Bottom line:** This PR will improve the performance for most users, prevent crashes for some users, and improve compatibility with many, many video files.