### PR TITLE
Refactoring Audio Device detection (don't crash on Windows, find actual sample rate and device details)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         sys:
           - { os: ubuntu-18.04, shell: bash }
-          - { os: ubuntu-latest, shell: bash }
+          - { os: ubuntu-20.04, shell: bash }
           - { os: windows-2022, shell: 'msys2 {0}' }
         compiler:
           - { cc: gcc, cxx: g++ }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
             libavutil-dev libswscale-dev libswresample-dev \
             libzmq3-dev libmagick++-dev libbabl-dev \
             libopencv-dev libprotobuf-dev protobuf-compiler \
-            cargo
+            cargo libomp5 libomp-dev
           # Install catch2 package from Ubuntu 20.10, since for some reason
           # even 20.04 only has Catch 1.12.1 available.
           wget https://launchpad.net/ubuntu/+archive/primary/+files/catch2_2.13.0-1_all.deb

--- a/src/AudioDevices.cpp
+++ b/src/AudioDevices.cpp
@@ -13,8 +13,6 @@
 
 #include "AudioDevices.h"
 
-#include <OpenShotAudio.h>
-
 using namespace openshot;
 
 using AudioDeviceList = std::vector<std::pair<std::string, std::string>>;
@@ -31,7 +29,7 @@ AudioDeviceList AudioDevices::getNames() {
     auto &types = manager->getAvailableDeviceTypes();
     for (auto* t : types) {
         t->scanForDevices();
-	const auto names = t->getDeviceNames();
+        const auto names = t->getDeviceNames();
         for (const auto& name : names) {
             m_devices.emplace_back(
                 name.toStdString(), t->getTypeName().toStdString());

--- a/src/AudioDevices.h
+++ b/src/AudioDevices.h
@@ -15,6 +15,7 @@
 
 #include <string>
 #include <vector>
+#include <OpenShotAudio.h>
 
 namespace openshot {
 /**
@@ -24,8 +25,18 @@ namespace openshot {
  */
 struct
 AudioDeviceInfo {
-	std::string name;
-	std::string type;
+	juce::String type;
+	juce::String name;
+
+	// Get the std::string device type
+	std::string get_type() {
+		return type.toStdString();
+	}
+
+	// Get the std::string device name
+	std::string get_name() {
+		return name.toStdString();
+	}
 };
 
 using AudioDeviceList = std::vector<std::pair<std::string, std::string>>;
@@ -34,7 +45,7 @@ using AudioDeviceList = std::vector<std::pair<std::string, std::string>>;
 class AudioDevices
 {
 public:
-        AudioDevices() = default;
+		AudioDevices() = default;
 
 	/// Return a vector of std::pair<> objects holding the
 	/// device name and type for each audio device detected

--- a/src/Qt/AudioPlaybackThread.cpp
+++ b/src/Qt/AudioPlaybackThread.cpp
@@ -48,6 +48,10 @@ namespace openshot
 			m_pInstance = new AudioDeviceManagerSingleton;
 			auto* mgr = &m_pInstance->audioDeviceManager;
 			AudioIODevice *foundAudioIODevice = NULL;
+			m_pInstance->initialise_error = "";
+			m_pInstance->currentAudioDevice.name = "";
+			m_pInstance->currentAudioDevice.type = "";
+			m_pInstance->defaultSampleRate = 0.0;
 
 			// Get preferred audio device type and name (if any - these can be blank)
 			openshot::AudioDeviceInfo requested_device = {Settings::Instance()->PLAYBACK_AUDIO_DEVICE_TYPE,

--- a/src/Qt/AudioPlaybackThread.cpp
+++ b/src/Qt/AudioPlaybackThread.cpp
@@ -54,6 +54,9 @@ namespace openshot
 			auto selected_type = juce::String(
 				Settings::Instance()->PLAYBACK_AUDIO_DEVICE_TYPE);
 
+			std::cout << "selected_device (before): " << selected_device.toStdString() << std::endl;
+            std::cout << "selected_type (before): " << selected_type.toStdString() << std::endl;
+
 			if (selected_type.isEmpty() && !selected_device.isEmpty()) {
 				// Look up type for the selected device
 				for (const auto t : mgr->getAvailableDeviceTypes()) {
@@ -68,7 +71,11 @@ namespace openshot
 				}
 			}
 
+            std::cout << "selected_device (after): " << selected_device.toStdString() << std::endl;
+            std::cout << "selected_type (after): " << selected_type.toStdString() << std::endl;
+
 			if (!selected_type.isEmpty()) {
+                std::cout << "setCurrentAudioDeviceType: " << selected_type.toStdString() << std::endl;
 				m_pInstance->audioDeviceManager.setCurrentAudioDeviceType(selected_type, true);
 			}
 
@@ -94,7 +101,7 @@ namespace openshot
 				// Update the audio device setup for the current sample rate
 				m_pInstance->defaultSampleRate = attempt_rate;
 				deviceSetup.sampleRate = attempt_rate;
-				m_pInstance->audioDeviceManager.setAudioDeviceSetup(deviceSetup, false);
+				m_pInstance->audioDeviceManager.setAudioDeviceSetup(deviceSetup, true);
 
 				// Open the audio device with specific sample rate (if possible)
 				// Not all sample rates are supported by audio devices
@@ -121,6 +128,10 @@ namespace openshot
 				if (currentDevice && currentDevice->getCurrentSampleRate() == attempt_rate) {
 					std::cout << "SUCCESS: rate: " << currentDevice->getCurrentSampleRate() << std::endl;
 					break;
+				} else if (currentDevice) {
+                    std::cout << "FAILED: rate does not match: " << currentDevice->getCurrentSampleRate() << std::endl;
+				} else {
+                    std::cout << "FAILED: no device found" << std::endl;
 				}
 			}
 		}

--- a/src/Qt/AudioPlaybackThread.cpp
+++ b/src/Qt/AudioPlaybackThread.cpp
@@ -20,8 +20,9 @@
 #include "../AudioDevices.h"
 #include "../Settings.h"
 
-#include <thread>    // for std::this_thread::sleep_for
-#include <chrono>    // for std::chrono::milliseconds
+#include <mutex>
+#include <thread>	// for std::this_thread::sleep_for
+#include <chrono>	// for std::chrono::milliseconds
 
 using namespace juce;
 
@@ -30,15 +31,18 @@ namespace openshot
 	// Global reference to device manager
 	AudioDeviceManagerSingleton *AudioDeviceManagerSingleton::m_pInstance = NULL;
 
-    // Create or Get audio device singleton with default settings (44100, 2)
-    AudioDeviceManagerSingleton *AudioDeviceManagerSingleton::Instance()
-    {
-        return AudioDeviceManagerSingleton::Instance(44100, 2);
-    }
+	// Create or Get audio device singleton with default settings (44100, 2)
+	AudioDeviceManagerSingleton *AudioDeviceManagerSingleton::Instance()
+	{
+		return AudioDeviceManagerSingleton::Instance(44100, 2);
+	}
 
 	// Create or Get an instance of the device manager singleton (with custom sample rate & channels)
 	AudioDeviceManagerSingleton *AudioDeviceManagerSingleton::Instance(int rate, int channels)
 	{
+		static std::mutex mutex;
+		std::lock_guard<std::mutex> lock(mutex);
+
 		if (!m_pInstance) {
 			// Create the actual instance of device manager only once
 			m_pInstance = new AudioDeviceManagerSingleton;
@@ -64,27 +68,35 @@ namespace openshot
 				}
 			}
 
-			if (!selected_type.isEmpty())
+			if (!selected_type.isEmpty()) {
 				m_pInstance->audioDeviceManager.setCurrentAudioDeviceType(selected_type, true);
+			}
 
 			// Settings for audio device playback
-            AudioDeviceManager::AudioDeviceSetup deviceSetup = AudioDeviceManager::AudioDeviceSetup();
-            deviceSetup.sampleRate = rate;
-            deviceSetup.inputChannels = 0;
-            deviceSetup.outputChannels = channels;
+			AudioDeviceManager::AudioDeviceSetup deviceSetup = AudioDeviceManager::AudioDeviceSetup();
+			deviceSetup.sampleRate = rate;
+			deviceSetup.inputChannels = 0;
+			deviceSetup.outputChannels = channels;
 
-            // Detect default sample rate (of default device)
-            m_pInstance->audioDeviceManager.initialiseWithDefaultDevices (0, 2);
-            m_pInstance->defaultSampleRate = m_pInstance->audioDeviceManager.getCurrentAudioDevice()->getCurrentSampleRate();
+			// Detect default sample rate (of default device)
+			m_pInstance->audioDeviceManager.initialiseWithDefaultDevices (0, 2);
 
-            // Initialize audio device with specific sample rate
+			// Set current sample rate (from audio device)
+			double currentSampleRate = 44100;
+			AudioIODevice* currentDevice = m_pInstance->audioDeviceManager.getCurrentAudioDevice();
+			if (currentDevice) {
+				currentSampleRate = currentDevice->getCurrentSampleRate();
+			}
+			m_pInstance->defaultSampleRate = currentSampleRate;
+
+			// Initialize audio device with specific sample rate
 			juce::String audio_error = m_pInstance->audioDeviceManager.initialise (
-				0,       // number of input channels
-                channels,       // number of output channels
+				0,	   // number of input channels
+				channels,	   // number of output channels
 				nullptr, // no XML settings..
-				true,    // select default device on failure
+				true,	// select default device on failure
 				selected_device, // preferredDefaultDeviceName
-                &deviceSetup // sample_rate & channels
+				&deviceSetup // sample_rate & channels
 			);
 
 			// Persist any errors detected
@@ -94,41 +106,40 @@ namespace openshot
 				m_pInstance->initialise_error = "";
 			}
 		}
-
 		return m_pInstance;
 	}
 
-    // Close audio device
-    void AudioDeviceManagerSingleton::CloseAudioDevice()
-    {
-        // Close Audio Device
-        audioDeviceManager.closeAudioDevice();
-        audioDeviceManager.removeAllChangeListeners();
-        audioDeviceManager.dispatchPendingMessages();
-    }
+	// Close audio device
+	void AudioDeviceManagerSingleton::CloseAudioDevice()
+	{
+		// Close Audio Device
+		audioDeviceManager.closeAudioDevice();
+		audioDeviceManager.removeAllChangeListeners();
+		audioDeviceManager.dispatchPendingMessages();
+	}
 
-    // Constructor
-    AudioPlaybackThread::AudioPlaybackThread(openshot::VideoCacheThread* cache)
+	// Constructor
+	AudioPlaybackThread::AudioPlaybackThread(openshot::VideoCacheThread* cache)
 	: juce::Thread("audio-playback")
 	, player()
 	, transport()
 	, mixer()
 	, source(NULL)
 	, sampleRate(0.0)
-    , numChannels(0)
-    , is_playing(false)
+	, numChannels(0)
+	, is_playing(false)
 	, time_thread("audio-buffer")
 	, videoCache(cache)
-    {
+	{
 	}
 
-    // Destructor
-    AudioPlaybackThread::~AudioPlaybackThread()
-    {
-    }
+	// Destructor
+	AudioPlaybackThread::~AudioPlaybackThread()
+	{
+	}
 
-    // Set the reader object
-    void AudioPlaybackThread::Reader(openshot::ReaderBase *reader) {
+	// Set the reader object
+	void AudioPlaybackThread::Reader(openshot::ReaderBase *reader) {
 		if (source)
 			source->Reader(reader);
 		else {
@@ -148,19 +159,19 @@ namespace openshot
 		Play();
 	}
 
-    // Get the current frame object (which is filling the buffer)
-    std::shared_ptr<openshot::Frame> AudioPlaybackThread::getFrame()
-    {
+	// Get the current frame object (which is filling the buffer)
+	std::shared_ptr<openshot::Frame> AudioPlaybackThread::getFrame()
+	{
 	if (source) return source->getFrame();
 		return std::shared_ptr<openshot::Frame>();
-    }
+	}
 
 	// Seek the audio thread
 	void AudioPlaybackThread::Seek(int64_t new_position)
 	{
-        if (source) {
-            source->Seek(new_position);
-        }
+		if (source) {
+			source->Seek(new_position);
+		}
 	}
 
 	// Play the audio
@@ -176,39 +187,39 @@ namespace openshot
 	}
 
 	// Start audio thread
-    void AudioPlaybackThread::run()
-    {
-    	while (!threadShouldExit())
-    	{
-    		if (source && !transport.isPlaying() && is_playing) {
+	void AudioPlaybackThread::run()
+	{
+		while (!threadShouldExit())
+		{
+			if (source && !transport.isPlaying() && is_playing) {
+				// Start new audio device (or get existing one)
+				AudioDeviceManagerSingleton *audioInstance = 
+						AudioDeviceManagerSingleton::Instance(sampleRate, numChannels);
 
-    			// Start new audio device (or get existing one)
-                AudioDeviceManagerSingleton *audioInstance = AudioDeviceManagerSingleton::Instance(sampleRate,
-                                                                                                   numChannels);
-                // Add callback
-                audioInstance->audioDeviceManager.addAudioCallback(&player);
+				// Add callback
+				audioInstance->audioDeviceManager.addAudioCallback(&player);
 
-    			// Create TimeSliceThread for audio buffering
+				// Create TimeSliceThread for audio buffering
 				time_thread.startThread();
 
-    			// Connect source to transport
-    			transport.setSource(
-    			    source,
-    			    0, // No read ahead buffer
-    			    &time_thread,
-    			    0, // Sample rate correction (none)
-                    numChannels); // max channels
-    			transport.setPosition(0);
-    			transport.setGain(1.0);
+				// Connect source to transport
+				transport.setSource(
+					source,
+					0, // No read ahead buffer
+					&time_thread,
+					0, // Sample rate correction (none)
+					numChannels); // max channels
+				transport.setPosition(0);
+				transport.setGain(1.0);
 
-    			// Connect transport to mixer and player
-    			mixer.addInputSource(&transport, false);
-    			player.setSource(&mixer);
+				// Connect transport to mixer and player
+				mixer.addInputSource(&transport, false);
+				player.setSource(&mixer);
 
-    			// Start the transport
-    			transport.start();
+				// Start the transport
+				transport.start();
 
-    			while (!threadShouldExit() && transport.isPlaying() && is_playing)
+				while (!threadShouldExit() && transport.isPlaying() && is_playing)
 					std::this_thread::sleep_for(std::chrono::milliseconds(2));
 
 				// Stop audio and shutdown transport
@@ -219,7 +230,7 @@ namespace openshot
 				transport.setSource(NULL);
 
 				player.setSource(NULL);
-                audioInstance->audioDeviceManager.removeAudioCallback(&player);
+				audioInstance->audioDeviceManager.removeAudioCallback(&player);
 
 				// Remove source
 				delete source;
@@ -227,8 +238,8 @@ namespace openshot
 
 				// Stop time slice thread
 				time_thread.stopThread(-1);
-    		}
-    	}
+			}
+		}
 
-    }
+	}
 }

--- a/src/Qt/AudioPlaybackThread.cpp
+++ b/src/Qt/AudioPlaybackThread.cpp
@@ -47,93 +47,91 @@ namespace openshot
 			// Create the actual instance of device manager only once
 			m_pInstance = new AudioDeviceManagerSingleton;
 			auto* mgr = &m_pInstance->audioDeviceManager;
+			AudioIODevice *foundAudioIODevice = NULL;
 
-			// Get preferred audio device name and type (if any)
-			auto selected_device = juce::String(
-				Settings::Instance()->PLAYBACK_AUDIO_DEVICE_NAME);
-			auto selected_type = juce::String(
-				Settings::Instance()->PLAYBACK_AUDIO_DEVICE_TYPE);
+			// Get preferred audio device type and name (if any - these can be blank)
+			openshot::AudioDeviceInfo requested_device = {Settings::Instance()->PLAYBACK_AUDIO_DEVICE_TYPE,
+														  Settings::Instance()->PLAYBACK_AUDIO_DEVICE_NAME};
 
-			std::cout << "selected_device (before): " << selected_device.toStdString() << std::endl;
-            std::cout << "selected_type (before): " << selected_type.toStdString() << std::endl;
-
-			if (selected_type.isEmpty() && !selected_device.isEmpty()) {
-				// Look up type for the selected device
+			// Find missing device type (if needed)
+			if (requested_device.type.isEmpty() && !requested_device.name.isEmpty()) {
 				for (const auto t : mgr->getAvailableDeviceTypes()) {
+					t->scanForDevices();
 					for (const auto n : t->getDeviceNames()) {
-						if (selected_device.trim().equalsIgnoreCase(n.trim())) {
-							selected_type = t->getTypeName();
+						if (requested_device.name.trim().equalsIgnoreCase(n.trim())) {
+							requested_device.type = t->getTypeName();
 							break;
 						}
 					}
-					if(!selected_type.isEmpty())
-						break;
 				}
 			}
 
-            std::cout << "selected_device (after): " << selected_device.toStdString() << std::endl;
-            std::cout << "selected_type (after): " << selected_type.toStdString() << std::endl;
-
-			if (!selected_type.isEmpty()) {
-                std::cout << "setCurrentAudioDeviceType: " << selected_type.toStdString() << std::endl;
-				m_pInstance->audioDeviceManager.setCurrentAudioDeviceType(selected_type, true);
+			// Populate all possible device types and device names (starting with the user's requested settings)
+			std::vector<openshot::AudioDeviceInfo> devices{ { requested_device } };
+			for (const auto t : mgr->getAvailableDeviceTypes()) {
+				t->scanForDevices();
+				for (const auto n : t->getDeviceNames()) {
+					AudioDeviceInfo device = { t->getTypeName(), n.trim() };
+					devices.push_back(device);
+				}
 			}
 
-			// Settings for audio device playback
-			AudioDeviceManager::AudioDeviceSetup deviceSetup = AudioDeviceManager::AudioDeviceSetup();
-			deviceSetup.inputChannels = 0;
-			deviceSetup.outputChannels = channels;
-
-			int initial_rate = rate;
-			std::cout << "INITIAL RATE: " << initial_rate << std::endl;
-
-			// Loop through common sample rates, starting with the user's requested rate
-			// Not all sample rates are supported by audio devices, for example, many VMs
-			// do not support 48000 causing no audio device to be found.
-
-			int possible_rates[] { initial_rate, 48000, 44100, 22050 };
-			for(int attempt_rate : possible_rates) {
-				std::cout << "testing rate: " << attempt_rate << std::endl;
+			// Loop through all device combinations (starting with the requested one)
+			for (auto attempt_device : devices) {
+				m_pInstance->currentAudioDevice = attempt_device;
 
 				// Resets everything to a default device setup
 				m_pInstance->audioDeviceManager.initialiseWithDefaultDevices(0, channels);
 
-				// Update the audio device setup for the current sample rate
-				m_pInstance->defaultSampleRate = attempt_rate;
-				deviceSetup.sampleRate = attempt_rate;
-				m_pInstance->audioDeviceManager.setAudioDeviceSetup(deviceSetup, true);
-
-				// Open the audio device with specific sample rate (if possible)
-				// Not all sample rates are supported by audio devices
-				juce::String audio_error = m_pInstance->audioDeviceManager.initialise(
-						0,	   // number of input channels
-						channels,	   // number of output channels
-						nullptr, // no XML settings..
-						true,	// select default device on failure
-						selected_device, // preferredDefaultDeviceName
-						&deviceSetup // sample_rate & channels
-				);
-
-				// Persist any errors detected
-				if (audio_error.isNotEmpty()) {
-					std::cout << "audio_error: " << audio_error.toStdString() << std::endl;
-					m_pInstance->initialise_error = audio_error.toStdString();
-				} else {
-					m_pInstance->initialise_error = "";
+				// Set device type (if any)
+				if (!attempt_device.type.isEmpty()) {
+					m_pInstance->audioDeviceManager.setCurrentAudioDeviceType(attempt_device.type, true);
 				}
 
-				// Determine if audio device was opened successfully, and matches the attempted sample rate
-				// If all rates fail to match, a default audio device and sample rate will be opened if possible
-				AudioIODevice *currentDevice = m_pInstance->audioDeviceManager.getCurrentAudioDevice();
-				if (currentDevice && currentDevice->getCurrentSampleRate() == attempt_rate) {
-					std::cout << "SUCCESS: rate: " << currentDevice->getCurrentSampleRate() << std::endl;
+				// Settings for audio device playback
+				AudioDeviceManager::AudioDeviceSetup deviceSetup = AudioDeviceManager::AudioDeviceSetup();
+				deviceSetup.inputChannels = 0;
+				deviceSetup.outputChannels = channels;
+
+				// Loop through common sample rates, starting with the user's requested rate
+				// Not all sample rates are supported by audio devices, for example, many VMs
+				// do not support 48000 causing no audio device to be found.
+				int possible_rates[] { rate, 48000, 44100, 22050 };
+				for(int attempt_rate : possible_rates) {
+					// Update the audio device setup for the current sample rate
+					m_pInstance->defaultSampleRate = attempt_rate;
+					deviceSetup.sampleRate = attempt_rate;
+					m_pInstance->audioDeviceManager.setAudioDeviceSetup(deviceSetup, true);
+
+					// Open the audio device with specific sample rate (if possible)
+					// Not all sample rates are supported by audio devices
+					juce::String audio_error = m_pInstance->audioDeviceManager.initialise(
+							0,		 // number of input channels
+							channels,					 // number of output channels
+							nullptr,		   // no XML settings..
+							true, // select default device on failure
+							attempt_device.name,  // preferredDefaultDeviceName
+							&deviceSetup				 // sample_rate & channels
+					);
+
+					// Persist any errors detected
+					m_pInstance->initialise_error = audio_error.toStdString();
+
+					// Determine if audio device was opened successfully, and matches the attempted sample rate
+					// If all rates fail to match, a default audio device and sample rate will be opened if possible
+					foundAudioIODevice = m_pInstance->audioDeviceManager.getCurrentAudioDevice();
+					if (foundAudioIODevice && foundAudioIODevice->getCurrentSampleRate() == attempt_rate) {
+						// Successfully tested a sample rate
+						break;
+					}
+				}
+
+				if (foundAudioIODevice) {
+					// Successfully opened an audio device
 					break;
-				} else if (currentDevice) {
-                    std::cout << "FAILED: rate does not match: " << currentDevice->getCurrentSampleRate() << std::endl;
-				} else {
-                    std::cout << "FAILED: no device found" << std::endl;
 				}
 			}
+
 		}
 		return m_pInstance;
 	}
@@ -145,6 +143,9 @@ namespace openshot
 		audioDeviceManager.closeAudioDevice();
 		audioDeviceManager.removeAllChangeListeners();
 		audioDeviceManager.dispatchPendingMessages();
+
+		delete m_pInstance;
+		m_pInstance = NULL;
 	}
 
 	// Constructor
@@ -178,7 +179,6 @@ namespace openshot
 		}
 
 		// Set local vars
-		std::cout << "AudioPlaybackThread sample rate: " << reader->info.sample_rate << std::endl;
 		sampleRate = reader->info.sample_rate;
 		numChannels = reader->info.channels;
 

--- a/src/Qt/AudioPlaybackThread.cpp
+++ b/src/Qt/AudioPlaybackThread.cpp
@@ -77,11 +77,17 @@ namespace openshot
 			deviceSetup.inputChannels = 0;
 			deviceSetup.outputChannels = channels;
 
+			int initial_rate = rate;
+			std::cout << "INITIAL RATE: " << initial_rate << std::endl;
+
 			// Loop through common sample rates, starting with the user's requested rate
 			// Not all sample rates are supported by audio devices, for example, many VMs
 			// do not support 48000 causing no audio device to be found.
-			int possible_rates[] = { rate, 48000, 44100, 22050 };
+
+			int possible_rates[] { initial_rate, 48000, 44100, 22050 };
 			for(int attempt_rate : possible_rates) {
+				std::cout << "testing rate: " << attempt_rate << std::endl;
+
 				// Resets everything to a default device setup
 				m_pInstance->audioDeviceManager.initialiseWithDefaultDevices(0, channels);
 
@@ -89,8 +95,6 @@ namespace openshot
 				m_pInstance->defaultSampleRate = attempt_rate;
 				deviceSetup.sampleRate = attempt_rate;
 				m_pInstance->audioDeviceManager.setAudioDeviceSetup(deviceSetup, false);
-
-				std::cout << "testing rate: " << attempt_rate << std::endl;
 
 				// Open the audio device with specific sample rate (if possible)
 				// Not all sample rates are supported by audio devices
@@ -163,6 +167,7 @@ namespace openshot
 		}
 
 		// Set local vars
+		std::cout << "AudioPlaybackThread sample rate: " << reader->info.sample_rate << std::endl;
 		sampleRate = reader->info.sample_rate;
 		numChannels = reader->info.channels;
 

--- a/src/Qt/AudioPlaybackThread.h
+++ b/src/Qt/AudioPlaybackThread.h
@@ -35,6 +35,7 @@ class Frame;
 class PlayerPrivate;
 class QtPlayer;
 
+
 /**
  *  @brief Singleton wrapper for AudioDeviceManager (to prevent multiple instances).
  */
@@ -51,14 +52,17 @@ public:
 		std::string initialise_error;
 
 		/// Default sample rate (as detected)
-        double defaultSampleRate;
+		double defaultSampleRate;
+
+		/// Current open audio device (or last attempted device - if none were successful)
+		AudioDeviceInfo currentAudioDevice;
 
 		/// Override with default sample rate & channels (44100, 2) and no preferred audio device
 		static AudioDeviceManagerSingleton* Instance();
 
-        /// Override with custom sample rate & channels and no preferred audio device
-        /// sample rate and channels are only set on 1st call (when singleton is created)
-        static AudioDeviceManagerSingleton* Instance(int rate, int channels);
+		/// Override with custom sample rate & channels and no preferred audio device
+		/// sample rate and channels are only set on 1st call (when singleton is created)
+		static AudioDeviceManagerSingleton* Instance(int rate, int channels);
 
 		/// Public device manager property
 		juce::AudioDeviceManager audioDeviceManager;
@@ -67,11 +71,11 @@ public:
 		void CloseAudioDevice();
 	};
 
-    /**
-     *  @brief The audio playback thread
-     */
-    class AudioPlaybackThread : juce::Thread
-    {
+	/**
+	 *  @brief The audio playback thread
+	 */
+	class AudioPlaybackThread : juce::Thread
+	{
 		juce::AudioSourcePlayer player;
 		juce::AudioTransportSource transport;
 		juce::MixerAudioSource mixer;
@@ -81,7 +85,7 @@ public:
 		juce::WaitableEvent play;
 		bool is_playing;
 		juce::TimeSliceThread time_thread;
-        openshot::VideoCacheThread *videoCache; /// The cache thread (for pre-roll checking)
+		openshot::VideoCacheThread *videoCache; /// The cache thread (for pre-roll checking)
 
 		/// Constructor
 		AudioPlaybackThread(openshot::VideoCacheThread* cache);
@@ -112,23 +116,29 @@ public:
 		/// Get Speed (The speed and direction to playback a reader (1=normal, 2=fast, 3=faster, -1=rewind, etc...)
 		int getSpeed() const { if (source) return source->getSpeed(); else return 1; }
 
-		/// Get Audio Error (if any)
+		/// Get audio initialization errors (if any)
 		std::string getError()
 		{
-		    return AudioDeviceManagerSingleton::Instance()->initialise_error;
+			return AudioDeviceManagerSingleton::Instance()->initialise_error;
 		}
 
-		/// Get detected audio sample rate (from default device)
+		/// Get detected audio sample rate (from active, open audio device)
 		double getDefaultSampleRate()
-        {
-            return AudioDeviceManagerSingleton::Instance()->defaultSampleRate;
-        }
-
-		/// Get Audio Device Names (if any)
-		std::vector<std::pair<std::string, std::string>> getAudioDeviceNames()
 		{
-                    AudioDevices devs;
-		    return devs.getNames();
+			return AudioDeviceManagerSingleton::Instance()->defaultSampleRate;
+		}
+
+		/// Get active, open audio device (or last attempted device if none were successful)
+		AudioDeviceInfo getCurrentAudioDevice()
+		{
+			return AudioDeviceManagerSingleton::Instance()->currentAudioDevice;
+		}
+
+		/// Get vector of audio device names & types
+		AudioDeviceList getAudioDeviceNames()
+		{
+			AudioDevices devs;
+			return devs.getNames();
 		};
 
 		friend class PlayerPrivate;

--- a/src/QtPlayer.cpp
+++ b/src/QtPlayer.cpp
@@ -71,10 +71,15 @@ namespace openshot
         }
     }
 
-    /// Get Audio Devices from JUCE
+    /// Get vector of audio device names & types
     AudioDeviceList QtPlayer::GetAudioDeviceNames() {
         AudioDevices devs;
         return devs.getNames();
+    }
+
+    // Get current audio device or last attempted (if none succeeded)
+    AudioDeviceInfo QtPlayer::GetCurrentAudioDevice() {
+        return p->audioPlayback->getCurrentAudioDevice();
     }
 
     // Set the source JSON of an openshot::Timelime

--- a/src/QtPlayer.h
+++ b/src/QtPlayer.h
@@ -23,18 +23,18 @@
 
 namespace openshot
 {
-    using AudioDeviceList = std::vector<std::pair<std::string, std::string>>;
+	using AudioDeviceList = std::vector<std::pair<std::string, std::string>>;
 
-    /**
-     * @brief This class is used to playback a video from a reader.
-     *
-     */
-    class QtPlayer : public openshot::PlayerBase
-    {
+	/**
+	 * @brief This class is used to playback a video from a reader.
+	 *
+	 */
+	class QtPlayer : public openshot::PlayerBase
+	{
 	openshot::PlayerPrivate *p;
 	bool threads_started;
 
-    public:
+	public:
 	/// Default constructor
 	explicit QtPlayer();
 	explicit QtPlayer(openshot::RendererBase *rb);
@@ -48,11 +48,14 @@ namespace openshot
 	/// Get Error (if any)
 	std::string GetError();
 
-    /// Return the default audio sample rate (from the system)
-    double GetDefaultSampleRate();
+	/// Return the default audio sample rate (from the system)
+	double GetDefaultSampleRate();
 
 	/// Get Audio Devices from JUCE
 	AudioDeviceList GetAudioDeviceNames();
+
+	/// Get current audio device or last attempted
+	AudioDeviceInfo GetCurrentAudioDevice();
 
 	/// Play the video
 	void Play();
@@ -76,7 +79,7 @@ namespace openshot
 	void SetSource(const std::string &source);
 
 	/// Set the source JSON of an openshot::Timelime
-    void SetTimelineSource(const std::string &json);
+	void SetTimelineSource(const std::string &json);
 
 	/// Set the QWidget which will be used as the display (note: QLabel works well). This does not take a
 	/// normal pointer, but rather a LONG pointer id (and it re-casts the QWidget pointer inside libopenshot).
@@ -106,7 +109,7 @@ namespace openshot
 
 	/// Set the Volume (1.0 = normal volume, <1.0 = quieter, >1.0 louder)
 	void Volume(float new_volume);
-    };
+	};
 }
 
 #endif

--- a/src/ZmqLogger.cpp
+++ b/src/ZmqLogger.cpp
@@ -170,7 +170,6 @@ void ZmqLogger::Close()
 
 	// Terminate zmq threads
 	if (context != NULL) {
-        context->shutdown();
         context->close();
 	}
 }

--- a/src/ZmqLogger.cpp
+++ b/src/ZmqLogger.cpp
@@ -167,6 +167,12 @@ void ZmqLogger::Close()
 		publisher->close();
 		publisher = NULL;
 	}
+
+	// Terminate zmq threads
+	if (context != NULL) {
+        context->shutdown();
+        context->close();
+	}
 }
 
 // Append debug information

--- a/tests/AudioDeviceManager.cpp
+++ b/tests/AudioDeviceManager.cpp
@@ -24,9 +24,12 @@ TEST_CASE( "Initialize Audio Device Manager Singleton", "[libopenshot][AudioDevi
 
     // Invalid sample rate
     AudioDeviceManagerSingleton *mng = AudioDeviceManagerSingleton::Instance(12300, 2);
-    if (mng->initialise_error.empty()) {
-        // Ignore systems with "No Driver" returned in the audio device error
-        CHECK((mng->defaultSampleRate == 48000 || mng->defaultSampleRate == 44100)); // verify common rate is returned
+    double detected_sample_rate = mng->defaultSampleRate;
+
+    // Ignore systems that fail to find a valid audio device (i.e. build servers w/no sound card)
+    if (mng->initialise_error.empty() && detected_sample_rate >= 44100.0) {
+        // Verify invalid sample rate not found
+        CHECK(detected_sample_rate != 12300); // verify common rate is returned
         mng->CloseAudioDevice();
 
         // Valid sample rate

--- a/tests/AudioDeviceManager.cpp
+++ b/tests/AudioDeviceManager.cpp
@@ -1,0 +1,55 @@
+/**
+ * @file
+ * @brief Unit tests for openshot::AudioDeviceManagerSingleton
+ * @author Jonathan Thomas <jonathan@openshot.org>
+ *
+ * @ref License
+ */
+
+// Copyright (c) 2008-2022 OpenShot Studios, LLC
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "openshot_catch.h"
+#include "Settings.h"
+#include "Qt/AudioPlaybackThread.h"
+
+
+using namespace openshot;
+
+TEST_CASE( "Initialize Audio Device Manager Singleton", "[libopenshot][AudioDeviceManagerSingleton]" )
+{
+    Settings::Instance()->PLAYBACK_AUDIO_DEVICE_TYPE = "";
+    Settings::Instance()->PLAYBACK_AUDIO_DEVICE_NAME = "";
+
+    // Invalid sample rate
+    AudioDeviceManagerSingleton *mng = AudioDeviceManagerSingleton::Instance(12300, 2);
+    if (mng->initialise_error.empty()) {
+        // Ignore systems with "No Driver" returned in the audio device error
+        CHECK((mng->defaultSampleRate == 48000 || mng->defaultSampleRate == 44100)); // verify common rate is returned
+        mng->CloseAudioDevice();
+
+        // Valid sample rate
+        mng = AudioDeviceManagerSingleton::Instance(44100, 2);
+        CHECK(mng->defaultSampleRate == 44100);
+        mng->CloseAudioDevice();
+
+        // Valid device type (for Linux)
+        Settings::Instance()->PLAYBACK_AUDIO_DEVICE_TYPE = "ALSA";
+        Settings::Instance()->PLAYBACK_AUDIO_DEVICE_NAME = "Playback/recording through the PulseAudio sound server";
+        mng = AudioDeviceManagerSingleton::Instance(44100, 2);
+        if (mng->currentAudioDevice.get_name() == Settings::Instance()->PLAYBACK_AUDIO_DEVICE_NAME &&
+            mng->currentAudioDevice.get_type() == Settings::Instance()->PLAYBACK_AUDIO_DEVICE_TYPE) {
+            // Only check this device if it exists (i.e. we are on Linux with ALSA and PulseAudio)
+            CHECK(mng->defaultSampleRate == 44100);
+            mng->CloseAudioDevice();
+        }
+
+        // Invalid device type (for Linux)
+        Settings::Instance()->PLAYBACK_AUDIO_DEVICE_TYPE = "Fake Type";
+        Settings::Instance()->PLAYBACK_AUDIO_DEVICE_NAME = "Fake Device";
+        mng = AudioDeviceManagerSingleton::Instance(44100, 2);
+        CHECK(mng->defaultSampleRate == 44100);
+        mng->CloseAudioDevice();
+    }
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -20,6 +20,7 @@ file(TO_NATIVE_PATH "${PROJECT_SOURCE_DIR}/examples/" TEST_MEDIA_PATH)
 ###  TEST SOURCE FILES
 ###
 set(OPENSHOT_TESTS
+  AudioDeviceManager
   AudioWaveformer
   CacheDisk
   CacheMemory


### PR DESCRIPTION
- Fixing a crash on Windows 7/8.1
- Refactor of Audio Device Manager
- Find the 1st valid audio device, if requested device is not valid or not available
- New method to return current active audio device