### PR TITLE
Detect video length (i.e. # of video frames) from Video Metadata

### DIFF
--- a/src/FFmpegReader.cpp
+++ b/src/FFmpegReader.cpp
@@ -822,7 +822,8 @@ void FFmpegReader::UpdateVideoInfo() {
 	}
 
 	// Get the # of video frames (if found in stream)
-	if (pStream->nb_frames > 0) {
+	// Only set this 1 time (this method can be called multiple times)
+	if (pStream->nb_frames > 0 && info.video_length <= 0) {
 		info.video_length = pStream->nb_frames;
 	}
 
@@ -837,6 +838,7 @@ void FFmpegReader::UpdateVideoInfo() {
 		is_duration_known = true;
 
 		// Calculate number of frames (if not already found in metadata)
+		// Only set this 1 time (this method can be called multiple times)
 		if (info.video_length <= 0) {
 			info.video_length = round(info.duration * info.fps.ToDouble());
 		}

--- a/src/FFmpegReader.cpp
+++ b/src/FFmpegReader.cpp
@@ -821,6 +821,11 @@ void FFmpegReader::UpdateVideoInfo() {
 		info.duration = float(info.file_size) / info.video_bit_rate;
 	}
 
+	// Get the # of video frames (if found in stream)
+	if (pStream->nb_frames > 0) {
+		info.video_length = pStream->nb_frames;
+	}
+
 	// No duration found in stream of file
 	if (info.duration <= 0.0f) {
 		// No duration is found in the video stream
@@ -831,8 +836,10 @@ void FFmpegReader::UpdateVideoInfo() {
 		// Yes, a duration was found
 		is_duration_known = true;
 
-		// Calculate number of frames
-		info.video_length = round(info.duration * info.fps.ToDouble());
+		// Calculate number of frames (if not already found in metadata)
+		if (info.video_length <= 0) {
+			info.video_length = round(info.duration * info.fps.ToDouble());
+		}
 	}
 
 	// Add video metadata (if any)


### PR DESCRIPTION
We were calculating the `video_length` from `duration * fps`. While this works pretty well, to approximate the # of frames encoded in a video, it is occasionally different by a small amount, and in my testing, the metadata `Stream->nb_frames` seems more accurate.

I've tested this with a bunch of test videos, and this seems to work great. :crossed_fingers: 