### PR TITLE
Removing cache clearing from Timeline::Clear method - unneeded

### DIFF
--- a/src/Timeline.cpp
+++ b/src/Timeline.cpp
@@ -779,9 +779,6 @@ void Timeline::Clear()
 	// Get lock (prevent getting frames while this happens)
 	const std::lock_guard<std::recursive_mutex> guard(getFrameMutex);
 
-	// Clear all cache (deep clear, including nested Readers)
-	ClearAllCache(true);
-
 	// Close all open clips
 	for (auto clip : clips)
 	{


### PR DESCRIPTION
This tends to be unstable and is causing crashes, not to mention we already Clear all cache in the destructor, so this is simply not needed.