### PR TITLE
Improving Caption Effect (centering, background color, line spacing...)

### DIFF
--- a/src/effects/Caption.h
+++ b/src/effects/Caption.h
@@ -61,6 +61,7 @@ public:
 	Keyframe stroke_width;  ///< Width of text border / stroke
 	Keyframe font_size;     ///< Font size in points
 	Keyframe font_alpha;     ///< Font color alpha
+	Keyframe line_spacing;	 ///< Distance between lines (1.0 default / 100%)
 	Keyframe left;		 ///< Size of left bar
 	Keyframe top;		 ///< Size of top bar
 	Keyframe right;		 ///< Size of right bar


### PR DESCRIPTION
Improving **Caption Effect** with many bug fixes and improvements:

- background color now sticks to the text
- background border now scales correctly (at different resolutions)
- background padding now scales correctly
- stroke size now scales correctly
- margins are now defaulted to 15% on left/right
- text caption area now centers between available left/right margins
- background color can now be faded in and out, animated
- new property: line_spacing, a % from 1.0 (100%) to affect how much space are between lines
- Use each font's default lineSpacing, instead of a fixed distance between lines. This property can be adjusted with the new line_spacing keyframe.

![Caption-align-area-center](https://user-images.githubusercontent.com/5551883/186506781-ecc53a56-cfcf-4cb9-b497-9c95c24f7ce1.png)