### PR TITLE
Fixing transition end frame calculation

### DIFF
--- a/src/Timeline.cpp
+++ b/src/Timeline.cpp
@@ -528,7 +528,7 @@ std::shared_ptr<Frame> Timeline::apply_effects(std::shared_ptr<Frame> frame, int
 	{
 		// Does clip intersect the current requested time
 		long effect_start_position = round(effect->Position() * info.fps.ToDouble()) + 1;
-		long effect_end_position = round((effect->Position() + (effect->Duration())) * info.fps.ToDouble()) + 1;
+		long effect_end_position = round((effect->Position() + (effect->Duration())) * info.fps.ToDouble());
 
 		bool does_effect_intersect = (effect_start_position <= timeline_frame_number && effect_end_position >= timeline_frame_number && effect->Layer() == layer);
 


### PR DESCRIPTION
The timeline was calculating the right edge of transitions incorrectly (by adding an extra frame). This fixes that mis-calculation, and brings it inline with our clip intersection logic.