### PR TITLE
Add fallback for AVFrame.pkt_dts (certain codecs fail to find a valid video PTS)

### DIFF
--- a/src/FFmpegReader.cpp
+++ b/src/FFmpegReader.cpp
@@ -1180,6 +1180,9 @@ bool FFmpegReader::GetAVFrame() {
 					// This is the current decoded frame (and should be the pts used) for
 					// processing this data
 					video_pts = next_frame->pts;
+				} else if (next_frame->pkt_dts != AV_NOPTS_VALUE) {
+					// Some videos only set this timestamp (fallback)
+					video_pts = next_frame->pkt_dts;
 				}
 
 				// break out of loop after each successful image returned


### PR DESCRIPTION
This is a regression caused by recent PTS changes, and apparently certain video codecs, such as AV1, do not correctly set the AVFrame->pts field, and instead rely on the AVFrame->pkt_dts. Strange, but the fix is a simple fallback.