### PR TITLE
Fix Memory leaks in FFmpegReader, Clip, and FrameMapper

### DIFF
--- a/src/Clip.cpp
+++ b/src/Clip.cpp
@@ -95,9 +95,6 @@ void Clip::init_settings()
 
 	// Init reader info struct
 	init_reader_settings();
-
-	// Init cache
-	final_cache.SetMaxBytesFromInfo(10, info.width, info.height, info.sample_rate, info.channels);
 }
 
 // Init reader info details
@@ -108,6 +105,9 @@ void Clip::init_reader_settings() {
 
 		// Initialize info struct
 		info = reader->info;
+
+		// Init cache
+		final_cache.SetMaxBytesFromInfo(8, info.width, info.height, info.sample_rate, info.channels);
 	}
 }
 

--- a/src/FrameMapper.cpp
+++ b/src/FrameMapper.cpp
@@ -491,7 +491,8 @@ std::shared_ptr<Frame> FrameMapper::GetFrame(int64_t requested_frame)
 		if (info.sample_rate == mapped_frame->SampleRate() &&
 			info.channels == mapped_frame->GetAudioChannelsCount() &&
 			info.channel_layout == mapped_frame->ChannelsLayout() &&
-			mapped.Samples.total == mapped_frame->GetAudioSamplesCount() == samples_in_frame && is_increasing &&
+			mapped.Samples.total == mapped_frame->GetAudioSamplesCount() &&
+			mapped.Samples.total == samples_in_frame && is_increasing &&
 			mapped.Samples.frame_start == mapped.Odd.Frame &&
 			mapped.Samples.sample_start == 0 &&
 			mapped_frame->number == frame_number &&// in some conditions (e.g. end of stream)


### PR DESCRIPTION
Due to a recent regression, and some investigating into memory leaks (thanks to Valgrind), we found and fixed 3 serious memory leaks in libopenshot. 

- AVFRAME in FFmpegReader::ProcessVideoPacket - initializing struct, but not deleting it if the packet was not ready
- AVFRAME in FFmpegReader::ProcessAudioPacket - initializing struct, but not deleting it if the packet was not ready
- Clip::final_cache was not being initialized correctly, and was defaulting to **infinite** Clip cache - always growing as large as the # of frames in the clip - oops - large leak