### PR TITLE
Support many new image formats with our FFmpegReader

### DIFF
--- a/src/FFmpegReader.cpp
+++ b/src/FFmpegReader.cpp
@@ -821,10 +821,10 @@ void FFmpegReader::UpdateVideoInfo() {
 
 	// Certain "image" formats do not have a valid duration
 	if (info.duration <= 0.0f && pStream->duration == AV_NOPTS_VALUE && pFormatCtx->duration == AV_NOPTS_VALUE) {
-	    // Force an "image" duration
-        info.duration = 60 * 60 * 1;  // 1 hour duration
-        info.video_length = 1;
-        info.has_single_image = true;
+		// Force an "image" duration
+		info.duration = 60 * 60 * 1;  // 1 hour duration
+		info.video_length = 1;
+		info.has_single_image = true;
 	}
 
 	// Get the # of video frames (if found in stream)

--- a/src/FFmpegReader.cpp
+++ b/src/FFmpegReader.cpp
@@ -1857,17 +1857,17 @@ void FFmpegReader::Seek(int64_t requested_frame) {
 
 // Get the PTS for the current video packet
 int64_t FFmpegReader::GetPacketPTS() {
-    if (packet) {
-        int64_t current_pts = packet->pts;
-        if (current_pts == AV_NOPTS_VALUE && packet->dts != AV_NOPTS_VALUE)
-            current_pts = packet->dts;
+	if (packet) {
+		int64_t current_pts = packet->pts;
+		if (current_pts == AV_NOPTS_VALUE && packet->dts != AV_NOPTS_VALUE)
+			current_pts = packet->dts;
 
-        // Return adjusted PTS
-        return current_pts;
-    } else {
-        // No packet, return NO PTS
-        return AV_NOPTS_VALUE;
-    }
+		// Return adjusted PTS
+		return current_pts;
+	} else {
+		// No packet, return NO PTS
+		return AV_NOPTS_VALUE;
+	}
 }
 
 // Update PTS Offset (if any)


### PR DESCRIPTION
Support many new image formats with our FFmpegReader, by safely protecting empty packets in `GetPacketPTS`, and generating a duration and correctly setting the `has_single_image` property.

Essentially, this is a 1 frame video, but we want OpenShot to pretend it's a 60 minute long image.