### PR TITLE
Fixing crash related to Undo

### DIFF
--- a/src/Clip.cpp
+++ b/src/Clip.cpp
@@ -270,8 +270,8 @@ void Clip::Reader(ReaderBase* new_reader)
 {
     // Delete previously allocated reader (if not related to new reader)
     // FrameMappers that point to the same allocated reader are ignored
-    if (reader && reader == allocated_reader) {
-        bool is_same_reader = false;
+    bool is_same_reader = false;
+    if (new_reader && allocated_reader) {
         if (new_reader->Name() == "FrameMapper") {
             // Determine if FrameMapper is pointing at the same allocated ready
             FrameMapper* clip_mapped_reader = (FrameMapper*) new_reader;
@@ -279,13 +279,14 @@ void Clip::Reader(ReaderBase* new_reader)
                 is_same_reader = true;
             }
         }
-        // Clear existing allocated reader (if different)
-        if (!is_same_reader) {
-            reader->Close();
-            delete reader;
-            reader = NULL;
-            allocated_reader = NULL;
-        }
+    }
+    // Clear existing allocated reader (if different)
+    if (allocated_reader && !is_same_reader) {
+        reader->Close();
+        allocated_reader->Close();
+        delete allocated_reader;
+        reader = NULL;
+        allocated_reader = NULL;
     }
 
 	// set reader pointer

--- a/src/Timeline.cpp
+++ b/src/Timeline.cpp
@@ -1526,6 +1526,7 @@ void Timeline::apply_json_to_effects(Json::Value change, EffectBase* existing_ef
 
 // Apply JSON diff to timeline properties
 void Timeline::apply_json_to_timeline(Json::Value change) {
+    bool cache_dirty = true;
 
 	// Get key and type of change
 	std::string change_type = change["type"].asString();
@@ -1533,9 +1534,6 @@ void Timeline::apply_json_to_timeline(Json::Value change) {
 	std::string sub_key = "";
 	if (change["key"].size() >= 2)
 		sub_key = change["key"][(uint)1].asString();
-
-	// Clear entire cache
-	ClearAllCache();
 
 	// Determine type of change operation
 	if (change_type == "insert" || change_type == "update") {
@@ -1558,6 +1556,9 @@ void Timeline::apply_json_to_timeline(Json::Value change) {
 			// Update duration of timeline
 			info.duration = change["value"].asDouble();
 			info.video_length = info.fps.ToFloat() * info.duration;
+
+			// We don't want to clear cache for duration adjustments
+            cache_dirty = false;
 		}
 		else if (root_key == "width") {
 			// Set width
@@ -1645,6 +1646,10 @@ void Timeline::apply_json_to_timeline(Json::Value change) {
 
 	}
 
+	if (cache_dirty) {
+        // Clear entire cache
+        ClearAllCache();
+	}
 }
 
 // Clear all caches

--- a/src/Timeline.cpp
+++ b/src/Timeline.cpp
@@ -343,9 +343,9 @@ void Timeline::AddClip(Clip* clip)
 
 	// All clips should be converted to the frame rate of this timeline
 	if (auto_map_clips) {
-        // Apply framemapper (or update existing framemapper)
-        apply_mapper_to_clip(clip);
-    }
+		// Apply framemapper (or update existing framemapper)
+		apply_mapper_to_clip(clip);
+	}
 
 	// Add clip to list
 	clips.push_back(clip);
@@ -856,8 +856,8 @@ void Timeline::Close()
 {
 	ZmqLogger::Instance()->AppendDebugMethod("Timeline::Close");
 
-    // Get lock (prevent getting frames while this happens)
-    const std::lock_guard<std::recursive_mutex> guard(getFrameMutex);
+	// Get lock (prevent getting frames while this happens)
+	const std::lock_guard<std::recursive_mutex> guard(getFrameMutex);
 
 	// Close all open clips
 	for (auto clip : clips)
@@ -1151,8 +1151,8 @@ Json::Value Timeline::JsonValue() const {
 // Load JSON string into this object
 void Timeline::SetJson(const std::string value) {
 
-    // Get lock (prevent getting frames while this happens)
-    const std::lock_guard<std::recursive_mutex> lock(getFrameMutex);
+	// Get lock (prevent getting frames while this happens)
+	const std::lock_guard<std::recursive_mutex> lock(getFrameMutex);
 
 	// Parse JSON string into JSON objects
 	try
@@ -1394,8 +1394,8 @@ void Timeline::apply_json_to_clips(Json::Value change) {
 
 			// Apply framemapper (or update existing framemapper)
 			if (auto_map_clips) {
-                apply_mapper_to_clip(existing_clip);
-            }
+				apply_mapper_to_clip(existing_clip);
+			}
 		}
 
 	} else if (change_type == "delete") {
@@ -1526,7 +1526,7 @@ void Timeline::apply_json_to_effects(Json::Value change, EffectBase* existing_ef
 
 // Apply JSON diff to timeline properties
 void Timeline::apply_json_to_timeline(Json::Value change) {
-    bool cache_dirty = true;
+	bool cache_dirty = true;
 
 	// Get key and type of change
 	std::string change_type = change["type"].asString();
@@ -1558,7 +1558,7 @@ void Timeline::apply_json_to_timeline(Json::Value change) {
 			info.video_length = info.fps.ToFloat() * info.duration;
 
 			// We don't want to clear cache for duration adjustments
-            cache_dirty = false;
+			cache_dirty = false;
 		}
 		else if (root_key == "width") {
 			// Set width
@@ -1647,8 +1647,8 @@ void Timeline::apply_json_to_timeline(Json::Value change) {
 	}
 
 	if (cache_dirty) {
-        // Clear entire cache
-        ClearAllCache();
+	    // Clear entire cache
+	    ClearAllCache();
 	}
 }
 

--- a/src/Timeline.cpp
+++ b/src/Timeline.cpp
@@ -857,6 +857,9 @@ void Timeline::Close()
 {
 	ZmqLogger::Instance()->AppendDebugMethod("Timeline::Close");
 
+    // Get lock (prevent getting frames while this happens)
+    const std::lock_guard<std::recursive_mutex> guard(getFrameMutex);
+
 	// Close all open clips
 	for (auto clip : clips)
 	{
@@ -1148,6 +1151,9 @@ Json::Value Timeline::JsonValue() const {
 
 // Load JSON string into this object
 void Timeline::SetJson(const std::string value) {
+
+    // Get lock (prevent getting frames while this happens)
+    const std::lock_guard<std::recursive_mutex> lock(getFrameMutex);
 
 	// Parse JSON string into JSON objects
 	try

--- a/src/Timeline.cpp
+++ b/src/Timeline.cpp
@@ -342,9 +342,10 @@ void Timeline::AddClip(Clip* clip)
 		clip->Reader()->GetCache()->Clear();
 
 	// All clips should be converted to the frame rate of this timeline
-	if (auto_map_clips)
-		// Apply framemapper (or update existing framemapper)
-		apply_mapper_to_clip(clip);
+	if (auto_map_clips) {
+        // Apply framemapper (or update existing framemapper)
+        apply_mapper_to_clip(clip);
+    }
 
 	// Add clip to list
 	clips.push_back(clip);
@@ -821,7 +822,6 @@ void Timeline::Clear()
 		bool allocated = allocated_clips.count(clip);
 		if (allocated) {
 			delete clip;
-			clip = NULL;
 		}
 	}
 	// Clear all clips
@@ -835,7 +835,6 @@ void Timeline::Clear()
 		bool allocated = allocated_effects.count(effect);
 		if (allocated) {
 			delete effect;
-			effect = NULL;
 		}
 	}
 	// Clear all effects
@@ -1372,10 +1371,9 @@ void Timeline::apply_json_to_clips(Json::Value change) {
 
 		// Set properties of clip from JSON
 		clip->SetJsonValue(change["value"]);
-		AddClip(clip); // Add clip to timeline
 
-		// Apply framemapper (or update existing framemapper)
-		apply_mapper_to_clip(clip);
+        // Add clip to timeline
+		AddClip(clip);
 
 	} else if (change_type == "update") {
 
@@ -1395,7 +1393,9 @@ void Timeline::apply_json_to_clips(Json::Value change) {
 			existing_clip->SetJsonValue(change["value"]);
 
 			// Apply framemapper (or update existing framemapper)
-			apply_mapper_to_clip(existing_clip);
+			if (auto_map_clips) {
+                apply_mapper_to_clip(existing_clip);
+            }
 		}
 
 	} else if (change_type == "delete") {

--- a/src/Timeline.cpp
+++ b/src/Timeline.cpp
@@ -1372,7 +1372,7 @@ void Timeline::apply_json_to_clips(Json::Value change) {
 		// Set properties of clip from JSON
 		clip->SetJsonValue(change["value"]);
 
-        // Add clip to timeline
+		// Add clip to timeline
 		AddClip(clip);
 
 	} else if (change_type == "update") {

--- a/tests/Clip.cpp
+++ b/tests/Clip.cpp
@@ -337,3 +337,35 @@ TEST_CASE( "access frames past reader length", "[libopenshot][clip]" )
     CHECK(frame->GetAudioSamples(0)[600] == Approx(0.0).margin(0.00001));
     CHECK(frame->GetAudioSamples(0)[1200] == Approx(0.0).margin(0.00001));
 }
+
+TEST_CASE( "setting and clobbering readers", "[libopenshot][clip]" )
+{
+    // Create a dummy reader #1, with a pre-existing cache
+    openshot::DummyReader r1(openshot::Fraction(24, 1), 1920, 1080, 44100, 2, 1.0);
+    r1.Open(); // Open the reader
+
+    // Create a dummy reader #2, with a pre-existing cache
+    openshot::DummyReader r2(openshot::Fraction(30, 1), 1920, 1080, 44100, 2, 1.0);
+    r2.Open(); // Open the reader
+
+    // Create a clip with constructor (and an allocated internal reader A)
+    std::stringstream path;
+    path << TEST_MEDIA_PATH << "piano.wav";
+    Clip c1(path.str());
+    c1.Open();
+
+    // Clobber allocated reader A with reader #1
+    c1.Reader(&r1);
+
+    // Clobber reader #1 with reader #2
+    c1.Reader(&r2);
+
+    // Clobber reader #2 with SetJson (allocated reader B)
+    c1.SetJson("{\"reader\":{\"acodec\":\"raw\",\"audio_bit_rate\":0,\"audio_stream_index\":-1,\"audio_timebase\":{\"den\":1,\"num\":1},\"channel_layout\":4,\"channels\":2,\"display_ratio\":{\"den\":9,\"num\":16},\"duration\":1.0,\"file_size\":\"8294400\",\"fps\":{\"den\":1,\"num\":30},\"has_audio\":false,\"has_single_image\":false,\"has_video\":true,\"height\":1080,\"interlaced_frame\":false,\"metadata\":{},\"pixel_format\":-1,\"pixel_ratio\":{\"den\":1,\"num\":1},\"sample_rate\":44100,\"top_field_first\":true,\"type\":\"DummyReader\",\"vcodec\":\"raw\",\"video_bit_rate\":0,\"video_length\":\"30\",\"video_stream_index\":-1,\"video_timebase\":{\"den\":30,\"num\":1},\"width\":1920}}");
+
+    // Clobber allocated reader B with reader 2
+    c1.Reader(&r2);
+
+    // Clobber reader 2 with reader 1
+    c1.Reader(&r1);
+}

--- a/tests/Timeline.cpp
+++ b/tests/Timeline.cpp
@@ -607,7 +607,7 @@ TEST_CASE( "GetMaxFrame and GetMaxTime", "[libopenshot][timeline]" )
 	std::stringstream path1;
 	path1 << TEST_MEDIA_PATH << "interlaced.png";
 	Clip clip1(path1.str());
-    clip1.Id("C1");
+	clip1.Id("C1");
 	clip1.Layer(1);
 	clip1.Position(50);
 	clip1.End(45);
@@ -643,21 +643,21 @@ TEST_CASE( "GetMaxFrame and GetMaxTime", "[libopenshot][timeline]" )
 	CHECK(t.GetMaxFrame() == 115 * 30 + 1);
 	CHECK(t.GetMaxTime() == Approx(115.0).margin(0.001));
 
-    // Update Clip's basic properties with JSON Diff
-    std::stringstream json_change1;
-    json_change1 << "[{\"type\":\"update\",\"key\":[\"clips\",{\"id\":\"C2\"}],\"value\":{\"id\":\"C2\",\"layer\":4000000,\"position\":0.0,\"start\":0,\"end\":10},\"partial\":false}]";
-    t.ApplyJsonDiff(json_change1.str());
+	// Update Clip's basic properties with JSON Diff
+	std::stringstream json_change1;
+	json_change1 << "[{\"type\":\"update\",\"key\":[\"clips\",{\"id\":\"C2\"}],\"value\":{\"id\":\"C2\",\"layer\":4000000,\"position\":0.0,\"start\":0,\"end\":10},\"partial\":false}]";
+	t.ApplyJsonDiff(json_change1.str());
 
-    CHECK(t.GetMaxFrame() == 10 * 30 + 1);
-    CHECK(t.GetMaxTime() == Approx(10.0).margin(0.001));
+	CHECK(t.GetMaxFrame() == 10 * 30 + 1);
+	CHECK(t.GetMaxTime() == Approx(10.0).margin(0.001));
 
-    // Insert NEW Clip with JSON Diff
-    std::stringstream json_change2;
-    json_change2 << "[{\"type\":\"insert\",\"key\":[\"clips\"],\"value\":{\"id\":\"C3\",\"layer\":4000000,\"position\":10.0,\"start\":0,\"end\":10,\"reader\":{\"acodec\":\"\",\"audio_bit_rate\":0,\"audio_stream_index\":-1,\"audio_timebase\":{\"den\":1,\"num\":1},\"channel_layout\":4,\"channels\":0,\"display_ratio\":{\"den\":1,\"num\":1},\"duration\":3600.0,\"file_size\":\"160000\",\"fps\":{\"den\":1,\"num\":30},\"has_audio\":false,\"has_single_image\":true,\"has_video\":true,\"height\":200,\"interlaced_frame\":false,\"metadata\":{},\"path\":\"" << path1.str() << "\",\"pixel_format\":-1,\"pixel_ratio\":{\"den\":1,\"num\":1},\"sample_rate\":0,\"top_field_first\":true,\"type\":\"QtImageReader\",\"vcodec\":\"\",\"video_bit_rate\":0,\"video_length\":\"108000\",\"video_stream_index\":-1,\"video_timebase\":{\"den\":30,\"num\":1},\"width\":200}},\"partial\":false}]";
-    t.ApplyJsonDiff(json_change2.str());
+	// Insert NEW Clip with JSON Diff
+	std::stringstream json_change2;
+	json_change2 << "[{\"type\":\"insert\",\"key\":[\"clips\"],\"value\":{\"id\":\"C3\",\"layer\":4000000,\"position\":10.0,\"start\":0,\"end\":10,\"reader\":{\"acodec\":\"\",\"audio_bit_rate\":0,\"audio_stream_index\":-1,\"audio_timebase\":{\"den\":1,\"num\":1},\"channel_layout\":4,\"channels\":0,\"display_ratio\":{\"den\":1,\"num\":1},\"duration\":3600.0,\"file_size\":\"160000\",\"fps\":{\"den\":1,\"num\":30},\"has_audio\":false,\"has_single_image\":true,\"has_video\":true,\"height\":200,\"interlaced_frame\":false,\"metadata\":{},\"path\":\"" << path1.str() << "\",\"pixel_format\":-1,\"pixel_ratio\":{\"den\":1,\"num\":1},\"sample_rate\":0,\"top_field_first\":true,\"type\":\"QtImageReader\",\"vcodec\":\"\",\"video_bit_rate\":0,\"video_length\":\"108000\",\"video_stream_index\":-1,\"video_timebase\":{\"den\":30,\"num\":1},\"width\":200}},\"partial\":false}]";
+	t.ApplyJsonDiff(json_change2.str());
 
-    CHECK(t.GetMaxFrame() == 20 * 30 + 1);
-    CHECK(t.GetMaxTime() == Approx(20.0).margin(0.001));
+	CHECK(t.GetMaxFrame() == 20 * 30 + 1);
+	CHECK(t.GetMaxTime() == Approx(20.0).margin(0.001));
 }
 
 TEST_CASE( "Multi-threaded Timeline GetFrame", "[libopenshot][timeline]" )
@@ -745,55 +745,55 @@ TEST_CASE( "Multi-threaded Timeline Add/Remove Clip", "[libopenshot][timeline]" 
 
 TEST_CASE( "ApplyJSONDiff and FrameMappers", "[libopenshot][timeline]" )
 {
-    // Create a timeline
-    Timeline t(640, 480, Fraction(60, 1), 44100, 2, LAYOUT_STEREO);
-    t.Open();
+	// Create a timeline
+	Timeline t(640, 480, Fraction(60, 1), 44100, 2, LAYOUT_STEREO);
+	t.Open();
 
-    // Auto create FrameMappers for each clip
-    t.AutoMapClips(true);
+	// Auto create FrameMappers for each clip
+	t.AutoMapClips(true);
 
-    // Add clip
-    std::stringstream path1;
-    path1 << TEST_MEDIA_PATH << "interlaced.png";
-    Clip clip1(path1.str());
-    clip1.Id("ABC");
-    clip1.Layer(1);
-    clip1.Position(0);
-    clip1.End(10);
+	// Add clip
+	std::stringstream path1;
+	path1 << TEST_MEDIA_PATH << "interlaced.png";
+	Clip clip1(path1.str());
+	clip1.Id("ABC");
+	clip1.Layer(1);
+	clip1.Position(0);
+	clip1.End(10);
 
-    // Verify clip reader type (not wrapped yet, because we have not added clip to timeline)
-    CHECK(clip1.Reader()->Name() == "QtImageReader");
+	// Verify clip reader type (not wrapped yet, because we have not added clip to timeline)
+	CHECK(clip1.Reader()->Name() == "QtImageReader");
 
-    t.AddClip(&clip1);
+	t.AddClip(&clip1);
 
-    // Verify clip was wrapped in FrameMapper
-    CHECK(clip1.Reader()->Name() == "FrameMapper");
+	// Verify clip was wrapped in FrameMapper
+	CHECK(clip1.Reader()->Name() == "FrameMapper");
 
-    // Update Clip's basic properties with JSON Diff (i.e. no reader JSON)
-    std::stringstream json_change1;
-    json_change1 << "[{\"type\":\"update\",\"key\":[\"clips\",{\"id\":\"" << clip1.Id() << "\"}],\"value\":{\"id\":\"" << clip1.Id() << "\",\"layer\":4000000,\"position\":14.7,\"start\":0,\"end\":10},\"partial\":false}]";
-    t.ApplyJsonDiff(json_change1.str());
+	// Update Clip's basic properties with JSON Diff (i.e. no reader JSON)
+	std::stringstream json_change1;
+	json_change1 << "[{\"type\":\"update\",\"key\":[\"clips\",{\"id\":\"" << clip1.Id() << "\"}],\"value\":{\"id\":\"" << clip1.Id() << "\",\"layer\":4000000,\"position\":14.7,\"start\":0,\"end\":10},\"partial\":false}]";
+	t.ApplyJsonDiff(json_change1.str());
 
-    // Verify clip is still wrapped in FrameMapper
-    CHECK(clip1.Reader()->Name() == "FrameMapper");
+	// Verify clip is still wrapped in FrameMapper
+	CHECK(clip1.Reader()->Name() == "FrameMapper");
 
-    // Update clip's reader back to a QtImageReader
-    std::stringstream json_change2;
-    json_change2 << "[{\"type\":\"update\",\"key\":[\"clips\",{\"id\":\"" << clip1.Id() << "\"}],\"value\":{\"id\":\"" << clip1.Id() << "\",\"reader\":{\"acodec\":\"\",\"audio_bit_rate\":0,\"audio_stream_index\":-1,\"audio_timebase\":{\"den\":1,\"num\":1},\"channel_layout\":4,\"channels\":0,\"display_ratio\":{\"den\":1,\"num\":1},\"duration\":3600.0,\"file_size\":\"160000\",\"fps\":{\"den\":1,\"num\":30},\"has_audio\":false,\"has_single_image\":true,\"has_video\":true,\"height\":200,\"interlaced_frame\":false,\"metadata\":{},\"path\":\"" << path1.str() << "\",\"pixel_format\":-1,\"pixel_ratio\":{\"den\":1,\"num\":1},\"sample_rate\":0,\"top_field_first\":true,\"type\":\"QtImageReader\",\"vcodec\":\"\",\"video_bit_rate\":0,\"video_length\":\"108000\",\"video_stream_index\":-1,\"video_timebase\":{\"den\":30,\"num\":1},\"width\":200},\"position\":14.7,\"start\":0,\"end\":10},\"partial\":false}]";
-    t.ApplyJsonDiff(json_change2.str());
+	// Update clip's reader back to a QtImageReader
+	std::stringstream json_change2;
+	json_change2 << "[{\"type\":\"update\",\"key\":[\"clips\",{\"id\":\"" << clip1.Id() << "\"}],\"value\":{\"id\":\"" << clip1.Id() << "\",\"reader\":{\"acodec\":\"\",\"audio_bit_rate\":0,\"audio_stream_index\":-1,\"audio_timebase\":{\"den\":1,\"num\":1},\"channel_layout\":4,\"channels\":0,\"display_ratio\":{\"den\":1,\"num\":1},\"duration\":3600.0,\"file_size\":\"160000\",\"fps\":{\"den\":1,\"num\":30},\"has_audio\":false,\"has_single_image\":true,\"has_video\":true,\"height\":200,\"interlaced_frame\":false,\"metadata\":{},\"path\":\"" << path1.str() << "\",\"pixel_format\":-1,\"pixel_ratio\":{\"den\":1,\"num\":1},\"sample_rate\":0,\"top_field_first\":true,\"type\":\"QtImageReader\",\"vcodec\":\"\",\"video_bit_rate\":0,\"video_length\":\"108000\",\"video_stream_index\":-1,\"video_timebase\":{\"den\":30,\"num\":1},\"width\":200},\"position\":14.7,\"start\":0,\"end\":10},\"partial\":false}]";
+	t.ApplyJsonDiff(json_change2.str());
 
-    // Verify clip reader type
-    CHECK(clip1.Reader()->Name() == "FrameMapper");
+	// Verify clip reader type
+	CHECK(clip1.Reader()->Name() == "FrameMapper");
 
-    // Disable Auto FrameMappers for each clip
-    t.AutoMapClips(false);
+	// Disable Auto FrameMappers for each clip
+	t.AutoMapClips(false);
 
-    // Update clip's reader back to a QtImageReader
-    std::stringstream json_change3;
-    json_change3 << "[{\"type\":\"update\",\"key\":[\"clips\",{\"id\":\"" << clip1.Id() << "\"}],\"value\":{\"id\":\"" << clip1.Id() << "\",\"reader\":{\"acodec\":\"\",\"audio_bit_rate\":0,\"audio_stream_index\":-1,\"audio_timebase\":{\"den\":1,\"num\":1},\"channel_layout\":4,\"channels\":0,\"display_ratio\":{\"den\":1,\"num\":1},\"duration\":3600.0,\"file_size\":\"160000\",\"fps\":{\"den\":1,\"num\":30},\"has_audio\":false,\"has_single_image\":true,\"has_video\":true,\"height\":200,\"interlaced_frame\":false,\"metadata\":{},\"path\":\"" << path1.str() << "\",\"pixel_format\":-1,\"pixel_ratio\":{\"den\":1,\"num\":1},\"sample_rate\":0,\"top_field_first\":true,\"type\":\"QtImageReader\",\"vcodec\":\"\",\"video_bit_rate\":0,\"video_length\":\"108000\",\"video_stream_index\":-1,\"video_timebase\":{\"den\":30,\"num\":1},\"width\":200},\"position\":14.7,\"start\":0,\"end\":10},\"partial\":false}]";
-    t.ApplyJsonDiff(json_change3.str());
+	// Update clip's reader back to a QtImageReader
+	std::stringstream json_change3;
+	json_change3 << "[{\"type\":\"update\",\"key\":[\"clips\",{\"id\":\"" << clip1.Id() << "\"}],\"value\":{\"id\":\"" << clip1.Id() << "\",\"reader\":{\"acodec\":\"\",\"audio_bit_rate\":0,\"audio_stream_index\":-1,\"audio_timebase\":{\"den\":1,\"num\":1},\"channel_layout\":4,\"channels\":0,\"display_ratio\":{\"den\":1,\"num\":1},\"duration\":3600.0,\"file_size\":\"160000\",\"fps\":{\"den\":1,\"num\":30},\"has_audio\":false,\"has_single_image\":true,\"has_video\":true,\"height\":200,\"interlaced_frame\":false,\"metadata\":{},\"path\":\"" << path1.str() << "\",\"pixel_format\":-1,\"pixel_ratio\":{\"den\":1,\"num\":1},\"sample_rate\":0,\"top_field_first\":true,\"type\":\"QtImageReader\",\"vcodec\":\"\",\"video_bit_rate\":0,\"video_length\":\"108000\",\"video_stream_index\":-1,\"video_timebase\":{\"den\":30,\"num\":1},\"width\":200},\"position\":14.7,\"start\":0,\"end\":10},\"partial\":false}]";
+	t.ApplyJsonDiff(json_change3.str());
 
-    // Verify clip reader type
-    CHECK(clip1.Reader()->Name() == "QtImageReader");
+	// Verify clip reader type
+	CHECK(clip1.Reader()->Name() == "QtImageReader");
 
 }

--- a/tests/Timeline.cpp
+++ b/tests/Timeline.cpp
@@ -717,10 +717,10 @@ TEST_CASE( "Multi-threaded Timeline Add/Remove Clip", "[libopenshot][timeline]" 
 			Clip* clip_video = new Clip(path.str());
 			clip_video->Layer(omp_get_thread_num());
 
-			 // Add clip to timeline
- 			t->AddClip(clip_video);
+			// Add clip to timeline
+			t->AddClip(clip_video);
 
-			 // Loop through all timeline frames - each new clip makes the timeline longer
+			// Loop through all timeline frames - each new clip makes the timeline longer
 			for (long int frame = 10; frame >= 1; frame--) {
 				std::shared_ptr<Frame> f = t->GetFrame(frame);
 				t->GetMaxFrame();

--- a/tests/Timeline.cpp
+++ b/tests/Timeline.cpp
@@ -607,6 +607,7 @@ TEST_CASE( "GetMaxFrame and GetMaxTime", "[libopenshot][timeline]" )
 	std::stringstream path1;
 	path1 << TEST_MEDIA_PATH << "interlaced.png";
 	Clip clip1(path1.str());
+    clip1.Id("C1");
 	clip1.Layer(1);
 	clip1.Position(50);
 	clip1.End(45);
@@ -616,6 +617,7 @@ TEST_CASE( "GetMaxFrame and GetMaxTime", "[libopenshot][timeline]" )
 	CHECK(t.GetMaxFrame() == 95 * 30 + 1);
 
 	Clip clip2(path1.str());
+	clip2.Id("C2");
 	clip2.Layer(2);
 	clip2.Position(0);
 	clip2.End(55);
@@ -640,6 +642,22 @@ TEST_CASE( "GetMaxFrame and GetMaxTime", "[libopenshot][timeline]" )
 	t.RemoveClip(&clip1);
 	CHECK(t.GetMaxFrame() == 115 * 30 + 1);
 	CHECK(t.GetMaxTime() == Approx(115.0).margin(0.001));
+
+    // Update Clip's basic properties with JSON Diff
+    std::stringstream json_change1;
+    json_change1 << "[{\"type\":\"update\",\"key\":[\"clips\",{\"id\":\"C2\"}],\"value\":{\"id\":\"C2\",\"layer\":4000000,\"position\":0.0,\"start\":0,\"end\":10},\"partial\":false}]";
+    t.ApplyJsonDiff(json_change1.str());
+
+    CHECK(t.GetMaxFrame() == 10 * 30 + 1);
+    CHECK(t.GetMaxTime() == Approx(10.0).margin(0.001));
+
+    // Insert NEW Clip with JSON Diff
+    std::stringstream json_change2;
+    json_change2 << "[{\"type\":\"insert\",\"key\":[\"clips\"],\"value\":{\"id\":\"C3\",\"layer\":4000000,\"position\":10.0,\"start\":0,\"end\":10,\"reader\":{\"acodec\":\"\",\"audio_bit_rate\":0,\"audio_stream_index\":-1,\"audio_timebase\":{\"den\":1,\"num\":1},\"channel_layout\":4,\"channels\":0,\"display_ratio\":{\"den\":1,\"num\":1},\"duration\":3600.0,\"file_size\":\"160000\",\"fps\":{\"den\":1,\"num\":30},\"has_audio\":false,\"has_single_image\":true,\"has_video\":true,\"height\":200,\"interlaced_frame\":false,\"metadata\":{},\"path\":\"" << path1.str() << "\",\"pixel_format\":-1,\"pixel_ratio\":{\"den\":1,\"num\":1},\"sample_rate\":0,\"top_field_first\":true,\"type\":\"QtImageReader\",\"vcodec\":\"\",\"video_bit_rate\":0,\"video_length\":\"108000\",\"video_stream_index\":-1,\"video_timebase\":{\"den\":30,\"num\":1},\"width\":200}},\"partial\":false}]";
+    t.ApplyJsonDiff(json_change2.str());
+
+    CHECK(t.GetMaxFrame() == 20 * 30 + 1);
+    CHECK(t.GetMaxTime() == Approx(20.0).margin(0.001));
 }
 
 TEST_CASE( "Multi-threaded Timeline GetFrame", "[libopenshot][timeline]" )


### PR DESCRIPTION
Related to https://github.com/OpenShot/openshot-qt/pull/4965

- New unit tests to verify Readers and FrameMappers are correctly cleaned up
- Some refactoring to ensure no double free on Reader cleanup