### PR TITLE
Break out of cache loop when caching is disabled

### DIFF
--- a/src/Qt/VideoCacheThread.cpp
+++ b/src/Qt/VideoCacheThread.cpp
@@ -253,7 +253,7 @@ namespace openshot
                 }
 
                 // Check if thread has stopped OR should_break is triggered
-                if (!is_playing || should_break) {
+                if (!is_playing || should_break || !s->ENABLE_PLAYBACK_CACHING) {
                     should_break = false;
                     break;
                 }


### PR DESCRIPTION
Break out of cache loop when caching is temporarily disabled (i.e. when transforming, editing keyframes, rotating, moving, resizing, etc...). This creates a much smoother editing workflow, and removes an initial delay from the transform tool caused by the cache loop still running.