### PR TITLE
fix package name per https://packages.msys2.org/package/mingw-w64-x86_64-python3-PyOpenGL

### DIFF
--- a/doc/INSTALL-WINDOWS.md
+++ b/doc/INSTALL-WINDOWS.md
@@ -204,7 +204,7 @@ pacman -S mingw64/mingw-w64-x86_64-python3-pyzmq
 pacman -S mingw64/mingw-w64-x86_64-python3-cx_Freeze
 pacman -S mingw64/mingw-w64-x86_64-ninja
 pacman -S mingw64/mingw-w64-x86_64-catch
-pacman -S mingw-w64-x86_64-python3-pyopengl
+pacman -S mingw-w64-x86_64-python3-PyOpenGL
 pacman -S mingw-w64-clang-x86_64-python-pyopengl-accelerate
 pacman -S mingw-w64-x86_64-python-pyopengl-accelerate
 pacman -S mingw-w64-x86_64-python-pywin32


### PR DESCRIPTION
The lowercase version wasn't working for me (fresh Windows 10 installation).