### PR TITLE
Frame Numbers: subtract the start value from the timeline frame number.

### DIFF
--- a/src/Clip.cpp
+++ b/src/Clip.cpp
@@ -1305,11 +1305,11 @@ void Clip::apply_keyframes(std::shared_ptr<Frame> frame, std::shared_ptr<QImage>
                     break;
 
                 case (FRAME_DISPLAY_TIMELINE):
-                    frame_number_str << (position * t->info.fps.ToFloat()) + frame->number;
+                    frame_number_str << round((Position() - Start()) * t->info.fps.ToFloat()) + frame->number;
                     break;
 
                 case (FRAME_DISPLAY_BOTH):
-                    frame_number_str << (position * t->info.fps.ToFloat()) + frame->number << " (" << frame->number << ")";
+                    frame_number_str << round((Position() - Start()) * t->info.fps.ToFloat()) + frame->number << " (" << frame->number << ")";
                     break;
             }
 


### PR DESCRIPTION
# Issue

1) If you put a clip at the beginning of the timeline
1) turn on `Frame Number: Both` in preferences
1) Cut the clip at frame 30. Keep both sides.
1) Use arrow keys to go back and forth across the cut.
    - See that the frame number goes from `30 (30)` to `61 (31)`

To solve this, we need to subtract the amount of time cut off the clip's beginning *then* add the `clip frame number` to the `frame at position 0`