### PR TITLE
Prevent seeking past EOF

### DIFF
--- a/examples/Example.cpp
+++ b/examples/Example.cpp
@@ -24,7 +24,7 @@ using namespace openshot;
 int main(int argc, char* argv[]) {
 
     // FFmpeg Reader performance test
-    FFmpegReader r9("/home/jonathan/Downloads/project-29/f5b6c409-1ecc-49cd-8660-478acf152dce.webm");
+    FFmpegReader r9("/home/jonathan/Downloads/pts-test-files/broken-files/lady-talking-1.mp4");
     r9.Open();
     for (long int frame = 1; frame <= r9.info.video_length; frame++)
     {

--- a/examples/Example.cpp
+++ b/examples/Example.cpp
@@ -24,7 +24,7 @@ using namespace openshot;
 int main(int argc, char* argv[]) {
 
     // FFmpeg Reader performance test
-    FFmpegReader r9("/home/jonathan/Downloads/pts-test-files/broken-files/lady-talking-1.mp4");
+    FFmpegReader r9("/home/jonathan/Downloads/project-29/f5b6c409-1ecc-49cd-8660-478acf152dce.webm");
     r9.Open();
     for (long int frame = 1; frame <= r9.info.video_length; frame++)
     {

--- a/src/FFmpegReader.cpp
+++ b/src/FFmpegReader.cpp
@@ -1057,26 +1057,26 @@ std::shared_ptr<Frame> FFmpegReader::ReadStream(int64_t requested_frame) {
 
 		// Check if largest frame is still cached
 		frame = final_cache.GetFrame(largest_frame_processed);
-        int samples_in_frame = Frame::GetSamplesPerFrame(requested_frame, info.fps,
-                                                         info.sample_rate, info.channels);
+		int samples_in_frame = Frame::GetSamplesPerFrame(requested_frame, info.fps,
+														 info.sample_rate, info.channels);
 		if (frame) {
 			// Copy and return the largest processed frame (assuming it was the last in the video file)
-            std::shared_ptr<Frame> f = CreateFrame(largest_frame_processed);
+			std::shared_ptr<Frame> f = CreateFrame(largest_frame_processed);
 
-            // Use solid color (if no image data found)
-            if (!frame->has_image_data) {
-                // Use solid black frame if no image data available
-                f->AddColor(info.width, info.height, "#000");
-            }
-            // Silence audio data (if any), since we are repeating the last frame
-            frame->AddAudioSilence(samples_in_frame);
+			// Use solid color (if no image data found)
+			if (!frame->has_image_data) {
+				// Use solid black frame if no image data available
+				f->AddColor(info.width, info.height, "#000");
+			}
+			// Silence audio data (if any), since we are repeating the last frame
+			frame->AddAudioSilence(samples_in_frame);
 
 			return frame;
 		} else {
 			// The largest processed frame is no longer in cache, return a blank frame
 			std::shared_ptr<Frame> f = CreateFrame(largest_frame_processed);
 			f->AddColor(info.width, info.height, "#000");
-            f->AddAudioSilence(samples_in_frame);
+			f->AddAudioSilence(samples_in_frame);
 			return f;
 		}
 	}
@@ -1787,8 +1787,8 @@ void FFmpegReader::Seek(int64_t requested_frame) {
 	if (requested_frame > info.video_length)
 		requested_frame = info.video_length;
 	if (requested_frame > largest_frame_processed && packet_status.end_of_file) {
-	    // Not possible to search past largest_frame once EOF is reached (no more packets)
-	    return;
+		// Not possible to search past largest_frame once EOF is reached (no more packets)
+		return;
 	}
 
 	// Debug output

--- a/src/FFmpegReader.cpp
+++ b/src/FFmpegReader.cpp
@@ -1057,13 +1057,26 @@ std::shared_ptr<Frame> FFmpegReader::ReadStream(int64_t requested_frame) {
 
 		// Check if largest frame is still cached
 		frame = final_cache.GetFrame(largest_frame_processed);
+        int samples_in_frame = Frame::GetSamplesPerFrame(requested_frame, info.fps,
+                                                         info.sample_rate, info.channels);
 		if (frame) {
-			// return the largest processed frame (assuming it was the last in the video file)
+			// Copy and return the largest processed frame (assuming it was the last in the video file)
+            std::shared_ptr<Frame> f = CreateFrame(largest_frame_processed);
+
+            // Use solid color (if no image data found)
+            if (!frame->has_image_data) {
+                // Use solid black frame if no image data available
+                f->AddColor(info.width, info.height, "#000");
+            }
+            // Silence audio data (if any), since we are repeating the last frame
+            frame->AddAudioSilence(samples_in_frame);
+
 			return frame;
 		} else {
 			// The largest processed frame is no longer in cache, return a blank frame
 			std::shared_ptr<Frame> f = CreateFrame(largest_frame_processed);
 			f->AddColor(info.width, info.height, "#000");
+            f->AddAudioSilence(samples_in_frame);
 			return f;
 		}
 	}

--- a/src/FFmpegReader.cpp
+++ b/src/FFmpegReader.cpp
@@ -1773,6 +1773,10 @@ void FFmpegReader::Seek(int64_t requested_frame) {
 		requested_frame = 1;
 	if (requested_frame > info.video_length)
 		requested_frame = info.video_length;
+	if (requested_frame > largest_frame_processed && packet_status.end_of_file) {
+	    // Not possible to search past largest_frame once EOF is reached (no more packets)
+	    return;
+	}
 
 	// Debug output
 	ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::Seek",


### PR DESCRIPTION
Prevent seeking past end of stream, which causes a huge # of Seeks once EOF is reached, if we try and request frame #s too large for the file. For example, if a video file is encoded with the metadata it has 1600 frames, but in reality, only 1500 frames are found, those last 100 frames are not possible to find, and we keep Seek()ing looking for the frame which doesn't exist... this is so slow, it might as well be a freeze.