### PR TITLE
Fix Transition/Mask `replace_image` Property

### DIFF
--- a/src/effects/ColorShift.cpp
+++ b/src/effects/ColorShift.cpp
@@ -112,10 +112,10 @@ std::shared_ptr<openshot::Frame> ColorShift::GetFrame(std::shared_ptr<openshot::
 			blue_starting_row_index = starting_row_index;
 			alpha_starting_row_index = starting_row_index;
 
-			red_pixel_offset = 0;
-			green_pixel_offset = 0;
-			blue_pixel_offset = 0;
-			alpha_pixel_offset = 0;
+			red_pixel_offset = col;
+			green_pixel_offset = col;
+			blue_pixel_offset = col;
+			alpha_pixel_offset = col;
 
 			// Get the RGBA value from each pixel (depending on offset)
 			R = temp_image[byte_index];

--- a/src/effects/Mask.cpp
+++ b/src/effects/Mask.cpp
@@ -123,10 +123,10 @@ std::shared_ptr<openshot::Frame> Mask::GetFrame(std::shared_ptr<openshot::Frame>
 		// Set the alpha channel to the gray value
 		if (replace_image) {
 			// Replace frame pixels with gray value (including alpha channel)
-			pixels[byte_index + 0] = gray_value;
-			pixels[byte_index + 1] = gray_value;
-			pixels[byte_index + 2] = gray_value;
-			pixels[byte_index + 3] = gray_value;
+			pixels[byte_index + 0] = constrain(255 * alpha_percent);
+			pixels[byte_index + 1] = constrain(255 * alpha_percent);
+			pixels[byte_index + 2] = constrain(255 * alpha_percent);
+			pixels[byte_index + 3] = constrain(255 * alpha_percent);
 		} else {
 			// Mulitply new alpha value with all the colors (since we are using a premultiplied
 			// alpha format)


### PR DESCRIPTION
This fixes a regression from a recent change to the Mask effect, which broke the `replace_image` property.