### PR TITLE
Refactor FFmpegReader GetAVFrame (for AV1 & async decoding)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,62 +9,6 @@ stages:
 variables:
   GIT_LOG_FORMAT: "- %h %ad %s [%aN]"
 
-linux-builder:
-  stage: build-libopenshot
-  artifacts:
-    expire_in: 6 months
-    paths:
-    - build/install-x64/*
-  script:
-    - "curl -O -J -L --header PRIVATE-TOKEN:$ACCESS_TOKEN http://gitlab.openshot.org/OpenShot/libopenshot-audio/-/jobs/artifacts/$CI_COMMIT_REF_NAME/download?job=linux-builder"
-    - if [ ! -f artifacts.zip ]; then
-    -    "curl -O -J -L --header PRIVATE-TOKEN:$ACCESS_TOKEN http://gitlab.openshot.org/OpenShot/libopenshot-audio/-/jobs/artifacts/develop/download?job=linux-builder"
-    - fi
-    - unzip artifacts.zip
-    - export LIBOPENSHOT_AUDIO_DIR=$CI_PROJECT_DIR/build/install-x64
-    - mkdir -p build; cd build;
-    - cmake -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -D"CMAKE_INSTALL_PREFIX:PATH=$CI_PROJECT_DIR/build/install-x64" -D"PYTHON_MODULE_PATH=python" -D"RUBY_MODULE_PATH=ruby" -DCMAKE_BUILD_TYPE:STRING=Release -DAPPIMAGE_BUILD=1 -DUSE_SYSTEM_JSONCPP=0 ../
-    - make -j 4
-    - make install
-    - make doc
-    - ~/auto-update-docs "$CI_PROJECT_DIR/build" "$CI_COMMIT_REF_NAME"
-    - PROJECT_VERSION=$(grep -E '^set\(PROJECT_VERSION_FULL "(.*)' ../CMakeLists.txt | awk '{print $2}' | tr -d '")')
-    - PROJECT_SO=$(grep -E '^set\(PROJECT_SO_VERSION (.*)' ../CMakeLists.txt | awk '{print $2}' | tr -d ')')
-    - echo -e "CI_PROJECT_NAME:$CI_PROJECT_NAME\nCI_COMMIT_REF_NAME:$CI_COMMIT_REF_NAME\nCI_COMMIT_SHA:$CI_COMMIT_SHA\nCI_JOB_ID:$CI_JOB_ID\nCI_PIPELINE_ID:$CI_PIPELINE_ID\nVERSION:$PROJECT_VERSION\nSO:$PROJECT_SO" > "install-x64/share/$CI_PROJECT_NAME.env"
-    - git log $(git describe --tags --abbrev=0 @^)..@ --oneline --pretty=format:"- %C(auto,yellow)%h%C(auto,magenta)% %C(auto,blue)%>(12,trunc)%ad %C(auto,green)%<(25,trunc)%aN%C(auto,reset)%s%C(auto,red)% gD% D" --date=short > "install-x64/share/$CI_PROJECT_NAME.log"
-  when: always
-  except:
-  - tags
-  tags:
-    - linux-bionic
-
-mac-builder:
-  stage: build-libopenshot
-  artifacts:
-    expire_in: 6 months
-    paths:
-    - build/install-x64/*
-  script:
-    - "curl -O -J -L --header PRIVATE-TOKEN:$ACCESS_TOKEN http://gitlab.openshot.org/OpenShot/libopenshot-audio/-/jobs/artifacts/$CI_COMMIT_REF_NAME/download?job=mac-builder"
-    - if [ ! -f artifacts.zip ]; then
-    -    "curl -O -J -L --header PRIVATE-TOKEN:$ACCESS_TOKEN http://gitlab.openshot.org/OpenShot/libopenshot-audio/-/jobs/artifacts/develop/download?job=mac-builder"
-    - fi
-    - unzip artifacts.zip
-    - export LIBOPENSHOT_AUDIO_DIR=$CI_PROJECT_DIR/build/install-x64
-    - mkdir -p build; cd build;
-    - cmake -DCMAKE_EXE_LINKER_FLAGS="-stdlib=libc++" -DCMAKE_SHARED_LINKER_FLAGS="-stdlib=libc++" -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -D"CMAKE_INSTALL_PREFIX:PATH=$CI_PROJECT_DIR/build/install-x64" -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang -D"CMAKE_BUILD_TYPE:STRING=Release" -D"CMAKE_OSX_SYSROOT=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.11.sdk" -D"CMAKE_OSX_DEPLOYMENT_TARGET=10.9" -DCMAKE_PREFIX_PATH=/usr/local/qt5.15.X/qt5.15/5.15.0/clang_64/ -D"CMAKE_INSTALL_RPATH_USE_LINK_PATH=1" -D"ENABLE_RUBY=0" ../
-    - make -j 9
-    - make install
-    - PROJECT_VERSION=$(grep -E '^set\(PROJECT_VERSION_FULL "(.*)' ../CMakeLists.txt | awk '{print $2}' | tr -d '")')
-    - PROJECT_SO=$(grep -E '^set\(PROJECT_SO_VERSION (.*)' ../CMakeLists.txt | awk '{print $2}' | tr -d ')')
-    - echo -e "CI_PROJECT_NAME:$CI_PROJECT_NAME\nCI_COMMIT_REF_NAME:$CI_COMMIT_REF_NAME\nCI_COMMIT_SHA:$CI_COMMIT_SHA\nCI_JOB_ID:$CI_JOB_ID\nCI_PIPELINE_ID:$CI_PIPELINE_ID\nVERSION:$PROJECT_VERSION\nSO:$PROJECT_SO" > "install-x64/share/$CI_PROJECT_NAME.env"
-    - git log $(git describe --tags --abbrev=0 @^)..@ --oneline --pretty=format:"- %C(auto,yellow)%h%C(auto,magenta)% %C(auto,blue)%>(12,trunc)%ad %C(auto,green)%<(25,trunc)%aN%C(auto,reset)%s%C(auto,red)% gD% D" --date=short > "install-x64/share/$CI_PROJECT_NAME.log"
-  when: always
-  except:
-  - tags
-  tags:
-    - mac
-
 windows-builder-x64:
   stage: build-libopenshot
   artifacts:
@@ -90,7 +34,7 @@ windows-builder-x64:
   except:
   - tags
   tags:
-    - windows
+    - windows-v2
 
 windows-builder-x86:
   stage: build-libopenshot
@@ -117,7 +61,7 @@ windows-builder-x86:
   except:
   - tags
   tags:
-    - windows
+    - windows-v2
 
 trigger-pipeline:
   stage: trigger-openshot-qt

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,6 +9,62 @@ stages:
 variables:
   GIT_LOG_FORMAT: "- %h %ad %s [%aN]"
 
+linux-builder:
+  stage: build-libopenshot
+  artifacts:
+    expire_in: 6 months
+    paths:
+    - build/install-x64/*
+  script:
+    - "curl -O -J -L --header PRIVATE-TOKEN:$ACCESS_TOKEN http://gitlab.openshot.org/OpenShot/libopenshot-audio/-/jobs/artifacts/$CI_COMMIT_REF_NAME/download?job=linux-builder"
+    - if [ ! -f artifacts.zip ]; then
+    -    "curl -O -J -L --header PRIVATE-TOKEN:$ACCESS_TOKEN http://gitlab.openshot.org/OpenShot/libopenshot-audio/-/jobs/artifacts/develop/download?job=linux-builder"
+    - fi
+    - unzip artifacts.zip
+    - export LIBOPENSHOT_AUDIO_DIR=$CI_PROJECT_DIR/build/install-x64
+    - mkdir -p build; cd build;
+    - cmake -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -D"CMAKE_INSTALL_PREFIX:PATH=$CI_PROJECT_DIR/build/install-x64" -D"PYTHON_MODULE_PATH=python" -D"RUBY_MODULE_PATH=ruby" -DCMAKE_BUILD_TYPE:STRING=Release -DAPPIMAGE_BUILD=1 -DUSE_SYSTEM_JSONCPP=0 ../
+    - make -j 4
+    - make install
+    - make doc
+    - ~/auto-update-docs "$CI_PROJECT_DIR/build" "$CI_COMMIT_REF_NAME"
+    - PROJECT_VERSION=$(grep -E '^set\(PROJECT_VERSION_FULL "(.*)' ../CMakeLists.txt | awk '{print $2}' | tr -d '")')
+    - PROJECT_SO=$(grep -E '^set\(PROJECT_SO_VERSION (.*)' ../CMakeLists.txt | awk '{print $2}' | tr -d ')')
+    - echo -e "CI_PROJECT_NAME:$CI_PROJECT_NAME\nCI_COMMIT_REF_NAME:$CI_COMMIT_REF_NAME\nCI_COMMIT_SHA:$CI_COMMIT_SHA\nCI_JOB_ID:$CI_JOB_ID\nCI_PIPELINE_ID:$CI_PIPELINE_ID\nVERSION:$PROJECT_VERSION\nSO:$PROJECT_SO" > "install-x64/share/$CI_PROJECT_NAME.env"
+    - git log $(git describe --tags --abbrev=0 @^)..@ --oneline --pretty=format:"- %C(auto,yellow)%h%C(auto,magenta)% %C(auto,blue)%>(12,trunc)%ad %C(auto,green)%<(25,trunc)%aN%C(auto,reset)%s%C(auto,red)% gD% D" --date=short > "install-x64/share/$CI_PROJECT_NAME.log"
+  when: always
+  except:
+  - tags
+  tags:
+    - linux-bionic
+
+mac-builder:
+  stage: build-libopenshot
+  artifacts:
+    expire_in: 6 months
+    paths:
+    - build/install-x64/*
+  script:
+    - "curl -O -J -L --header PRIVATE-TOKEN:$ACCESS_TOKEN http://gitlab.openshot.org/OpenShot/libopenshot-audio/-/jobs/artifacts/$CI_COMMIT_REF_NAME/download?job=mac-builder"
+    - if [ ! -f artifacts.zip ]; then
+    -    "curl -O -J -L --header PRIVATE-TOKEN:$ACCESS_TOKEN http://gitlab.openshot.org/OpenShot/libopenshot-audio/-/jobs/artifacts/develop/download?job=mac-builder"
+    - fi
+    - unzip artifacts.zip
+    - export LIBOPENSHOT_AUDIO_DIR=$CI_PROJECT_DIR/build/install-x64
+    - mkdir -p build; cd build;
+    - cmake -DCMAKE_EXE_LINKER_FLAGS="-stdlib=libc++" -DCMAKE_SHARED_LINKER_FLAGS="-stdlib=libc++" -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -D"CMAKE_INSTALL_PREFIX:PATH=$CI_PROJECT_DIR/build/install-x64" -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang -D"CMAKE_BUILD_TYPE:STRING=Release" -D"CMAKE_OSX_SYSROOT=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.11.sdk" -D"CMAKE_OSX_DEPLOYMENT_TARGET=10.9" -DCMAKE_PREFIX_PATH=/usr/local/qt5.15.X/qt5.15/5.15.0/clang_64/ -D"CMAKE_INSTALL_RPATH_USE_LINK_PATH=1" -D"ENABLE_RUBY=0" ../
+    - make -j 9
+    - make install
+    - PROJECT_VERSION=$(grep -E '^set\(PROJECT_VERSION_FULL "(.*)' ../CMakeLists.txt | awk '{print $2}' | tr -d '")')
+    - PROJECT_SO=$(grep -E '^set\(PROJECT_SO_VERSION (.*)' ../CMakeLists.txt | awk '{print $2}' | tr -d ')')
+    - echo -e "CI_PROJECT_NAME:$CI_PROJECT_NAME\nCI_COMMIT_REF_NAME:$CI_COMMIT_REF_NAME\nCI_COMMIT_SHA:$CI_COMMIT_SHA\nCI_JOB_ID:$CI_JOB_ID\nCI_PIPELINE_ID:$CI_PIPELINE_ID\nVERSION:$PROJECT_VERSION\nSO:$PROJECT_SO" > "install-x64/share/$CI_PROJECT_NAME.env"
+    - git log $(git describe --tags --abbrev=0 @^)..@ --oneline --pretty=format:"- %C(auto,yellow)%h%C(auto,magenta)% %C(auto,blue)%>(12,trunc)%ad %C(auto,green)%<(25,trunc)%aN%C(auto,reset)%s%C(auto,red)% gD% D" --date=short > "install-x64/share/$CI_PROJECT_NAME.log"
+  when: always
+  except:
+  - tags
+  tags:
+    - mac
+
 windows-builder-x64:
   stage: build-libopenshot
   artifacts:
@@ -34,7 +90,7 @@ windows-builder-x64:
   except:
   - tags
   tags:
-    - windows-v2
+    - windows
 
 windows-builder-x86:
   stage: build-libopenshot
@@ -61,7 +117,7 @@ windows-builder-x86:
   except:
   - tags
   tags:
-    - windows-v2
+    - windows
 
 trigger-pipeline:
   stage: trigger-openshot-qt

--- a/doc/INSTALL-WINDOWS.md
+++ b/doc/INSTALL-WINDOWS.md
@@ -193,6 +193,7 @@ pacman -Syu
 ```
 pacman -S --needed base-devel mingw-w64-x86_64-toolchain
 pacman -S mingw64/mingw-w64-x86_64-ffmpeg
+pacman -S mingw64/mingw-w64-x86_64-qt5
 pacman -S mingw64/mingw-w64-x86_64-python3-pyqt5
 pacman -S mingw64/mingw-w64-x86_64-swig
 pacman -S mingw64/mingw-w64-x86_64-cmake
@@ -202,6 +203,11 @@ pacman -S mingw32/mingw-w64-i686-zeromq
 pacman -S mingw64/mingw-w64-x86_64-python3-pyzmq
 pacman -S mingw64/mingw-w64-x86_64-python3-cx_Freeze
 pacman -S mingw64/mingw-w64-x86_64-ninja
+pacman -S mingw64/mingw-w64-x86_64-catch
+pacman -S mingw-w64-x86_64-python3-pyopengl
+pacman -S mingw-w64-clang-x86_64-python-pyopengl-accelerate
+pacman -S mingw-w64-x86_64-python-pyopengl-accelerate
+pacman -S mingw-w64-x86_64-python-pywin32
 pacman -S git
 
 # Install ImageMagick if needed (OPTIONAL and NOT NEEDED)
@@ -213,6 +219,7 @@ pacman -S mingw64/mingw-w64-x86_64-imagemagick
 ```
 pacman -S --needed base-devel mingw32/mingw-w64-i686-toolchain
 pacman -S mingw32/mingw-w64-i686-ffmpeg
+pacman -S mingw32/mingw-w64-i686-qt5
 pacman -S mingw32/mingw-w64-i686-python3-pyqt5
 pacman -S mingw32/mingw-w64-i686-swig
 pacman -S mingw32/mingw-w64-i686-cmake
@@ -222,6 +229,10 @@ pacman -S mingw32/mingw-w64-i686-zeromq
 pacman -S mingw32/mingw-w64-i686-python3-pyzmq
 pacman -S mingw32/mingw-w64-i686-python3-cx_Freeze
 pacman -S mingw32/mingw-w64-i686-ninja
+pacman -S mingw32/mingw-w64-i686-catch
+pacman -S mingw-w64-i686-python-pyopengl
+pacman -S mingw-w64-i686-python-pyopengl-accelerate
+pacman -S mingw-w64-i686-python-pywin32
 pacman -S git
 
 # Install ImageMagick if needed (OPTIONAL and NOT NEEDED)
@@ -237,6 +248,8 @@ pip3 install tinys3
 pip3 install github3.py
 pip3 install requests
 pip3 install meson
+pip3 install PyOpenGL
+pip3 install PyOpenGL-accelerate
 ```  
 
 7) Download Unittest++ (https://github.com/unittest-cpp/unittest-cpp) into /MSYS2/[USER]/unittest-cpp-master/
@@ -251,12 +264,50 @@ mingw32-make install
 ``` 
 git clone https://gitlab.gnome.org/GNOME/babl.git
 cd babl
-meson build --prefix=C:/msys64/mingw32
+meson build --prefix=C:/msys64/mingw64    (or `--prefix=C:/msys64/mingw32` for a 32 bit build)
 cd build
 meson install
 ```
 
-9) ZMQ++ Header (This might not be needed anymore)
+9) Install opencv (used for AI and computer vision effects)
+
+Note: Had to edit 1 header file and add a missing typedef: `typedef unsigned int uint;`
+
+``` 
+git clone https://github.com/opencv/opencv
+cd opencv/
+git checkout '4.3.0'
+cd ..
+git clone https://github.com/opencv/opencv_contrib
+cd opencv_contrib/
+git checkout '4.3.0'
+cd ..
+cd opencv
+mkdir build
+cd build
+cmake -D CMAKE_BUILD_TYPE=RELEASE -D WITH_TBB=OFF -D WITH_QT=ON -D WITH_OPENGL=ON -D OPENCV_EXTRA_MODULES_PATH=../../opencv_contrib/modules -D OPENCV_GENERATE_PKGCONFIG=ON -D BUILD_opencv_python2=OFF -D BUILD_opencv_python3=ON -G "MSYS Makefiles" .. 
+make -j4 -i    (-i ignores errors on MSYS2 which happens for some reason)
+make install -i
+```
+
+10) Install ReSVG (SVG rasterizing)
+
+``` 
+git clone https://github.com/RazrFalcon/resvg
+cd resvg/c-api
+QT_DIR="C:\\msys64\\mingw64\\" cargo build --verbose --release
+  **OR**
+QT_DIR="C:\\msys64\\mingw32\\" cargo build --verbose --release
+
+cd ../
+
+# copy all required files into the system directories
+cp target/release/resvg.dll /usr/lib/
+mkdir -p /usr/include/resvg/
+cp c-api/*.h /usr/include/resvg/
+```
+
+11) ZMQ++ Header (This might not be needed anymore)
   NOTE: Download and copy zmq.hpp into the /c/msys64/mingw64/include/ folder
 
 ## Manual Dependencies

--- a/src/FFmpegReader.cpp
+++ b/src/FFmpegReader.cpp
@@ -1123,7 +1123,10 @@ bool FFmpegReader::GetAVFrame() {
                 ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::GetAVFrame (AVERRORAVERROR(ENOMEM) failed to add packet to internal queue, or similar other errors: legitimate decoding errors");
             }
 		}
-		else {
+		if (send_packet_err != AVERROR_EOF) {
+		    // Always try and receive a packet, if not EOF.
+		    // Even if the above avcodec_send_packet failed to send,
+		    // we might still need to receive a packet.
 			int receive_frame_err = 0;
 			AVFrame *next_frame2;
 	#if USE_HW_ACCEL

--- a/src/FFmpegReader.cpp
+++ b/src/FFmpegReader.cpp
@@ -1112,8 +1112,16 @@ bool FFmpegReader::GetAVFrame() {
 		hw_de_av_device_type = hw_de_av_device_type_global;
 	#endif // USE_HW_ACCEL
 		if (send_packet_err < 0 && send_packet_err != AVERROR_EOF) {
-			ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::GetAVFrame (Packet not sent)",
-											"send_packet_err", send_packet_err);
+            ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::GetAVFrame (Packet not sent)", "send_packet_err", send_packet_err);
+            if (send_packet_err == AVERROR(EAGAIN)) {
+                ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::GetAVFrame (AVERROR(EAGAIN) user must read output with avcodec_receive_frame()");
+            }
+            if (send_packet_err == AVERROR(EINVAL)) {
+                ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::GetAVFrame (AVERROR(EINVAL) codec not opened, it is an encoder, or requires flush");
+            }
+            if (send_packet_err == AVERROR(ENOMEM)) {
+                ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::GetAVFrame (AVERRORAVERROR(ENOMEM) failed to add packet to internal queue, or similar other errors: legitimate decoding errors");
+            }
 		}
 		else {
 			int receive_frame_err = 0;

--- a/src/FFmpegReader.cpp
+++ b/src/FFmpegReader.cpp
@@ -213,6 +213,7 @@ void FFmpegReader::Open() {
 		pFormatCtx = NULL;
 		{
 			hw_de_on = (openshot::Settings::Instance()->HARDWARE_DECODER == 0 ? 0 : 1);
+            ZmqLogger::Instance()->AppendDebugMethod("Decode hardware acceleration settings", "hw_de_on", hw_de_on, "HARDWARE_DECODER", openshot::Settings::Instance()->HARDWARE_DECODER);
 		}
 
 		// Open video file
@@ -1177,10 +1178,10 @@ bool FFmpegReader::GetAVFrame() {
                 if (next_frame2->format == hw_de_av_pix_fmt) {
                     next_frame->format = AV_PIX_FMT_YUV420P;
                     if ((err = av_hwframe_transfer_data(next_frame,next_frame2,0)) < 0) {
-                        ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::GetAVFrame (Failed to transfer data to output frame)");
+                        ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::GetAVFrame (Failed to transfer data to output frame)", "hw_de_on", hw_de_on);
                     }
                     if ((err = av_frame_copy_props(next_frame,next_frame2)) < 0) {
-                        ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::GetAVFrame (Failed to copy props to output frame)");
+                        ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::GetAVFrame (Failed to copy props to output frame)", "hw_de_on", hw_de_on);
                     }
                 }
             }

--- a/src/FFmpegReader.h
+++ b/src/FFmpegReader.h
@@ -153,7 +153,7 @@ namespace openshot {
 
 		int64_t audio_pts;
 		int64_t video_pts;
-		bool resend_packet;
+		bool hold_packet;
 		double pts_offset_seconds;
 		double audio_pts_seconds;
 		double video_pts_seconds;

--- a/src/FFmpegReader.h
+++ b/src/FFmpegReader.h
@@ -153,6 +153,7 @@ namespace openshot {
 
 		int64_t audio_pts;
 		int64_t video_pts;
+		bool resend_packet;
 		double pts_offset_seconds;
 		double audio_pts_seconds;
 		double video_pts_seconds;

--- a/tests/FFmpegReader.cpp
+++ b/tests/FFmpegReader.cpp
@@ -287,60 +287,60 @@ TEST_CASE( "DisplayInfo", "[libopenshot][ffmpegreader]" )
 
 TEST_CASE( "Decoding AV1 Video", "[libopenshot][ffmpegreader]" )
 {
-    // Create a reader
-    std::stringstream path;
-    path << TEST_MEDIA_PATH << "test_video_sync.mp4";
-    FFmpegReader r(path.str());
-    r.Open();
+	// Create a reader
+	std::stringstream path;
+	path << TEST_MEDIA_PATH << "test_video_sync.mp4";
+	FFmpegReader r(path.str());
+	r.Open();
 
-    std::shared_ptr<Frame> f = r.GetFrame(1);
+	std::shared_ptr<Frame> f = r.GetFrame(1);
 
-    // Get the image data
-    const unsigned char* pixels = f->GetPixels(10);
-    int pixel_index = 112 * 4;
+	// Get the image data
+	const unsigned char* pixels = f->GetPixels(10);
+	int pixel_index = 112 * 4;
 
-    // Check image properties on scanline 10, pixel 112
-    CHECK((int)pixels[pixel_index] == Approx(0).margin(5));
-    CHECK((int)pixels[pixel_index + 1] == Approx(0).margin(5));
-    CHECK((int)pixels[pixel_index + 2] == Approx(0).margin(5));
-    CHECK((int)pixels[pixel_index + 3] == Approx(255).margin(5));
+	// Check image properties on scanline 10, pixel 112
+	CHECK((int)pixels[pixel_index] == Approx(0).margin(5));
+	CHECK((int)pixels[pixel_index + 1] == Approx(0).margin(5));
+	CHECK((int)pixels[pixel_index + 2] == Approx(0).margin(5));
+	CHECK((int)pixels[pixel_index + 3] == Approx(255).margin(5));
 
-    f = r.GetFrame(90);
+	f = r.GetFrame(90);
 
-    // Get the image data
-    pixels = f->GetPixels(820);
-    pixel_index = 930 * 4;
+	// Get the image data
+	pixels = f->GetPixels(820);
+	pixel_index = 930 * 4;
 
-    // Check image properties on scanline 820, pixel 930
-    CHECK((int)pixels[pixel_index] == Approx(255).margin(5));
-    CHECK((int)pixels[pixel_index + 1] == Approx(255).margin(5));
-    CHECK((int)pixels[pixel_index + 2] == Approx(255).margin(5));
-    CHECK((int)pixels[pixel_index + 3] == Approx(255).margin(5));
+	// Check image properties on scanline 820, pixel 930
+	CHECK((int)pixels[pixel_index] == Approx(255).margin(5));
+	CHECK((int)pixels[pixel_index + 1] == Approx(255).margin(5));
+	CHECK((int)pixels[pixel_index + 2] == Approx(255).margin(5));
+	CHECK((int)pixels[pixel_index + 3] == Approx(255).margin(5));
 
-    f = r.GetFrame(160);
+	f = r.GetFrame(160);
 
-    // Get the image data
-    pixels = f->GetPixels(420);
-    pixel_index = 930 * 4;
+	// Get the image data
+	pixels = f->GetPixels(420);
+	pixel_index = 930 * 4;
 
-    // Check image properties on scanline 820, pixel 930
-    CHECK((int)pixels[pixel_index] == Approx(255).margin(5));
-    CHECK((int)pixels[pixel_index + 1] == Approx(255).margin(5));
-    CHECK((int)pixels[pixel_index + 2] == Approx(255).margin(5));
-    CHECK((int)pixels[pixel_index + 3] == Approx(255).margin(5));
+	// Check image properties on scanline 820, pixel 930
+	CHECK((int)pixels[pixel_index] == Approx(255).margin(5));
+	CHECK((int)pixels[pixel_index + 1] == Approx(255).margin(5));
+	CHECK((int)pixels[pixel_index + 2] == Approx(255).margin(5));
+	CHECK((int)pixels[pixel_index + 3] == Approx(255).margin(5));
 
-    f = r.GetFrame(240);
+	f = r.GetFrame(240);
 
-    // Get the image data
-    pixels = f->GetPixels(624);
-    pixel_index = 930 * 4;
+	// Get the image data
+	pixels = f->GetPixels(624);
+	pixel_index = 930 * 4;
 
-    // Check image properties on scanline 820, pixel 930
-    CHECK((int)pixels[pixel_index] == Approx(255).margin(5));
-    CHECK((int)pixels[pixel_index + 1] == Approx(255).margin(5));
-    CHECK((int)pixels[pixel_index + 2] == Approx(255).margin(5));
-    CHECK((int)pixels[pixel_index + 3] == Approx(255).margin(5));
+	// Check image properties on scanline 820, pixel 930
+	CHECK((int)pixels[pixel_index] == Approx(255).margin(5));
+	CHECK((int)pixels[pixel_index + 1] == Approx(255).margin(5));
+	CHECK((int)pixels[pixel_index + 2] == Approx(255).margin(5));
+	CHECK((int)pixels[pixel_index + 3] == Approx(255).margin(5));
 
-    // Close reader
-    r.Close();
+	// Close reader
+	r.Close();
 }

--- a/tests/FFmpegReader.cpp
+++ b/tests/FFmpegReader.cpp
@@ -287,60 +287,65 @@ TEST_CASE( "DisplayInfo", "[libopenshot][ffmpegreader]" )
 
 TEST_CASE( "Decoding AV1 Video", "[libopenshot][ffmpegreader]" )
 {
-	// Create a reader
-	std::stringstream path;
-	path << TEST_MEDIA_PATH << "test_video_sync.mp4";
-	FFmpegReader r(path.str());
-	r.Open();
+	try {
+		// Create a reader
+		std::stringstream path;
+		path << TEST_MEDIA_PATH << "test_video_sync.mp4";
+		FFmpegReader r(path.str());
+		r.Open();
 
-	std::shared_ptr<Frame> f = r.GetFrame(1);
+		std::shared_ptr<Frame> f = r.GetFrame(1);
 
-	// Get the image data
-	const unsigned char* pixels = f->GetPixels(10);
-	int pixel_index = 112 * 4;
+		// Get the image data
+		const unsigned char *pixels = f->GetPixels(10);
+		int pixel_index = 112 * 4;
 
-	// Check image properties on scanline 10, pixel 112
-	CHECK((int)pixels[pixel_index] == Approx(0).margin(5));
-	CHECK((int)pixels[pixel_index + 1] == Approx(0).margin(5));
-	CHECK((int)pixels[pixel_index + 2] == Approx(0).margin(5));
-	CHECK((int)pixels[pixel_index + 3] == Approx(255).margin(5));
+		// Check image properties on scanline 10, pixel 112
+		CHECK((int) pixels[pixel_index] == Approx(0).margin(5));
+		CHECK((int) pixels[pixel_index + 1] == Approx(0).margin(5));
+		CHECK((int) pixels[pixel_index + 2] == Approx(0).margin(5));
+		CHECK((int) pixels[pixel_index + 3] == Approx(255).margin(5));
 
-	f = r.GetFrame(90);
+		f = r.GetFrame(90);
 
-	// Get the image data
-	pixels = f->GetPixels(820);
-	pixel_index = 930 * 4;
+		// Get the image data
+		pixels = f->GetPixels(820);
+		pixel_index = 930 * 4;
 
-	// Check image properties on scanline 820, pixel 930
-	CHECK((int)pixels[pixel_index] == Approx(255).margin(5));
-	CHECK((int)pixels[pixel_index + 1] == Approx(255).margin(5));
-	CHECK((int)pixels[pixel_index + 2] == Approx(255).margin(5));
-	CHECK((int)pixels[pixel_index + 3] == Approx(255).margin(5));
+		// Check image properties on scanline 820, pixel 930
+		CHECK((int) pixels[pixel_index] == Approx(255).margin(5));
+		CHECK((int) pixels[pixel_index + 1] == Approx(255).margin(5));
+		CHECK((int) pixels[pixel_index + 2] == Approx(255).margin(5));
+		CHECK((int) pixels[pixel_index + 3] == Approx(255).margin(5));
 
-	f = r.GetFrame(160);
+		f = r.GetFrame(160);
 
-	// Get the image data
-	pixels = f->GetPixels(420);
-	pixel_index = 930 * 4;
+		// Get the image data
+		pixels = f->GetPixels(420);
+		pixel_index = 930 * 4;
 
-	// Check image properties on scanline 820, pixel 930
-	CHECK((int)pixels[pixel_index] == Approx(255).margin(5));
-	CHECK((int)pixels[pixel_index + 1] == Approx(255).margin(5));
-	CHECK((int)pixels[pixel_index + 2] == Approx(255).margin(5));
-	CHECK((int)pixels[pixel_index + 3] == Approx(255).margin(5));
+		// Check image properties on scanline 820, pixel 930
+		CHECK((int) pixels[pixel_index] == Approx(255).margin(5));
+		CHECK((int) pixels[pixel_index + 1] == Approx(255).margin(5));
+		CHECK((int) pixels[pixel_index + 2] == Approx(255).margin(5));
+		CHECK((int) pixels[pixel_index + 3] == Approx(255).margin(5));
 
-	f = r.GetFrame(240);
+		f = r.GetFrame(240);
 
-	// Get the image data
-	pixels = f->GetPixels(624);
-	pixel_index = 930 * 4;
+		// Get the image data
+		pixels = f->GetPixels(624);
+		pixel_index = 930 * 4;
 
-	// Check image properties on scanline 820, pixel 930
-	CHECK((int)pixels[pixel_index] == Approx(255).margin(5));
-	CHECK((int)pixels[pixel_index + 1] == Approx(255).margin(5));
-	CHECK((int)pixels[pixel_index + 2] == Approx(255).margin(5));
-	CHECK((int)pixels[pixel_index + 3] == Approx(255).margin(5));
+		// Check image properties on scanline 820, pixel 930
+		CHECK((int) pixels[pixel_index] == Approx(255).margin(5));
+		CHECK((int) pixels[pixel_index + 1] == Approx(255).margin(5));
+		CHECK((int) pixels[pixel_index + 2] == Approx(255).margin(5));
+		CHECK((int) pixels[pixel_index + 3] == Approx(255).margin(5));
 
-	// Close reader
-	r.Close();
+		// Close reader
+		r.Close();
+
+	} catch (const InvalidFile & e) {
+		// Ignore older FFmpeg versions which don't support AV1
+	}
 }

--- a/tests/FFmpegReader.cpp
+++ b/tests/FFmpegReader.cpp
@@ -345,6 +345,8 @@ TEST_CASE( "Decoding AV1 Video", "[libopenshot][ffmpegreader]" )
 		// Close reader
 		r.Close();
 
+	} catch (const InvalidCodec & e) {
+		// Ignore older FFmpeg versions which don't support AV1
 	} catch (const InvalidFile & e) {
 		// Ignore older FFmpeg versions which don't support AV1
 	}

--- a/tests/FFmpegReader.cpp
+++ b/tests/FFmpegReader.cpp
@@ -284,3 +284,24 @@ TEST_CASE( "DisplayInfo", "[libopenshot][ffmpegreader]" )
 	// Compare a [0, expected.size()) substring of output to expected
 	CHECK(output.str().substr(0, expected.size()) == expected);
 }
+
+TEST_CASE( "Decode_AV1_to_PNG", "[libopenshot][ffmpegreader]" )
+{
+    // Create a reader
+    std::stringstream path;
+    path << TEST_MEDIA_PATH << "test_video_sync.mp4";
+    FFmpegReader r(path.str());
+    r.Open();
+
+    for (long int frame = 1; frame <= 200; frame++)
+    {
+        std::cout << "Requesting Frame: #: " << frame << std::endl;
+        std::stringstream output;
+        output << "frame-" << frame << ".png";
+        std::shared_ptr<Frame> f = r.GetFrame(frame);
+        f->Save(output.str(), 1.0, "PNG");
+    }
+
+    // Close reader
+    r.Close();
+}

--- a/tests/FFmpegReader.cpp
+++ b/tests/FFmpegReader.cpp
@@ -285,7 +285,7 @@ TEST_CASE( "DisplayInfo", "[libopenshot][ffmpegreader]" )
 	CHECK(output.str().substr(0, expected.size()) == expected);
 }
 
-TEST_CASE( "Decode_AV1_to_PNG", "[libopenshot][ffmpegreader]" )
+TEST_CASE( "Decoding AV1 Video", "[libopenshot][ffmpegreader]" )
 {
     // Create a reader
     std::stringstream path;
@@ -293,14 +293,53 @@ TEST_CASE( "Decode_AV1_to_PNG", "[libopenshot][ffmpegreader]" )
     FFmpegReader r(path.str());
     r.Open();
 
-    for (long int frame = 1; frame <= 200; frame++)
-    {
-        std::cout << "Requesting Frame: #: " << frame << std::endl;
-        std::stringstream output;
-        output << "frame-" << frame << ".png";
-        std::shared_ptr<Frame> f = r.GetFrame(frame);
-        f->Save(output.str(), 1.0, "PNG");
-    }
+    std::shared_ptr<Frame> f = r.GetFrame(1);
+
+    // Get the image data
+    const unsigned char* pixels = f->GetPixels(10);
+    int pixel_index = 112 * 4;
+
+    // Check image properties on scanline 10, pixel 112
+    CHECK((int)pixels[pixel_index] == Approx(0).margin(5));
+    CHECK((int)pixels[pixel_index + 1] == Approx(0).margin(5));
+    CHECK((int)pixels[pixel_index + 2] == Approx(0).margin(5));
+    CHECK((int)pixels[pixel_index + 3] == Approx(255).margin(5));
+
+    f = r.GetFrame(90);
+
+    // Get the image data
+    pixels = f->GetPixels(820);
+    pixel_index = 930 * 4;
+
+    // Check image properties on scanline 820, pixel 930
+    CHECK((int)pixels[pixel_index] == Approx(255).margin(5));
+    CHECK((int)pixels[pixel_index + 1] == Approx(255).margin(5));
+    CHECK((int)pixels[pixel_index + 2] == Approx(255).margin(5));
+    CHECK((int)pixels[pixel_index + 3] == Approx(255).margin(5));
+
+    f = r.GetFrame(160);
+
+    // Get the image data
+    pixels = f->GetPixels(420);
+    pixel_index = 930 * 4;
+
+    // Check image properties on scanline 820, pixel 930
+    CHECK((int)pixels[pixel_index] == Approx(255).margin(5));
+    CHECK((int)pixels[pixel_index + 1] == Approx(255).margin(5));
+    CHECK((int)pixels[pixel_index + 2] == Approx(255).margin(5));
+    CHECK((int)pixels[pixel_index + 3] == Approx(255).margin(5));
+
+    f = r.GetFrame(240);
+
+    // Get the image data
+    pixels = f->GetPixels(624);
+    pixel_index = 930 * 4;
+
+    // Check image properties on scanline 820, pixel 930
+    CHECK((int)pixels[pixel_index] == Approx(255).margin(5));
+    CHECK((int)pixels[pixel_index + 1] == Approx(255).margin(5));
+    CHECK((int)pixels[pixel_index + 2] == Approx(255).margin(5));
+    CHECK((int)pixels[pixel_index + 3] == Approx(255).margin(5));
 
     // Close reader
     r.Close();


### PR DESCRIPTION
Some decoders, for example `dav1d`, process packets asynchronously and are multi-threaded. OpenShot was not correctly handling these async decoders, which resulted in dropping packets and freezing videos. This PR adds an AV1 decoding unit test as a verification, and correctly retries packets that fail to be sent to the decoder.

For example, if a decoder can accept many packets before returning an AVFrame, it might also stop accepting new packets... until it's done processing the previous ones. In those cases, we need to halt getting the next packet, until we can successfully send the current packet.