### PR TITLE
Add Support for Windows 7/8.1

### DIFF
--- a/src/Qt/AudioPlaybackThread.cpp
+++ b/src/Qt/AudioPlaybackThread.cpp
@@ -21,8 +21,8 @@
 #include "../Settings.h"
 
 #include <mutex>
-#include <thread>    // for std::this_thread::sleep_for
-#include <chrono>    // for std::chrono::milliseconds
+#include <thread>	// for std::this_thread::sleep_for
+#include <chrono>	// for std::chrono::milliseconds
 
 using namespace juce;
 
@@ -31,17 +31,17 @@ namespace openshot
 	// Global reference to device manager
 	AudioDeviceManagerSingleton *AudioDeviceManagerSingleton::m_pInstance = NULL;
 
-    // Create or Get audio device singleton with default settings (44100, 2)
-    AudioDeviceManagerSingleton *AudioDeviceManagerSingleton::Instance()
-    {
-        return AudioDeviceManagerSingleton::Instance(44100, 2);
-    }
+	// Create or Get audio device singleton with default settings (44100, 2)
+	AudioDeviceManagerSingleton *AudioDeviceManagerSingleton::Instance()
+	{
+		return AudioDeviceManagerSingleton::Instance(44100, 2);
+	}
 
 	// Create or Get an instance of the device manager singleton (with custom sample rate & channels)
 	AudioDeviceManagerSingleton *AudioDeviceManagerSingleton::Instance(int rate, int channels)
 	{
-        static std::mutex mutex;
-        std::lock_guard<std::mutex> lock(mutex);
+		static std::mutex mutex;
+		std::lock_guard<std::mutex> lock(mutex);
 
 		if (!m_pInstance) {
 			// Create the actual instance of device manager only once
@@ -69,34 +69,34 @@ namespace openshot
 			}
 
 			if (!selected_type.isEmpty()) {
-                m_pInstance->audioDeviceManager.setCurrentAudioDeviceType(selected_type, true);
-            }
+				m_pInstance->audioDeviceManager.setCurrentAudioDeviceType(selected_type, true);
+			}
 
 			// Settings for audio device playback
-            AudioDeviceManager::AudioDeviceSetup deviceSetup = AudioDeviceManager::AudioDeviceSetup();
-            deviceSetup.sampleRate = rate;
-            deviceSetup.inputChannels = 0;
-            deviceSetup.outputChannels = channels;
+			AudioDeviceManager::AudioDeviceSetup deviceSetup = AudioDeviceManager::AudioDeviceSetup();
+			deviceSetup.sampleRate = rate;
+			deviceSetup.inputChannels = 0;
+			deviceSetup.outputChannels = channels;
 
-            // Detect default sample rate (of default device)
-            m_pInstance->audioDeviceManager.initialiseWithDefaultDevices (0, 2);
+			// Detect default sample rate (of default device)
+			m_pInstance->audioDeviceManager.initialiseWithDefaultDevices (0, 2);
 
-            // Set current sample rate (from audio device)
-            double currentSampleRate = 44100;
-            AudioIODevice* currentDevice = m_pInstance->audioDeviceManager.getCurrentAudioDevice();
-            if (currentDevice) {
-                currentSampleRate = currentDevice->getCurrentSampleRate();
-            }
-            m_pInstance->defaultSampleRate = currentSampleRate;
+			// Set current sample rate (from audio device)
+			double currentSampleRate = 44100;
+			AudioIODevice* currentDevice = m_pInstance->audioDeviceManager.getCurrentAudioDevice();
+			if (currentDevice) {
+				currentSampleRate = currentDevice->getCurrentSampleRate();
+			}
+			m_pInstance->defaultSampleRate = currentSampleRate;
 
-            // Initialize audio device with specific sample rate
+			// Initialize audio device with specific sample rate
 			juce::String audio_error = m_pInstance->audioDeviceManager.initialise (
-				0,       // number of input channels
-                channels,       // number of output channels
+				0,	   // number of input channels
+				channels,	   // number of output channels
 				nullptr, // no XML settings..
-				true,    // select default device on failure
+				true,	// select default device on failure
 				selected_device, // preferredDefaultDeviceName
-                &deviceSetup // sample_rate & channels
+				&deviceSetup // sample_rate & channels
 			);
 
 			// Persist any errors detected
@@ -109,37 +109,37 @@ namespace openshot
 		return m_pInstance;
 	}
 
-    // Close audio device
-    void AudioDeviceManagerSingleton::CloseAudioDevice()
-    {
-        // Close Audio Device
-        audioDeviceManager.closeAudioDevice();
-        audioDeviceManager.removeAllChangeListeners();
-        audioDeviceManager.dispatchPendingMessages();
-    }
+	// Close audio device
+	void AudioDeviceManagerSingleton::CloseAudioDevice()
+	{
+		// Close Audio Device
+		audioDeviceManager.closeAudioDevice();
+		audioDeviceManager.removeAllChangeListeners();
+		audioDeviceManager.dispatchPendingMessages();
+	}
 
-    // Constructor
-    AudioPlaybackThread::AudioPlaybackThread(openshot::VideoCacheThread* cache)
+	// Constructor
+	AudioPlaybackThread::AudioPlaybackThread(openshot::VideoCacheThread* cache)
 	: juce::Thread("audio-playback")
 	, player()
 	, transport()
 	, mixer()
 	, source(NULL)
 	, sampleRate(0.0)
-    , numChannels(0)
-    , is_playing(false)
+	, numChannels(0)
+	, is_playing(false)
 	, time_thread("audio-buffer")
 	, videoCache(cache)
-    {
+	{
 	}
 
-    // Destructor
-    AudioPlaybackThread::~AudioPlaybackThread()
-    {
-    }
+	// Destructor
+	AudioPlaybackThread::~AudioPlaybackThread()
+	{
+	}
 
-    // Set the reader object
-    void AudioPlaybackThread::Reader(openshot::ReaderBase *reader) {
+	// Set the reader object
+	void AudioPlaybackThread::Reader(openshot::ReaderBase *reader) {
 		if (source)
 			source->Reader(reader);
 		else {
@@ -159,19 +159,19 @@ namespace openshot
 		Play();
 	}
 
-    // Get the current frame object (which is filling the buffer)
-    std::shared_ptr<openshot::Frame> AudioPlaybackThread::getFrame()
-    {
+	// Get the current frame object (which is filling the buffer)
+	std::shared_ptr<openshot::Frame> AudioPlaybackThread::getFrame()
+	{
 	if (source) return source->getFrame();
 		return std::shared_ptr<openshot::Frame>();
-    }
+	}
 
 	// Seek the audio thread
 	void AudioPlaybackThread::Seek(int64_t new_position)
 	{
-        if (source) {
-            source->Seek(new_position);
-        }
+		if (source) {
+			source->Seek(new_position);
+		}
 	}
 
 	// Play the audio
@@ -187,38 +187,38 @@ namespace openshot
 	}
 
 	// Start audio thread
-    void AudioPlaybackThread::run()
-    {
-    	while (!threadShouldExit())
-    	{
-    		if (source && !transport.isPlaying() && is_playing) {
-    			// Start new audio device (or get existing one)
-                AudioDeviceManagerSingleton *audioInstance = AudioDeviceManagerSingleton::Instance(sampleRate,
+	void AudioPlaybackThread::run()
+	{
+		while (!threadShouldExit())
+		{
+			if (source && !transport.isPlaying() && is_playing) {
+				// Start new audio device (or get existing one)
+				AudioDeviceManagerSingleton *audioInstance = AudioDeviceManagerSingleton::Instance(sampleRate,
 
-                // Add callback
-                audioInstance->audioDeviceManager.addAudioCallback(&player);
+				// Add callback
+				audioInstance->audioDeviceManager.addAudioCallback(&player);
 
-    			// Create TimeSliceThread for audio buffering
+				// Create TimeSliceThread for audio buffering
 				time_thread.startThread();
 
-    			// Connect source to transport
-    			transport.setSource(
-    			    source,
-    			    0, // No read ahead buffer
-    			    &time_thread,
-    			    0, // Sample rate correction (none)
-                    numChannels); // max channels
-    			transport.setPosition(0);
-    			transport.setGain(1.0);
+				// Connect source to transport
+				transport.setSource(
+					source,
+					0, // No read ahead buffer
+					&time_thread,
+					0, // Sample rate correction (none)
+					numChannels); // max channels
+				transport.setPosition(0);
+				transport.setGain(1.0);
 
-    			// Connect transport to mixer and player
-    			mixer.addInputSource(&transport, false);
-    			player.setSource(&mixer);
+				// Connect transport to mixer and player
+				mixer.addInputSource(&transport, false);
+				player.setSource(&mixer);
 
-    			// Start the transport
-    			transport.start();
+				// Start the transport
+				transport.start();
 
-    			while (!threadShouldExit() && transport.isPlaying() && is_playing)
+				while (!threadShouldExit() && transport.isPlaying() && is_playing)
 					std::this_thread::sleep_for(std::chrono::milliseconds(2));
 
 				// Stop audio and shutdown transport
@@ -229,7 +229,7 @@ namespace openshot
 				transport.setSource(NULL);
 
 				player.setSource(NULL);
-                audioInstance->audioDeviceManager.removeAudioCallback(&player);
+				audioInstance->audioDeviceManager.removeAudioCallback(&player);
 
 				// Remove source
 				delete source;
@@ -237,8 +237,8 @@ namespace openshot
 
 				// Stop time slice thread
 				time_thread.stopThread(-1);
-    		}
-    	}
+			}
+		}
 
-    }
+	}
 }

--- a/src/Qt/AudioPlaybackThread.cpp
+++ b/src/Qt/AudioPlaybackThread.cpp
@@ -96,9 +96,16 @@ namespace openshot
 
             std::cout << "-> AudioDeviceManagerSingleton:: F.1" << std::endl;
 
-            m_pInstance->defaultSampleRate = m_pInstance->audioDeviceManager.getCurrentAudioDevice()->getCurrentSampleRate();
+            // Set current sample rate (from audio device)
+            double currentSampleRate = 44100;
+            AudioIODevice* currentDevice = m_pInstance->audioDeviceManager.getCurrentAudioDevice();
+            if (currentDevice) {
+                std::cout << "-> AudioDeviceManagerSingleton:: F.2" << std::endl;
+                currentSampleRate = currentDevice->getCurrentSampleRate();
+            }
+            m_pInstance->defaultSampleRate = currentSampleRate;
 
-            std::cout << "-> AudioDeviceManagerSingleton:: G" << std::endl;
+            std::cout << "-> AudioDeviceManagerSingleton:: G, currentSampleRate: " << currentSampleRate << std::endl;
 
             // Initialize audio device with specific sample rate
 			juce::String audio_error = m_pInstance->audioDeviceManager.initialise (

--- a/src/Qt/AudioPlaybackThread.cpp
+++ b/src/Qt/AudioPlaybackThread.cpp
@@ -40,15 +40,20 @@ namespace openshot
 	AudioDeviceManagerSingleton *AudioDeviceManagerSingleton::Instance(int rate, int channels)
 	{
 		if (!m_pInstance) {
+		    std::cout << "-> AudioDeviceManagerSingleton:: A" << std::endl;
 			// Create the actual instance of device manager only once
 			m_pInstance = new AudioDeviceManagerSingleton;
 			auto* mgr = &m_pInstance->audioDeviceManager;
+
+            std::cout << "-> AudioDeviceManagerSingleton:: B" << std::endl;
 
 			// Get preferred audio device name and type (if any)
 			auto selected_device = juce::String(
 				Settings::Instance()->PLAYBACK_AUDIO_DEVICE_NAME);
 			auto selected_type = juce::String(
 				Settings::Instance()->PLAYBACK_AUDIO_DEVICE_TYPE);
+
+            std::cout << "-> AudioDeviceManagerSingleton:: C" << std::endl;
 
 			if (selected_type.isEmpty() && !selected_device.isEmpty()) {
 				// Look up type for the selected device
@@ -64,8 +69,12 @@ namespace openshot
 				}
 			}
 
+            std::cout << "-> AudioDeviceManagerSingleton:: D" << std::endl;
+
 			if (!selected_type.isEmpty())
 				m_pInstance->audioDeviceManager.setCurrentAudioDeviceType(selected_type, true);
+
+            std::cout << "-> AudioDeviceManagerSingleton:: E" << std::endl;
 
 			// Settings for audio device playback
             AudioDeviceManager::AudioDeviceSetup deviceSetup = AudioDeviceManager::AudioDeviceSetup();
@@ -73,9 +82,13 @@ namespace openshot
             deviceSetup.inputChannels = 0;
             deviceSetup.outputChannels = channels;
 
+            std::cout << "-> AudioDeviceManagerSingleton:: F" << std::endl;
+
             // Detect default sample rate (of default device)
             m_pInstance->audioDeviceManager.initialiseWithDefaultDevices (0, 2);
             m_pInstance->defaultSampleRate = m_pInstance->audioDeviceManager.getCurrentAudioDevice()->getCurrentSampleRate();
+
+            std::cout << "-> AudioDeviceManagerSingleton:: G" << std::endl;
 
             // Initialize audio device with specific sample rate
 			juce::String audio_error = m_pInstance->audioDeviceManager.initialise (
@@ -87,14 +100,19 @@ namespace openshot
                 &deviceSetup // sample_rate & channels
 			);
 
+            std::cout << "-> AudioDeviceManagerSingleton:: H" << std::endl;
+
 			// Persist any errors detected
 			if (audio_error.isNotEmpty()) {
 				m_pInstance->initialise_error = audio_error.toStdString();
 			} else {
 				m_pInstance->initialise_error = "";
 			}
+
+            std::cout << "-> AudioDeviceManagerSingleton:: I" << std::endl;
 		}
 
+        std::cout << "-> AudioDeviceManagerSingleton:: J" << std::endl;
 		return m_pInstance;
 	}
 
@@ -178,18 +196,28 @@ namespace openshot
 	// Start audio thread
     void AudioPlaybackThread::run()
     {
+        std::cout << "-> AudioPlaybackThread::run() A" << std::endl;
     	while (!threadShouldExit())
     	{
+            std::cout << "-> AudioPlaybackThread::run() B" << std::endl;
     		if (source && !transport.isPlaying() && is_playing) {
+                std::cout << "-> AudioPlaybackThread::run() C" << std::endl;
 
     			// Start new audio device (or get existing one)
                 AudioDeviceManagerSingleton *audioInstance = AudioDeviceManagerSingleton::Instance(sampleRate,
                                                                                                    numChannels);
+
+                std::cout << "-> AudioPlaybackThread::run() D" << std::endl;
+
                 // Add callback
                 audioInstance->audioDeviceManager.addAudioCallback(&player);
 
+                std::cout << "-> AudioPlaybackThread::run() E" << std::endl;
+
     			// Create TimeSliceThread for audio buffering
 				time_thread.startThread();
+
+                std::cout << "-> AudioPlaybackThread::run() F" << std::endl;
 
     			// Connect source to transport
     			transport.setSource(
@@ -201,12 +229,18 @@ namespace openshot
     			transport.setPosition(0);
     			transport.setGain(1.0);
 
+                std::cout << "-> AudioPlaybackThread::run() G" << std::endl;
+
     			// Connect transport to mixer and player
     			mixer.addInputSource(&transport, false);
     			player.setSource(&mixer);
 
+                std::cout << "-> AudioPlaybackThread::run() H" << std::endl;
+
     			// Start the transport
     			transport.start();
+
+                std::cout << "-> AudioPlaybackThread::run() I" << std::endl;
 
     			while (!threadShouldExit() && transport.isPlaying() && is_playing)
 					std::this_thread::sleep_for(std::chrono::milliseconds(2));

--- a/src/Qt/AudioPlaybackThread.cpp
+++ b/src/Qt/AudioPlaybackThread.cpp
@@ -20,6 +20,7 @@
 #include "../AudioDevices.h"
 #include "../Settings.h"
 
+#include <mutex>
 #include <thread>    // for std::this_thread::sleep_for
 #include <chrono>    // for std::chrono::milliseconds
 
@@ -39,6 +40,10 @@ namespace openshot
 	// Create or Get an instance of the device manager singleton (with custom sample rate & channels)
 	AudioDeviceManagerSingleton *AudioDeviceManagerSingleton::Instance(int rate, int channels)
 	{
+        static std::mutex mutex;
+        std::lock_guard<std::mutex> lock(mutex);
+
+        std::cout << "-> AudioDeviceManagerSingleton:: start" << std::endl;
 		if (!m_pInstance) {
 		    std::cout << "-> AudioDeviceManagerSingleton:: A" << std::endl;
 			// Create the actual instance of device manager only once
@@ -69,10 +74,12 @@ namespace openshot
 				}
 			}
 
-            std::cout << "-> AudioDeviceManagerSingleton:: D" << std::endl;
+            std::cout << "-> AudioDeviceManagerSingleton:: D: selected_type: " << selected_type.toStdString() << std::endl;
 
-			if (!selected_type.isEmpty())
-				m_pInstance->audioDeviceManager.setCurrentAudioDeviceType(selected_type, true);
+			if (!selected_type.isEmpty()) {
+                std::cout << "-> AudioDeviceManagerSingleton:: D.1: selected_type: " << selected_type.toStdString() << std::endl;
+                m_pInstance->audioDeviceManager.setCurrentAudioDeviceType(selected_type, true);
+            }
 
             std::cout << "-> AudioDeviceManagerSingleton:: E" << std::endl;
 
@@ -82,10 +89,13 @@ namespace openshot
             deviceSetup.inputChannels = 0;
             deviceSetup.outputChannels = channels;
 
-            std::cout << "-> AudioDeviceManagerSingleton:: F" << std::endl;
+            std::cout << "-> AudioDeviceManagerSingleton:: F: rate: " << rate << ", channels: " << channels << std::endl;
 
             // Detect default sample rate (of default device)
             m_pInstance->audioDeviceManager.initialiseWithDefaultDevices (0, 2);
+
+            std::cout << "-> AudioDeviceManagerSingleton:: F.1" << std::endl;
+
             m_pInstance->defaultSampleRate = m_pInstance->audioDeviceManager.getCurrentAudioDevice()->getCurrentSampleRate();
 
             std::cout << "-> AudioDeviceManagerSingleton:: G" << std::endl;
@@ -112,7 +122,7 @@ namespace openshot
             std::cout << "-> AudioDeviceManagerSingleton:: I" << std::endl;
 		}
 
-        std::cout << "-> AudioDeviceManagerSingleton:: J" << std::endl;
+        std::cout << "-> AudioDeviceManagerSingleton:: end" << std::endl;
 		return m_pInstance;
 	}
 

--- a/src/Qt/AudioPlaybackThread.cpp
+++ b/src/Qt/AudioPlaybackThread.cpp
@@ -193,7 +193,8 @@ namespace openshot
 		{
 			if (source && !transport.isPlaying() && is_playing) {
 				// Start new audio device (or get existing one)
-				AudioDeviceManagerSingleton *audioInstance = AudioDeviceManagerSingleton::Instance(sampleRate,
+				AudioDeviceManagerSingleton *audioInstance = 
+						AudioDeviceManagerSingleton::Instance(sampleRate, numChannels);
 
 				// Add callback
 				audioInstance->audioDeviceManager.addAudioCallback(&player);

--- a/src/Qt/AudioPlaybackThread.cpp
+++ b/src/Qt/AudioPlaybackThread.cpp
@@ -43,22 +43,16 @@ namespace openshot
         static std::mutex mutex;
         std::lock_guard<std::mutex> lock(mutex);
 
-        std::cout << "-> AudioDeviceManagerSingleton:: start" << std::endl;
 		if (!m_pInstance) {
-		    std::cout << "-> AudioDeviceManagerSingleton:: A" << std::endl;
 			// Create the actual instance of device manager only once
 			m_pInstance = new AudioDeviceManagerSingleton;
 			auto* mgr = &m_pInstance->audioDeviceManager;
-
-            std::cout << "-> AudioDeviceManagerSingleton:: B" << std::endl;
 
 			// Get preferred audio device name and type (if any)
 			auto selected_device = juce::String(
 				Settings::Instance()->PLAYBACK_AUDIO_DEVICE_NAME);
 			auto selected_type = juce::String(
 				Settings::Instance()->PLAYBACK_AUDIO_DEVICE_TYPE);
-
-            std::cout << "-> AudioDeviceManagerSingleton:: C" << std::endl;
 
 			if (selected_type.isEmpty() && !selected_device.isEmpty()) {
 				// Look up type for the selected device
@@ -74,14 +68,9 @@ namespace openshot
 				}
 			}
 
-            std::cout << "-> AudioDeviceManagerSingleton:: D: selected_type: " << selected_type.toStdString() << std::endl;
-
 			if (!selected_type.isEmpty()) {
-                std::cout << "-> AudioDeviceManagerSingleton:: D.1: selected_type: " << selected_type.toStdString() << std::endl;
                 m_pInstance->audioDeviceManager.setCurrentAudioDeviceType(selected_type, true);
             }
-
-            std::cout << "-> AudioDeviceManagerSingleton:: E" << std::endl;
 
 			// Settings for audio device playback
             AudioDeviceManager::AudioDeviceSetup deviceSetup = AudioDeviceManager::AudioDeviceSetup();
@@ -89,23 +78,16 @@ namespace openshot
             deviceSetup.inputChannels = 0;
             deviceSetup.outputChannels = channels;
 
-            std::cout << "-> AudioDeviceManagerSingleton:: F: rate: " << rate << ", channels: " << channels << std::endl;
-
             // Detect default sample rate (of default device)
             m_pInstance->audioDeviceManager.initialiseWithDefaultDevices (0, 2);
-
-            std::cout << "-> AudioDeviceManagerSingleton:: F.1" << std::endl;
 
             // Set current sample rate (from audio device)
             double currentSampleRate = 44100;
             AudioIODevice* currentDevice = m_pInstance->audioDeviceManager.getCurrentAudioDevice();
             if (currentDevice) {
-                std::cout << "-> AudioDeviceManagerSingleton:: F.2" << std::endl;
                 currentSampleRate = currentDevice->getCurrentSampleRate();
             }
             m_pInstance->defaultSampleRate = currentSampleRate;
-
-            std::cout << "-> AudioDeviceManagerSingleton:: G, currentSampleRate: " << currentSampleRate << std::endl;
 
             // Initialize audio device with specific sample rate
 			juce::String audio_error = m_pInstance->audioDeviceManager.initialise (
@@ -117,19 +99,13 @@ namespace openshot
                 &deviceSetup // sample_rate & channels
 			);
 
-            std::cout << "-> AudioDeviceManagerSingleton:: H" << std::endl;
-
 			// Persist any errors detected
 			if (audio_error.isNotEmpty()) {
 				m_pInstance->initialise_error = audio_error.toStdString();
 			} else {
 				m_pInstance->initialise_error = "";
 			}
-
-            std::cout << "-> AudioDeviceManagerSingleton:: I" << std::endl;
 		}
-
-        std::cout << "-> AudioDeviceManagerSingleton:: end" << std::endl;
 		return m_pInstance;
 	}
 
@@ -213,28 +189,17 @@ namespace openshot
 	// Start audio thread
     void AudioPlaybackThread::run()
     {
-        std::cout << "-> AudioPlaybackThread::run() A" << std::endl;
     	while (!threadShouldExit())
     	{
-            std::cout << "-> AudioPlaybackThread::run() B" << std::endl;
     		if (source && !transport.isPlaying() && is_playing) {
-                std::cout << "-> AudioPlaybackThread::run() C" << std::endl;
-
     			// Start new audio device (or get existing one)
                 AudioDeviceManagerSingleton *audioInstance = AudioDeviceManagerSingleton::Instance(sampleRate,
-                                                                                                   numChannels);
-
-                std::cout << "-> AudioPlaybackThread::run() D" << std::endl;
 
                 // Add callback
                 audioInstance->audioDeviceManager.addAudioCallback(&player);
 
-                std::cout << "-> AudioPlaybackThread::run() E" << std::endl;
-
     			// Create TimeSliceThread for audio buffering
 				time_thread.startThread();
-
-                std::cout << "-> AudioPlaybackThread::run() F" << std::endl;
 
     			// Connect source to transport
     			transport.setSource(
@@ -246,18 +211,12 @@ namespace openshot
     			transport.setPosition(0);
     			transport.setGain(1.0);
 
-                std::cout << "-> AudioPlaybackThread::run() G" << std::endl;
-
     			// Connect transport to mixer and player
     			mixer.addInputSource(&transport, false);
     			player.setSource(&mixer);
 
-                std::cout << "-> AudioPlaybackThread::run() H" << std::endl;
-
     			// Start the transport
     			transport.start();
-
-                std::cout << "-> AudioPlaybackThread::run() I" << std::endl;
 
     			while (!threadShouldExit() && transport.isPlaying() && is_playing)
 					std::this_thread::sleep_for(std::chrono::milliseconds(2));


### PR DESCRIPTION
Currently, OpenShot 3.0 crashes on Windows 7 and Windows 8.1 during launch (or immediately after launch). I can repeat this in a VM, but I'm not sure if this happens in non-VM environments. We fail to find the default audio device when trying to detect `sample rate`, and need some added protection.