### PR TITLE
AudioWaveformData: Adding protection from divide by zero + more unit tests

### DIFF
--- a/src/AudioWaveformer.cpp
+++ b/src/AudioWaveformer.cpp
@@ -47,9 +47,19 @@ AudioWaveformData AudioWaveformer::ExtractSamples(int channel, int num_per_secon
         int total_samples = num_per_second * (reader->info.duration + 1.0);
         int extracted_index = 0;
 
+        // Force output to zero elements for non-audio readers
+        if (!reader->info.has_audio) {
+            total_samples = 0;
+        }
+
         // Resize and clear audio buffers
         data.resize(total_samples);
         data.zero(total_samples);
+
+        // Bail out, if no samples needed
+        if (total_samples == 0 || reader->info.channels == 0) {
+            return data;
+        }
 
         // Loop through all frames
         int sample_index = 0;

--- a/src/AudioWaveformer.h
+++ b/src/AudioWaveformer.h
@@ -39,10 +39,8 @@ namespace openshot {
 
         /// Zero out # of values in both datasets
         void zero(int total_samples) {
-            for (auto s = 0; s < total_samples; s++) {
-                max_samples[s] = 0.0;
-                rms_samples[s] = 0.0;
-            }
+            std::fill(max_samples.begin(), max_samples.end(), 0);
+            std::fill(rms_samples.begin(), rms_samples.end(), 0);
         }
 
         /// Scale # of values by some factor


### PR DESCRIPTION
AudioWaveformData: 

- Adding protection from divide by zero from no audio
- Additional unit tests 
- Faster zero() function

Related to https://github.com/OpenShot/libopenshot/pull/868