### PR TITLE
Release 0.3.1 (SO 24)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,8 +24,8 @@ For more information, please visit <http://www.openshot.org/>.
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/Modules")
 
 ################ PROJECT VERSION ####################
-set(PROJECT_VERSION_FULL "0.3.0")
-set(PROJECT_SO_VERSION 23)
+set(PROJECT_VERSION_FULL "0.3.1")
+set(PROJECT_SO_VERSION 24)
 
 # Remove the dash and anything following, to get the #.#.# version for project()
 STRING(REGEX REPLACE "\-.*$" "" VERSION_NUM "${PROJECT_VERSION_FULL}")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -176,7 +176,7 @@ target_include_directories(openshot
 # Find JUCE-based openshot Audio libraries
 if(NOT TARGET OpenShot::Audio)
   # Only load if necessary (not for integrated builds)
-  find_package(OpenShotAudio 0.3.0 REQUIRED)
+  find_package(OpenShotAudio 0.3.1 REQUIRED)
 endif()
 target_link_libraries(openshot PUBLIC OpenShot::Audio)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -176,7 +176,7 @@ target_include_directories(openshot
 # Find JUCE-based openshot Audio libraries
 if(NOT TARGET OpenShot::Audio)
   # Only load if necessary (not for integrated builds)
-  find_package(OpenShotAudio 0.3.1 REQUIRED)
+  find_package(OpenShotAudio 0.3.0...0.3.1 REQUIRED)
 endif()
 target_link_libraries(openshot PUBLIC OpenShot::Audio)
 

--- a/src/effects/Caption.cpp
+++ b/src/effects/Caption.cpp
@@ -27,7 +27,7 @@
 using namespace openshot;
 
 /// Blank constructor, useful when using Json to load the effect properties
-Caption::Caption() : color("#ffffff"), stroke("#a9a9a9"), background("#ff000000"), background_alpha(0.0), left(0.1), top(0.70), right(0.1),
+Caption::Caption() : color("#ffffff"), stroke("#a9a9a9"), background("#ff000000"), background_alpha(0.0), left(0.1), top(0.72), right(0.1),
 					 stroke_width(0.5), font_size(20.0), font_alpha(1.0), is_dirty(true), font_name("sans"), font(NULL), metrics(NULL),
 					 fade_in(0.35), fade_out(0.35), background_corner(10.0), background_padding(20.0), line_spacing(1.0)
 {
@@ -37,9 +37,10 @@ Caption::Caption() : color("#ffffff"), stroke("#a9a9a9"), background("#ff000000"
 
 // Default constructor
 Caption::Caption(std::string captions) :
-		color("#ffffff"), caption_text(captions), stroke("#a9a9a9"), background("#ff000000"), background_alpha(0.0),
-		left(0.1), top(0.70), right(0.1), stroke_width(0.5), font_size(20.0), font_alpha(1.0), is_dirty(true), font_name("sans"),
-		font(NULL), metrics(NULL), fade_in(0.35), fade_out(0.35), background_corner(10.0), background_padding(20.0), line_spacing(1.0)
+		color("#ffffff"), stroke("#a9a9a9"), background("#ff000000"), background_alpha(0.0), left(0.1), top(0.72), right(0.1),
+		stroke_width(0.5), font_size(20.0), font_alpha(1.0), is_dirty(true), font_name("sans"), font(NULL), metrics(NULL),
+		fade_in(0.35), fade_out(0.35), background_corner(10.0), background_padding(20.0), line_spacing(1.0),
+		caption_text(captions)
 {
 	// Init effect properties
 	init_effect_details();
@@ -116,7 +117,7 @@ std::shared_ptr<openshot::Frame> Caption::GetFrame(std::shared_ptr<openshot::Fra
 	Clip* clip = (Clip*) ParentClip();
 	Timeline* timeline = NULL;
 	Fraction fps;
-	double scale_factor = 1.0; // amount of scaling needed for text (based on preview window size)
+
 	if (clip && clip->ParentTimeline() != NULL) {
 		timeline = (Timeline*) clip->ParentTimeline();
 	} else if (this->ParentTimeline() != NULL) {
@@ -125,18 +126,17 @@ std::shared_ptr<openshot::Frame> Caption::GetFrame(std::shared_ptr<openshot::Fra
 
 	// Get the FPS from the parent object (Timeline or Clip's Reader)
 	if (timeline != NULL) {
-		fps.num = timeline->info.fps.num;
-		fps.den = timeline->info.fps.den;
-		// preview window is sometimes smaller/larger than the timeline size
-		scale_factor = (double) timeline->preview_width / (double) timeline->info.width;
+		fps = timeline->info.fps;
 	} else if (clip != NULL && clip->Reader() != NULL) {
-		fps.num = clip->Reader()->info.fps.num;
-		fps.den = clip->Reader()->info.fps.den;
-		scale_factor = 1.0;
+		fps = clip->Reader()->info.fps;
 	}
 
 	// Get the frame's image
 	std::shared_ptr<QImage> frame_image = frame->GetImage();
+
+	// Calculate scale factor, to keep different resolutions from
+	// having dramatically different font sizes
+	double timeline_scale_factor = frame->GetImage()->width() / 1280.0;
 
 	// Load timeline's new frame image into a QPainter
 	QPainter painter(frame_image.get());
@@ -146,7 +146,7 @@ std::shared_ptr<openshot::Frame> Caption::GetFrame(std::shared_ptr<openshot::Fra
 	painter.setCompositionMode(QPainter::CompositionMode_SourceOver);
 
 	// Font options and metrics for caption text
-	double font_size_value = font_size.GetValue(frame_number) * device_pixel_ratio;
+	double font_size_value = font_size.GetValue(frame_number) * device_pixel_ratio * timeline_scale_factor;
 	QFont font(QString(font_name.c_str()), int(font_size_value));
 	font.setPointSizeF(std::max(font_size_value, 1.0));
 	QFontMetricsF metrics = QFontMetricsF(font);
@@ -157,9 +157,9 @@ std::shared_ptr<openshot::Frame> Caption::GetFrame(std::shared_ptr<openshot::Fra
 	double fade_in_value = fade_in.GetValue(frame_number) * fps.ToDouble();
 	double fade_out_value = fade_out.GetValue(frame_number) * fps.ToDouble();
 	double right_value = right.GetValue(frame_number);
-	double background_corner_value = background_corner.GetValue(frame_number) * scale_factor;
-	double padding_value = background_padding.GetValue(frame_number) * scale_factor;
-	double stroke_width_value = stroke_width.GetValue(frame_number) * scale_factor;
+	double background_corner_value = background_corner.GetValue(frame_number) * timeline_scale_factor;
+	double padding_value = background_padding.GetValue(frame_number) * timeline_scale_factor;
+	double stroke_width_value = stroke_width.GetValue(frame_number) * timeline_scale_factor;
 	double line_spacing_value = line_spacing.GetValue(frame_number);
 	double metrics_line_spacing = metrics.lineSpacing();
 

--- a/src/effects/Caption.cpp
+++ b/src/effects/Caption.cpp
@@ -15,6 +15,7 @@
 #include "../Clip.h"
 #include "../Timeline.h"
 
+#include <QGuiApplication>
 #include <QString>
 #include <QPoint>
 #include <QRect>
@@ -26,8 +27,8 @@
 using namespace openshot;
 
 /// Blank constructor, useful when using Json to load the effect properties
-Caption::Caption() : color("#ffffff"), stroke("#a9a9a9"), background("#ff000000"), background_alpha(0.0), left(0.15), top(0.7), right(0.15),
-					 stroke_width(0.5), font_size(30.0), font_alpha(1.0), is_dirty(true), font_name("sans"), font(NULL), metrics(NULL),
+Caption::Caption() : color("#ffffff"), stroke("#a9a9a9"), background("#ff000000"), background_alpha(0.0), left(0.1), top(0.75), right(0.1),
+					 stroke_width(0.5), font_size(20.0), font_alpha(1.0), is_dirty(true), font_name("sans"), font(NULL), metrics(NULL),
 					 fade_in(0.35), fade_out(0.35), background_corner(10.0), background_padding(20.0), line_spacing(1.0)
 {
 	// Init effect properties
@@ -37,7 +38,7 @@ Caption::Caption() : color("#ffffff"), stroke("#a9a9a9"), background("#ff000000"
 // Default constructor
 Caption::Caption(std::string captions) :
 		color("#ffffff"), caption_text(captions), stroke("#a9a9a9"), background("#ff000000"), background_alpha(0.0),
-		left(0.15), top(0.7), right(0.15), stroke_width(0.5), font_size(30.0), font_alpha(1.0), is_dirty(true), font_name("sans"),
+		left(0.1), top(0.75), right(0.1), stroke_width(0.5), font_size(20.0), font_alpha(1.0), is_dirty(true), font_name("sans"),
 		font(NULL), metrics(NULL), fade_in(0.35), fade_out(0.35), background_corner(10.0), background_padding(20.0), line_spacing(1.0)
 {
 	// Init effect properties
@@ -108,6 +109,9 @@ std::shared_ptr<openshot::Frame> Caption::GetFrame(std::shared_ptr<openshot::Fra
 	// Process regex (if needed)
 	process_regex();
 
+	// Get largest pixel ratio (of screen)
+	double device_pixel_ratio = qGuiApp->devicePixelRatio();
+
 	// Get the Clip and Timeline pointers (if available)
 	Clip* clip = (Clip*) ParentClip();
 	Timeline* timeline = NULL;
@@ -142,7 +146,7 @@ std::shared_ptr<openshot::Frame> Caption::GetFrame(std::shared_ptr<openshot::Fra
 	painter.setCompositionMode(QPainter::CompositionMode_SourceOver);
 
 	// Font options and metrics for caption text
-	double font_size_value = font_size.GetValue(frame_number) * scale_factor;
+	double font_size_value = font_size.GetValue(frame_number) * device_pixel_ratio;
 	QFont font(QString(font_name.c_str()), int(font_size_value));
 	font.setPointSizeF(std::max(font_size_value, 1.0));
 	QFontMetricsF metrics = QFontMetricsF(font);

--- a/src/effects/Caption.cpp
+++ b/src/effects/Caption.cpp
@@ -27,8 +27,8 @@
 using namespace openshot;
 
 /// Blank constructor, useful when using Json to load the effect properties
-Caption::Caption() : color("#ffffff"), stroke("#a9a9a9"), background("#ff000000"), background_alpha(0.0), left(0.1), top(0.72), right(0.1),
-					 stroke_width(0.5), font_size(20.0), font_alpha(1.0), is_dirty(true), font_name("sans"), font(NULL), metrics(NULL),
+Caption::Caption() : color("#ffffff"), stroke("#a9a9a9"), background("#ff000000"), background_alpha(0.0), left(0.1), top(0.75), right(0.1),
+					 stroke_width(0.5), font_size(30.0), font_alpha(1.0), is_dirty(true), font_name("sans"), font(NULL), metrics(NULL),
 					 fade_in(0.35), fade_out(0.35), background_corner(10.0), background_padding(20.0), line_spacing(1.0)
 {
 	// Init effect properties
@@ -37,8 +37,8 @@ Caption::Caption() : color("#ffffff"), stroke("#a9a9a9"), background("#ff000000"
 
 // Default constructor
 Caption::Caption(std::string captions) :
-		color("#ffffff"), stroke("#a9a9a9"), background("#ff000000"), background_alpha(0.0), left(0.1), top(0.72), right(0.1),
-		stroke_width(0.5), font_size(20.0), font_alpha(1.0), is_dirty(true), font_name("sans"), font(NULL), metrics(NULL),
+		color("#ffffff"), stroke("#a9a9a9"), background("#ff000000"), background_alpha(0.0), left(0.1), top(0.75), right(0.1),
+		stroke_width(0.5), font_size(30.0), font_alpha(1.0), is_dirty(true), font_name("sans"), font(NULL), metrics(NULL),
 		fade_in(0.35), fade_out(0.35), background_corner(10.0), background_padding(20.0), line_spacing(1.0),
 		caption_text(captions)
 {
@@ -133,7 +133,7 @@ std::shared_ptr<openshot::Frame> Caption::GetFrame(std::shared_ptr<openshot::Fra
 
 	// Calculate scale factor, to keep different resolutions from
 	// having dramatically different font sizes
-	double timeline_scale_factor = frame->GetImage()->width() / 1280.0;
+	double timeline_scale_factor = frame->GetImage()->width() / 600.0;
 
 	// Load timeline's new frame image into a QPainter
 	QPainter painter(frame_image.get());
@@ -143,11 +143,10 @@ std::shared_ptr<openshot::Frame> Caption::GetFrame(std::shared_ptr<openshot::Fra
 	painter.setCompositionMode(QPainter::CompositionMode_SourceOver);
 
 	// Font options and metrics for caption text
-	double font_size_value = font_size.GetValue(frame_number) * timeline_scale_factor * qGuiApp->devicePixelRatio();
+	double font_size_value = font_size.GetValue(frame_number) * timeline_scale_factor;
 	QFont font(QString(font_name.c_str()), int(font_size_value));
-	font.setPointSizeF(std::max(font_size_value, 1.0));
+	font.setPixelSize(std::max(font_size_value, 1.0));
 	QFontMetricsF metrics = QFontMetricsF(font);
-	std::cout << "font_size_value: " << font_size_value << std::endl;
 
 	// Get current keyframe values
 	double left_value = left.GetValue(frame_number);

--- a/src/effects/Caption.cpp
+++ b/src/effects/Caption.cpp
@@ -27,7 +27,7 @@
 using namespace openshot;
 
 /// Blank constructor, useful when using Json to load the effect properties
-Caption::Caption() : color("#ffffff"), stroke("#a9a9a9"), background("#ff000000"), background_alpha(0.0), left(0.1), top(0.75), right(0.1),
+Caption::Caption() : color("#ffffff"), stroke("#a9a9a9"), background("#ff000000"), background_alpha(0.0), left(0.1), top(0.70), right(0.1),
 					 stroke_width(0.5), font_size(20.0), font_alpha(1.0), is_dirty(true), font_name("sans"), font(NULL), metrics(NULL),
 					 fade_in(0.35), fade_out(0.35), background_corner(10.0), background_padding(20.0), line_spacing(1.0)
 {
@@ -38,7 +38,7 @@ Caption::Caption() : color("#ffffff"), stroke("#a9a9a9"), background("#ff000000"
 // Default constructor
 Caption::Caption(std::string captions) :
 		color("#ffffff"), caption_text(captions), stroke("#a9a9a9"), background("#ff000000"), background_alpha(0.0),
-		left(0.1), top(0.75), right(0.1), stroke_width(0.5), font_size(20.0), font_alpha(1.0), is_dirty(true), font_name("sans"),
+		left(0.1), top(0.70), right(0.1), stroke_width(0.5), font_size(20.0), font_alpha(1.0), is_dirty(true), font_name("sans"),
 		font(NULL), metrics(NULL), fade_in(0.35), fade_out(0.35), background_corner(10.0), background_padding(20.0), line_spacing(1.0)
 {
 	// Init effect properties

--- a/src/effects/Caption.cpp
+++ b/src/effects/Caption.cpp
@@ -110,9 +110,6 @@ std::shared_ptr<openshot::Frame> Caption::GetFrame(std::shared_ptr<openshot::Fra
 	// Process regex (if needed)
 	process_regex();
 
-	// Get largest pixel ratio (of screen)
-	double device_pixel_ratio = qGuiApp->devicePixelRatio();
-
 	// Get the Clip and Timeline pointers (if available)
 	Clip* clip = (Clip*) ParentClip();
 	Timeline* timeline = NULL;
@@ -146,10 +143,11 @@ std::shared_ptr<openshot::Frame> Caption::GetFrame(std::shared_ptr<openshot::Fra
 	painter.setCompositionMode(QPainter::CompositionMode_SourceOver);
 
 	// Font options and metrics for caption text
-	double font_size_value = font_size.GetValue(frame_number) * device_pixel_ratio * timeline_scale_factor;
+	double font_size_value = font_size.GetValue(frame_number) * timeline_scale_factor * qGuiApp->devicePixelRatio();
 	QFont font(QString(font_name.c_str()), int(font_size_value));
 	font.setPointSizeF(std::max(font_size_value, 1.0));
 	QFontMetricsF metrics = QFontMetricsF(font);
+	std::cout << "font_size_value: " << font_size_value << std::endl;
 
 	// Get current keyframe values
 	double left_value = left.GetValue(frame_number);

--- a/tests/Caption.cpp
+++ b/tests/Caption.cpp
@@ -168,7 +168,7 @@ TEST_CASE( "caption effect", "[libopenshot][caption]" )
 #ifdef _WIN32
         // Windows pixel location
         check_col = 105;
-        check_row = 377;
+        check_row = 379;
 #else
         // Linux/Mac pixel location
         check_col = 141;

--- a/tests/Caption.cpp
+++ b/tests/Caption.cpp
@@ -75,7 +75,6 @@ TEST_CASE( "caption effect", "[libopenshot][caption]" )
 
         // Get frame
         std::shared_ptr<openshot::Frame> f = clip1.GetFrame(10);
-        f->Save("caption-sintel-10.png", 1.0, "PNG");
 
 #ifdef _WIN32
         // Windows pixel location
@@ -101,7 +100,6 @@ TEST_CASE( "caption effect", "[libopenshot][caption]" )
 
         // Get timeline frame
         f = t.GetFrame(10);
-        f->Save("caption-sintel-10B.png", 1.0, "PNG");
 
 #ifdef _WIN32
         // Windows pixel location
@@ -141,7 +139,6 @@ TEST_CASE( "caption effect", "[libopenshot][caption]" )
 
         // Get frame
         std::shared_ptr<openshot::Frame> f = clip1.GetFrame(10);
-        f->Save("caption-piano-10.png", 1.0, "PNG");
 
 #ifdef _WIN32
         // Windows pixel location
@@ -167,7 +164,6 @@ TEST_CASE( "caption effect", "[libopenshot][caption]" )
 
         // Get timeline frame
         f = t.GetFrame(10);
-        f->Save("caption-piano-10B.png", 1.0, "PNG");
 
 #ifdef _WIN32
         // Windows pixel location
@@ -208,7 +204,6 @@ TEST_CASE( "caption effect", "[libopenshot][caption]" )
 
         // Get frame
         std::shared_ptr<openshot::Frame> f = clip1.GetFrame(11);
-        f->Save("caption-sintel-11.png", 1.0, "PNG");
 
 #ifdef _WIN32
         // Windows pixel location

--- a/tests/Caption.cpp
+++ b/tests/Caption.cpp
@@ -79,8 +79,8 @@ TEST_CASE( "caption effect", "[libopenshot][caption]" )
 
 #ifdef _WIN32
         // Windows pixel location
-        check_col = 185;
-        check_row = 572;
+        check_col = 625;
+        check_row = 600;
 #else
         // Linux/Mac pixel location
         check_col = 251;
@@ -105,8 +105,8 @@ TEST_CASE( "caption effect", "[libopenshot][caption]" )
 
 #ifdef _WIN32
         // Windows pixel location
-        check_col = 185;
-        check_row = 574;
+        check_col = 625;
+        check_row = 600;
 #else
         // Linux/Mac pixel location
         check_col = 251;
@@ -145,8 +145,8 @@ TEST_CASE( "caption effect", "[libopenshot][caption]" )
 
 #ifdef _WIN32
         // Windows pixel location
-        check_col = 105;
-        check_row = 378;
+        check_col = 351;
+        check_row = 391;
 #else
         // Linux/Mac pixel location
         check_col = 141;
@@ -171,8 +171,8 @@ TEST_CASE( "caption effect", "[libopenshot][caption]" )
 
 #ifdef _WIN32
         // Windows pixel location
-        check_col = 105;
-        check_row = 379;
+        check_col = 351;
+        check_row = 391;
 #else
         // Linux/Mac pixel location
         check_col = 141;
@@ -212,8 +212,8 @@ TEST_CASE( "caption effect", "[libopenshot][caption]" )
 
 #ifdef _WIN32
         // Windows pixel location
-        check_col = 291;
-        check_row = 571;
+        check_col = 633;
+        check_row = 580;
 #else
         // Linux/Mac pixel location
         check_col = 284;

--- a/tests/Caption.cpp
+++ b/tests/Caption.cpp
@@ -52,9 +52,9 @@ TEST_CASE( "caption effect", "[libopenshot][caption]" )
         CHECK(c1.background_alpha.GetValue(1) == Approx(0.0f).margin(0.00001));
         CHECK(c1.left.GetValue(1) == Approx(0.10f).margin(0.00001));
         CHECK(c1.right.GetValue(1) == Approx(0.10f).margin(0.00001));
-        CHECK(c1.top.GetValue(1) == Approx(0.72).margin(0.00001));
+        CHECK(c1.top.GetValue(1) == Approx(0.75).margin(0.00001));
         CHECK(c1.stroke_width.GetValue(1) == Approx(0.5f).margin(0.00001));
-        CHECK(c1.font_size.GetValue(1) == Approx(20.0f).margin(0.00001));
+        CHECK(c1.font_size.GetValue(1) == Approx(30.0f).margin(0.00001));
         CHECK(c1.font_alpha.GetValue(1) == Approx(1.0f).margin(0.00001));
         CHECK(c1.font_name == "sans");
         CHECK(c1.fade_in.GetValue(1) == Approx(0.35f).margin(0.00001));
@@ -80,11 +80,11 @@ TEST_CASE( "caption effect", "[libopenshot][caption]" )
 #ifdef _WIN32
         // Windows pixel location
         check_col = 300;
-        check_row = 544;
+        check_row = 572;
 #else
         // Linux/Mac pixel location
-        check_col = 214;
-        check_row = 544;
+        check_col = 251;
+        check_row = 572;
 #endif
 
         // Verify pixel values (black background pixels)
@@ -106,11 +106,11 @@ TEST_CASE( "caption effect", "[libopenshot][caption]" )
 #ifdef _WIN32
         // Windows pixel location
         check_col = 300;
-        check_row = 544;
+        check_row = 572;
 #else
         // Linux/Mac pixel location
-        check_col = 214;
-        check_row = 544;
+        check_col = 251;
+        check_row = 572;
 #endif
 
         // Verify pixel values (black background pixels)
@@ -146,11 +146,11 @@ TEST_CASE( "caption effect", "[libopenshot][caption]" )
 #ifdef _WIN32
         // Windows pixel location
         check_col = 146;
-        check_row = 360;
+        check_row = 378;
 #else
         // Linux/Mac pixel location
-        check_col = 118;
-        check_row = 360;
+        check_col = 141;
+        check_row = 378;
 #endif
 
         // Verify pixel values (black background pixels)
@@ -172,11 +172,11 @@ TEST_CASE( "caption effect", "[libopenshot][caption]" )
 #ifdef _WIN32
         // Windows pixel location
         check_col = 146;
-        check_row = 360;
+        check_row = 377;
 #else
         // Linux/Mac pixel location
-        check_col = 119;
-        check_row = 360;
+        check_col = 141;
+        check_row = 377;
 #endif
 
         // Verify pixel values (black background pixels)
@@ -213,11 +213,11 @@ TEST_CASE( "caption effect", "[libopenshot][caption]" )
 #ifdef _WIN32
         // Windows pixel location
         check_col = 325;
-        check_row = 542;
+        check_row = 569;
 #else
         // Linux/Mac pixel location
-        check_col = 291;
-        check_row = 542;
+        check_col = 284;
+        check_row = 569;
 #endif
 
         // Verify pixel values (black background pixels)

--- a/tests/Caption.cpp
+++ b/tests/Caption.cpp
@@ -75,6 +75,7 @@ TEST_CASE( "caption effect", "[libopenshot][caption]" )
 
         // Get frame
         std::shared_ptr<openshot::Frame> f = clip1.GetFrame(10);
+        f->Save("caption-sintel-10.png", 1.0, "PNG");
 
 #ifdef _WIN32
         // Windows pixel location
@@ -100,11 +101,12 @@ TEST_CASE( "caption effect", "[libopenshot][caption]" )
 
         // Get timeline frame
         f = t.GetFrame(10);
+        f->Save("caption-sintel-10B.png", 1.0, "PNG");
 
 #ifdef _WIN32
         // Windows pixel location
         check_col = 185;
-        check_row = 572;
+        check_row = 574;
 #else
         // Linux/Mac pixel location
         check_col = 251;
@@ -139,6 +141,7 @@ TEST_CASE( "caption effect", "[libopenshot][caption]" )
 
         // Get frame
         std::shared_ptr<openshot::Frame> f = clip1.GetFrame(10);
+        f->Save("caption-piano-10.png", 1.0, "PNG");
 
 #ifdef _WIN32
         // Windows pixel location
@@ -164,6 +167,7 @@ TEST_CASE( "caption effect", "[libopenshot][caption]" )
 
         // Get timeline frame
         f = t.GetFrame(10);
+        f->Save("caption-piano-10B.png", 1.0, "PNG");
 
 #ifdef _WIN32
         // Windows pixel location
@@ -204,6 +208,7 @@ TEST_CASE( "caption effect", "[libopenshot][caption]" )
 
         // Get frame
         std::shared_ptr<openshot::Frame> f = clip1.GetFrame(11);
+        f->Save("caption-sintel-11.png", 1.0, "PNG");
 
 #ifdef _WIN32
         // Windows pixel location

--- a/tests/Caption.cpp
+++ b/tests/Caption.cpp
@@ -75,11 +75,10 @@ TEST_CASE( "caption effect", "[libopenshot][caption]" )
 
         // Get frame
         std::shared_ptr<openshot::Frame> f = clip1.GetFrame(10);
-        f->Save("caption-sintel-10.png", 1.0, "PNG");
 
 #ifdef _WIN32
         // Windows pixel location
-        check_col = 300;
+        check_col = 185;
         check_row = 572;
 #else
         // Linux/Mac pixel location
@@ -101,11 +100,10 @@ TEST_CASE( "caption effect", "[libopenshot][caption]" )
 
         // Get timeline frame
         f = t.GetFrame(10);
-        f->Save("caption-sintel-10B.png", 1.0, "PNG");
 
 #ifdef _WIN32
         // Windows pixel location
-        check_col = 300;
+        check_col = 185;
         check_row = 572;
 #else
         // Linux/Mac pixel location
@@ -141,11 +139,10 @@ TEST_CASE( "caption effect", "[libopenshot][caption]" )
 
         // Get frame
         std::shared_ptr<openshot::Frame> f = clip1.GetFrame(10);
-        f->Save("caption-piano-10.png", 1.0, "PNG");
 
 #ifdef _WIN32
         // Windows pixel location
-        check_col = 146;
+        check_col = 105;
         check_row = 378;
 #else
         // Linux/Mac pixel location
@@ -167,11 +164,10 @@ TEST_CASE( "caption effect", "[libopenshot][caption]" )
 
         // Get timeline frame
         f = t.GetFrame(10);
-        f->Save("caption-piano-10B.png", 1.0, "PNG");
 
 #ifdef _WIN32
         // Windows pixel location
-        check_col = 146;
+        check_col = 105;
         check_row = 377;
 #else
         // Linux/Mac pixel location
@@ -208,12 +204,11 @@ TEST_CASE( "caption effect", "[libopenshot][caption]" )
 
         // Get frame
         std::shared_ptr<openshot::Frame> f = clip1.GetFrame(11);
-        f->Save("caption-sintel-11.png", 1.0, "PNG");
 
 #ifdef _WIN32
         // Windows pixel location
-        check_col = 325;
-        check_row = 569;
+        check_col = 291;
+        check_row = 571;
 #else
         // Linux/Mac pixel location
         check_col = 284;

--- a/tests/Caption.cpp
+++ b/tests/Caption.cpp
@@ -50,11 +50,11 @@ TEST_CASE( "caption effect", "[libopenshot][caption]" )
         CHECK(c1.stroke.GetColorHex(1) == "#a9a9a9");
         CHECK(c1.background.GetColorHex(1) == "#000000");
         CHECK(c1.background_alpha.GetValue(1) == Approx(0.0f).margin(0.00001));
-        CHECK(c1.left.GetValue(1) == Approx(0.15f).margin(0.00001));
-        CHECK(c1.right.GetValue(1) == Approx(0.15f).margin(0.00001));
-        CHECK(c1.top.GetValue(1) == Approx(0.7).margin(0.00001));
+        CHECK(c1.left.GetValue(1) == Approx(0.10f).margin(0.00001));
+        CHECK(c1.right.GetValue(1) == Approx(0.10f).margin(0.00001));
+        CHECK(c1.top.GetValue(1) == Approx(0.70).margin(0.00001));
         CHECK(c1.stroke_width.GetValue(1) == Approx(0.5f).margin(0.00001));
-        CHECK(c1.font_size.GetValue(1) == Approx(30.0f).margin(0.00001));
+        CHECK(c1.font_size.GetValue(1) == Approx(20.0f).margin(0.00001));
         CHECK(c1.font_alpha.GetValue(1) == Approx(1.0f).margin(0.00001));
         CHECK(c1.font_name == "sans");
         CHECK(c1.fade_in.GetValue(1) == Approx(0.35f).margin(0.00001));
@@ -75,15 +75,16 @@ TEST_CASE( "caption effect", "[libopenshot][caption]" )
 
         // Get frame
         std::shared_ptr<openshot::Frame> f = clip1.GetFrame(10);
+        f->Save("caption-sintel-10.png", 1.0, "PNG");
 
 #ifdef _WIN32
         // Windows pixel location
         check_col = 300;
-        check_row = 524;
+        check_row = 528;
 #else
         // Linux/Mac pixel location
-        check_col = 252;
-        check_row = 523;
+        check_col = 213;
+        check_row = 528;
 #endif
 
         // Verify pixel values (black background pixels)
@@ -100,15 +101,16 @@ TEST_CASE( "caption effect", "[libopenshot][caption]" )
 
         // Get timeline frame
         f = t.GetFrame(10);
+        f->Save("caption-sintel-10B.png", 1.0, "PNG");
 
 #ifdef _WIN32
         // Windows pixel location
         check_col = 300;
-        check_row = 523;
+        check_row = 528;
 #else
         // Linux/Mac pixel location
-        check_col = 252;
-        check_row = 523;
+        check_col = 214;
+        check_row = 528;
 #endif
 
         // Verify pixel values (black background pixels)
@@ -139,15 +141,16 @@ TEST_CASE( "caption effect", "[libopenshot][caption]" )
 
         // Get frame
         std::shared_ptr<openshot::Frame> f = clip1.GetFrame(10);
+        f->Save("caption-piano-10.png", 1.0, "PNG");
 
 #ifdef _WIN32
         // Windows pixel location
         check_col = 146;
-        check_row = 355;
+        check_row = 361;
 #else
         // Linux/Mac pixel location
-        check_col = 117;
-        check_row = 355;
+        check_col = 92;
+        check_row = 361;
 #endif
 
         // Verify pixel values (black background pixels)
@@ -164,15 +167,16 @@ TEST_CASE( "caption effect", "[libopenshot][caption]" )
 
         // Get timeline frame
         f = t.GetFrame(10);
+        f->Save("caption-piano-10B.png", 1.0, "PNG");
 
 #ifdef _WIN32
         // Windows pixel location
         check_col = 146;
-        check_row = 355;
+        check_row = 360;
 #else
         // Linux/Mac pixel location
-        check_col = 117;
-        check_row = 355;
+        check_col = 93;
+        check_row = 360;
 #endif
 
         // Verify pixel values (black background pixels)
@@ -203,16 +207,17 @@ TEST_CASE( "caption effect", "[libopenshot][caption]" )
         clip1.AddEffect(&c1);
 
         // Get frame
-        std::shared_ptr<openshot::Frame> f = clip1.GetFrame(10);
+        std::shared_ptr<openshot::Frame> f = clip1.GetFrame(11);
+        f->Save("caption-sintel-11.png", 1.0, "PNG");
 
 #ifdef _WIN32
         // Windows pixel location
         check_col = 325;
-        check_row = 522;
+        check_row = 527;
 #else
         // Linux/Mac pixel location
-        check_col = 318;
-        check_row = 521;
+        check_col = 292;
+        check_row = 527;
 #endif
 
         // Verify pixel values (black background pixels)

--- a/tests/Caption.cpp
+++ b/tests/Caption.cpp
@@ -52,7 +52,7 @@ TEST_CASE( "caption effect", "[libopenshot][caption]" )
         CHECK(c1.background_alpha.GetValue(1) == Approx(0.0f).margin(0.00001));
         CHECK(c1.left.GetValue(1) == Approx(0.10f).margin(0.00001));
         CHECK(c1.right.GetValue(1) == Approx(0.10f).margin(0.00001));
-        CHECK(c1.top.GetValue(1) == Approx(0.70).margin(0.00001));
+        CHECK(c1.top.GetValue(1) == Approx(0.72).margin(0.00001));
         CHECK(c1.stroke_width.GetValue(1) == Approx(0.5f).margin(0.00001));
         CHECK(c1.font_size.GetValue(1) == Approx(20.0f).margin(0.00001));
         CHECK(c1.font_alpha.GetValue(1) == Approx(1.0f).margin(0.00001));
@@ -80,11 +80,11 @@ TEST_CASE( "caption effect", "[libopenshot][caption]" )
 #ifdef _WIN32
         // Windows pixel location
         check_col = 300;
-        check_row = 528;
+        check_row = 544;
 #else
         // Linux/Mac pixel location
-        check_col = 213;
-        check_row = 528;
+        check_col = 214;
+        check_row = 544;
 #endif
 
         // Verify pixel values (black background pixels)
@@ -106,11 +106,11 @@ TEST_CASE( "caption effect", "[libopenshot][caption]" )
 #ifdef _WIN32
         // Windows pixel location
         check_col = 300;
-        check_row = 528;
+        check_row = 544;
 #else
         // Linux/Mac pixel location
         check_col = 214;
-        check_row = 528;
+        check_row = 544;
 #endif
 
         // Verify pixel values (black background pixels)
@@ -146,11 +146,11 @@ TEST_CASE( "caption effect", "[libopenshot][caption]" )
 #ifdef _WIN32
         // Windows pixel location
         check_col = 146;
-        check_row = 361;
+        check_row = 360;
 #else
         // Linux/Mac pixel location
-        check_col = 92;
-        check_row = 361;
+        check_col = 118;
+        check_row = 360;
 #endif
 
         // Verify pixel values (black background pixels)
@@ -175,7 +175,7 @@ TEST_CASE( "caption effect", "[libopenshot][caption]" )
         check_row = 360;
 #else
         // Linux/Mac pixel location
-        check_col = 93;
+        check_col = 119;
         check_row = 360;
 #endif
 
@@ -213,11 +213,11 @@ TEST_CASE( "caption effect", "[libopenshot][caption]" )
 #ifdef _WIN32
         // Windows pixel location
         check_col = 325;
-        check_row = 527;
+        check_row = 542;
 #else
         // Linux/Mac pixel location
-        check_col = 292;
-        check_row = 527;
+        check_col = 291;
+        check_row = 542;
 #endif
 
         // Verify pixel values (black background pixels)


### PR DESCRIPTION
Also changing min **libopenshot-audio** version to a range: `0.3.0 to 0.3.1`, since both work fine with this version of libopenshot.

This is part of the new OpenShot Video Editor 3.1.0 release.
- https://github.com/OpenShot/libopenshot-audio/pull/149 (libopenshot-audio release PR)