### PR TITLE
Prevent crash in ObjectDetection (due to NULL parentClip)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,14 @@ jobs:
             libzmq3-dev libmagick++-dev libbabl-dev \
             libopencv-dev libprotobuf-dev protobuf-compiler \
             cargo libomp5 libomp-dev
-          # Install catch2 package from Ubuntu 22.04
+
+          # Install catch2 package from source
+          git clone https://github.com/catchorg/Catch2.git
+          pushd Catch2
+          cmake -Bbuild -H. -DBUILD_TESTING=OFF
+          cmake --build build/ --target install
+          popd
+
           wget https://launchpad.net/ubuntu/+archive/primary/+files/catch2_2.13.8-1_amd64.deb
           sudo dpkg -i catch2_2.13.8-1_amd64.deb
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,8 @@ jobs:
     strategy:
       matrix:
         sys:
-          - { os: ubuntu-18.04, shell: bash }
           - { os: ubuntu-20.04, shell: bash }
+          - { os: ubuntu-22.04, shell: bash }
           - { os: windows-2022, shell: 'msys2 {0}' }
         compiler:
           - { cc: gcc, cxx: g++ }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,7 @@ jobs:
           git clone https://github.com/catchorg/Catch2.git
           pushd Catch2
           cmake -Bbuild -H. -DBUILD_TESTING=OFF
-          cmake --build build/ --target install
+          sudo cmake --build build/ --target install
           popd
 
           wget https://launchpad.net/ubuntu/+archive/primary/+files/catch2_2.13.8-1_amd64.deb

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,10 +85,9 @@ jobs:
             libzmq3-dev libmagick++-dev libbabl-dev \
             libopencv-dev libprotobuf-dev protobuf-compiler \
             cargo libomp5 libomp-dev
-          # Install catch2 package from Ubuntu 20.10, since for some reason
-          # even 20.04 only has Catch 1.12.1 available.
-          wget https://launchpad.net/ubuntu/+archive/primary/+files/catch2_2.13.0-1_all.deb
-          sudo dpkg -i catch2_2.13.0-1_all.deb
+          # Install catch2 package from Ubuntu 22.04
+          wget https://launchpad.net/ubuntu/+archive/primary/+files/catch2_2.13.8-1_amd64.deb
+          sudo dpkg -i catch2_2.13.8-1_amd64.deb
 
       - name: Install macOS dependencies
         if: ${{ runner.os == 'macos' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
             qtbase5-dev qtbase5-dev-tools libqt5svg5-dev \
             libfdk-aac-dev libavcodec-dev libavformat-dev \
             libavutil-dev libswscale-dev libswresample-dev \
-            libzmq3-dev libmagick++-dev libbabl-dev \
+            libzmq3-dev libbabl-dev \
             libopencv-dev libprotobuf-dev protobuf-compiler \
             cargo libomp5 libomp-dev
 

--- a/src/Clip.cpp
+++ b/src/Clip.cpp
@@ -792,7 +792,7 @@ std::string Clip::PropertiesJSON(int64_t requested_frame) const {
 	root["waveform"]["choices"].append(add_property_choice_json("No", false, waveform));
 
 	// Add the parentTrackedObject's properties
-	if (parentTrackedObject)
+	if (parentTrackedObject && parentClipObject)
 	{
 		// Convert Clip's frame position to Timeline's frame position
 		long clip_start_position = round(Position() * info.fps.ToDouble()) + 1;
@@ -1445,7 +1445,10 @@ QTransform Clip::get_transform(std::shared_ptr<Frame> frame, int width, int heig
 		double timeline_frame_number = frame->number + clip_start_position - clip_start_frame;
 
 		// Get parentTrackedObject's parent clip's properties
-		std::map<std::string, float> trackedObjectParentClipProperties = parentTrackedObject->GetParentClipProperties(timeline_frame_number);
+		std::map<std::string, float> trackedObjectParentClipProperties;
+		if (parentClipObject) {
+            parentTrackedObject->GetParentClipProperties(timeline_frame_number);
+        }
 
 		// Get the attached object's parent clip's properties
 		if (!trackedObjectParentClipProperties.empty())

--- a/src/Clip.cpp
+++ b/src/Clip.cpp
@@ -253,19 +253,16 @@ void Clip::AttachToObject(std::string object_id)
 			SetAttachedClip(clipObject);
 		}
 	}
-	return;
 }
 
 // Set the pointer to the trackedObject this clip is attached to
 void Clip::SetAttachedObject(std::shared_ptr<openshot::TrackedObjectBase> trackedObject){
 	parentTrackedObject = trackedObject;
-	return;
 }
 
 // Set the pointer to the clip this clip is attached to
 void Clip::SetAttachedClip(Clip* clipObject){
 	parentClipObject = clipObject;
-	return;
 }
 
 /// Set the current reader
@@ -754,11 +751,8 @@ std::string Clip::PropertiesJSON(int64_t requested_frame) const {
 	root["display"] = add_property_json("Frame Number", display, "int", "", NULL, 0, 3, false, requested_frame);
 	root["mixing"] = add_property_json("Volume Mixing", mixing, "int", "", NULL, 0, 2, false, requested_frame);
 	root["waveform"] = add_property_json("Waveform", waveform, "int", "", NULL, 0, 1, false, requested_frame);
-	if (!parentObjectId.empty()) {
-		root["parentObjectId"] = add_property_json("Parent", 0.0, "string", parentObjectId, NULL, -1, -1, false, requested_frame);
-	} else {
-		root["parentObjectId"] = add_property_json("Parent", 0.0, "string", "", NULL, -1, -1, false, requested_frame);
-	}
+	root["parentObjectId"] = add_property_json("Parent", 0.0, "string", parentObjectId, NULL, -1, -1, false, requested_frame);
+
 	// Add gravity choices (dropdown style)
 	root["gravity"]["choices"].append(add_property_choice_json("Top Left", GRAVITY_TOP_LEFT, gravity));
 	root["gravity"]["choices"].append(add_property_choice_json("Top Center", GRAVITY_TOP, gravity));
@@ -1438,17 +1432,14 @@ QTransform Clip::get_transform(std::shared_ptr<Frame> frame, int width, int heig
 
 	// Get the parentTrackedObject properties
 	if (parentTrackedObject){
-
 		// Convert Clip's frame position to Timeline's frame position
 		long clip_start_position = round(Position() * info.fps.ToDouble()) + 1;
 		long clip_start_frame = (Start() * info.fps.ToDouble()) + 1;
 		double timeline_frame_number = frame->number + clip_start_position - clip_start_frame;
 
 		// Get parentTrackedObject's parent clip's properties
-		std::map<std::string, float> trackedObjectParentClipProperties;
-		if (parentClipObject) {
-            parentTrackedObject->GetParentClipProperties(timeline_frame_number);
-        }
+		std::map<std::string, float> trackedObjectParentClipProperties =
+		        parentTrackedObject->GetParentClipProperties(timeline_frame_number);
 
 		// Get the attached object's parent clip's properties
 		if (!trackedObjectParentClipProperties.empty())

--- a/src/Clip.cpp
+++ b/src/Clip.cpp
@@ -1439,7 +1439,7 @@ QTransform Clip::get_transform(std::shared_ptr<Frame> frame, int width, int heig
 
 		// Get parentTrackedObject's parent clip's properties
 		std::map<std::string, float> trackedObjectParentClipProperties =
-		        parentTrackedObject->GetParentClipProperties(timeline_frame_number);
+				parentTrackedObject->GetParentClipProperties(timeline_frame_number);
 
 		// Get the attached object's parent clip's properties
 		if (!trackedObjectParentClipProperties.empty())

--- a/src/TrackedObjectBBox.cpp
+++ b/src/TrackedObjectBBox.cpp
@@ -383,9 +383,11 @@ void TrackedObjectBBox::SetJsonValue(const Json::Value root)
 	// Set the id of the child clip
 	if (!root["child_clip_id"].isNull() && root["child_clip_id"].asString() != "" && root["child_clip_id"].asString() != Id()){
 		Clip* parentClip = (Clip *) ParentClip();
-
-		if (root["child_clip_id"].asString() != parentClip->Id())
-			ChildClipId(root["child_clip_id"].asString());
+		if (parentClip && root["child_clip_id"].asString() != parentClip->Id()) {
+            ChildClipId(root["child_clip_id"].asString());
+		} else if (parentClip == NULL) {
+            ChildClipId(root["child_clip_id"].asString());
+		}
 	}
 
 	// Set the Keyframes by the given JSON object

--- a/src/TrackedObjectBBox.cpp
+++ b/src/TrackedObjectBBox.cpp
@@ -382,12 +382,7 @@ void TrackedObjectBBox::SetJsonValue(const Json::Value root)
 
 	// Set the id of the child clip
 	if (!root["child_clip_id"].isNull() && root["child_clip_id"].asString() != Id()){
-		Clip* parentClip = (Clip *) ParentClip();
-		if (parentClip && root["child_clip_id"].asString() != parentClip->Id()) {
-            ChildClipId(root["child_clip_id"].asString());
-		} else if (parentClip == NULL) {
-            ChildClipId(root["child_clip_id"].asString());
-		}
+        ChildClipId(root["child_clip_id"].asString());
 	}
 
 	// Set the Keyframes by the given JSON object

--- a/src/TrackedObjectBBox.cpp
+++ b/src/TrackedObjectBBox.cpp
@@ -235,7 +235,7 @@ void TrackedObjectBBox::ScalePoints(double time_scale){
 // Load the bounding-boxes information from the protobuf file
 bool TrackedObjectBBox::LoadBoxData(std::string inputFilePath)
 {
-    using std::ios;
+	using std::ios;
 
 	// Variable to hold the loaded data
 	pb_tracker::Tracker bboxMessage;
@@ -282,7 +282,7 @@ bool TrackedObjectBBox::LoadBoxData(std::string inputFilePath)
 	if (bboxMessage.has_last_updated())
 	{
 		std::cout << " Loaded Data. Saved Time Stamp: "
-		          << TimeUtil::ToString(bboxMessage.last_updated()) << std::endl;
+				  << TimeUtil::ToString(bboxMessage.last_updated()) << std::endl;
 	}
 
 	// Delete all global objects allocated by libprotobuf.
@@ -382,7 +382,7 @@ void TrackedObjectBBox::SetJsonValue(const Json::Value root)
 
 	// Set the id of the child clip
 	if (!root["child_clip_id"].isNull() && root["child_clip_id"].asString() != Id()){
-        ChildClipId(root["child_clip_id"].asString());
+		ChildClipId(root["child_clip_id"].asString());
 	}
 
 	// Set the Keyframes by the given JSON object

--- a/src/TrackedObjectBBox.cpp
+++ b/src/TrackedObjectBBox.cpp
@@ -381,7 +381,7 @@ void TrackedObjectBBox::SetJsonValue(const Json::Value root)
 		protobufDataPath = root["protobuf_data_path"].asString();
 
 	// Set the id of the child clip
-	if (!root["child_clip_id"].isNull() && root["child_clip_id"].asString() != "" && root["child_clip_id"].asString() != Id()){
+	if (!root["child_clip_id"].isNull() && root["child_clip_id"].asString() != Id()){
 		Clip* parentClip = (Clip *) ParentClip();
 		if (parentClip && root["child_clip_id"].asString() != parentClip->Id()) {
             ChildClipId(root["child_clip_id"].asString());

--- a/src/TrackedObjectBase.h
+++ b/src/TrackedObjectBase.h
@@ -22,8 +22,8 @@
 
 namespace openshot {
 
-    // Forward decls
-    class ClipBase;
+	// Forward decls
+	class ClipBase;
 
 	/**
 	 * @brief This abstract class is the base class of all Tracked Objects.
@@ -50,8 +50,8 @@ namespace openshot {
 		/// Constructor which takes an object ID
 		TrackedObjectBase(std::string _id);
 
-        /// Destructor
-        virtual ~TrackedObjectBase() = default;
+		/// Destructor
+		virtual ~TrackedObjectBase() = default;
 
 		/// Get the id of this object
 		std::string Id() const { return id; }

--- a/src/effects/ObjectDetection.cpp
+++ b/src/effects/ObjectDetection.cpp
@@ -122,15 +122,6 @@ std::shared_ptr<Frame> ObjectDetection::GetFrame(std::shared_ptr<Frame> frame, i
                 std::vector<int> bg_rgba = trackedObject->background.GetColorRGBA(frame_number);
                 float bg_alpha = trackedObject->background_alpha.GetValue(frame_number);
 
-                // Create a rotated rectangle object that holds the bounding box
-                // cv::RotatedRect box ( cv::Point2f( (int)(trackedBox.cx*fw), (int)(trackedBox.cy*fh) ),
-                //					 cv::Size2f( (int)(trackedBox.width*fw), (int)(trackedBox.height*fh) ),
-                //					 (int) (trackedBox.angle) );
-
-                // DrawRectangleRGBA(cv_image, box, bg_rgba, bg_alpha, 1, true);
-                // DrawRectangleRGBA(cv_image, box, stroke_rgba, stroke_alpha, stroke_width, false);
-
-
                 cv::Rect2d box(
                     (int)( (trackedBox.cx-trackedBox.width/2)*fw),
                     (int)( (trackedBox.cy-trackedBox.height/2)*fh),
@@ -160,9 +151,8 @@ std::shared_ptr<Frame> ObjectDetection::GetFrame(std::shared_ptr<Frame> frame, i
                         Clip* childClip = parentTimeline->GetClip(trackedObject->ChildClipId());
 
                         if (childClip){
-                            std::shared_ptr<Frame> f(new Frame(1, frame->GetWidth(), frame->GetHeight(), "#00000000"));
                             // Get the image of the child clip for this frame
-					        std::shared_ptr<Frame> childClipFrame = childClip->GetFrame(f, frame_number);
+					        std::shared_ptr<Frame> childClipFrame = childClip->GetFrame(frame_number);
                             childClipImages.push_back(childClipFrame->GetImage());
 
                             // Set the Qt rectangle with the bounding-box properties
@@ -190,7 +180,7 @@ std::shared_ptr<Frame> ObjectDetection::GetFrame(std::shared_ptr<Frame> frame, i
             // Set a Qt painter to the frame image
             QPainter painter(&frameImage);
             // Draw the child clip image inside the bounding-box
-            painter.drawImage(boxRects[i], *childClipImages[i], QRectF(0, 0, frameImage.size().width(),  frameImage.size().height()));
+            painter.drawImage(boxRects[i], *childClipImages[i]);
         }
         // Set the frame image as the composed image
         frame->AddImage(std::make_shared<QImage>(frameImage));

--- a/src/effects/ObjectDetection.cpp
+++ b/src/effects/ObjectDetection.cpp
@@ -78,9 +78,9 @@ std::shared_ptr<Frame> ObjectDetection::GetFrame(std::shared_ptr<Frame> frame, i
     }
 
     // Initialize the Qt rectangle that will hold the positions of the bounding-box
-	std::vector<QRectF> boxRects;
-	// Initialize the image of the TrackedObject child clip
-	std::vector<std::shared_ptr<QImage>> childClipImages;
+    std::vector<QRectF> boxRects;
+    // Initialize the image of the TrackedObject child clip
+    std::vector<std::shared_ptr<QImage>> childClipImages;
 
     // Check if track data exists for the requested frame
     if (detectionsData.find(frame_number) != detectionsData.end()) {
@@ -152,7 +152,7 @@ std::shared_ptr<Frame> ObjectDetection::GetFrame(std::shared_ptr<Frame> frame, i
 
                         if (childClip){
                             // Get the image of the child clip for this frame
-					        std::shared_ptr<Frame> childClipFrame = childClip->GetFrame(frame_number);
+                            std::shared_ptr<Frame> childClipFrame = childClip->GetFrame(frame_number);
                             childClipImages.push_back(childClipFrame->GetImage());
 
                             // Set the Qt rectangle with the bounding-box properties
@@ -172,8 +172,8 @@ std::shared_ptr<Frame> ObjectDetection::GetFrame(std::shared_ptr<Frame> frame, i
     // Update Qt image with new Opencv frame
     frame->SetImageCV(cv_image);
 
-	// Set the bounding-box image with the Tracked Object's child clip image
-	if(boxRects.size() > 0){
+    // Set the bounding-box image with the Tracked Object's child clip image
+    if(boxRects.size() > 0){
         // Get the frame image
         QImage frameImage = *(frame->GetImage());
         for(int i; i < boxRects.size();i++){
@@ -352,7 +352,7 @@ bool ObjectDetection::LoadObjDetectdData(std::string inputFilePath){
 
                 std::shared_ptr<TrackedObjectBBox> trackedObjPtr = std::make_shared<TrackedObjectBBox>(trackedObj);
                 ClipBase* parentClip = this->ParentClip();
-	            trackedObjPtr->ParentClip(parentClip);
+                trackedObjPtr->ParentClip(parentClip);
 
                 // Create a temp ID. This ID is necessary to initialize the object_id Json list
                 // this Id will be replaced by the one created in the UI

--- a/src/effects/Tracker.cpp
+++ b/src/effects/Tracker.cpp
@@ -132,8 +132,7 @@ std::shared_ptr<Frame> Tracker::GetFrame(std::shared_ptr<Frame> frame, int64_t f
 				Clip* childClip = parentTimeline->GetClip(trackedData->ChildClipId());
 				if (childClip){
 					// Get the image of the child clip for this frame
-					std::shared_ptr<Frame> f(new Frame(1, frame->GetWidth(), frame->GetHeight(), "#00000000"));
-					std::shared_ptr<Frame> childClipFrame = childClip->GetFrame(f, frame_number);
+					std::shared_ptr<Frame> childClipFrame = childClip->GetFrame(frame_number);
 					childClipImage = childClipFrame->GetImage();
 
 					// Set the Qt rectangle with the bounding-box properties
@@ -160,7 +159,7 @@ std::shared_ptr<Frame> Tracker::GetFrame(std::shared_ptr<Frame> frame, int64_t f
 		QPainter painter(&frameImage);
 
 		// Draw the child clip image inside the bounding-box
-		painter.drawImage(boxRect, *childClipImage, QRectF(0, 0, frameImage.size().width(),  frameImage.size().height()));
+		painter.drawImage(boxRect, *childClipImage);
 
 		// Set the frame image as the composed image
 		frame->AddImage(std::make_shared<QImage>(frameImage));

--- a/src/effects/Tracker.cpp
+++ b/src/effects/Tracker.cpp
@@ -34,9 +34,9 @@ using google::protobuf::util::TimeUtil;
 /// Blank constructor, useful when using Json to load the effect properties
 Tracker::Tracker(std::string clipTrackerDataPath)
 {
-    // Init effect properties
+	// Init effect properties
 	init_effect_details();
-    // Instantiate a TrackedObjectBBox object and point to it
+	// Instantiate a TrackedObjectBBox object and point to it
 	TrackedObjectBBox trackedDataObject;
 	trackedData = std::make_shared<TrackedObjectBBox>(trackedDataObject);
 	// Tries to load the tracked object's data from protobuf file
@@ -85,7 +85,7 @@ void Tracker::init_effect_details()
 // modified openshot::Frame object
 std::shared_ptr<Frame> Tracker::GetFrame(std::shared_ptr<Frame> frame, int64_t frame_number)
 {
-    // Get the frame's image
+	// Get the frame's image
 	cv::Mat frame_image = frame->GetImageCV();
 
 	// Initialize the Qt rectangle that will hold the positions of the bounding-box
@@ -93,8 +93,8 @@ std::shared_ptr<Frame> Tracker::GetFrame(std::shared_ptr<Frame> frame, int64_t f
 	// Initialize the image of the TrackedObject child clip
 	std::shared_ptr<QImage> childClipImage = nullptr;
 
-    // Check if frame isn't NULL
-    if(!frame_image.empty() &&
+	// Check if frame isn't NULL
+	if(!frame_image.empty() &&
 		trackedData->Contains(frame_number) &&
 		trackedData->visible.GetValue(frame_number) == 1)
 	{
@@ -105,8 +105,8 @@ std::shared_ptr<Frame> Tracker::GetFrame(std::shared_ptr<Frame> frame, int64_t f
 		// Get the bounding-box of given frame
 		BBox fd = trackedData->GetBox(frame_number);
 
-        // Check if track data exists for the requested frame
-        if (trackedData->draw_box.GetValue(frame_number) == 1)
+		// Check if track data exists for the requested frame
+		if (trackedData->draw_box.GetValue(frame_number) == 1)
 		{
 			std::vector<int> stroke_rgba = trackedData->stroke.GetColorRGBA(frame_number);
 			int stroke_width = trackedData->stroke_width.GetValue(frame_number);
@@ -144,10 +144,10 @@ std::shared_ptr<Frame> Tracker::GetFrame(std::shared_ptr<Frame> frame, int64_t f
 			}
 		}
 
-    }
+	}
 
 	// Set image with drawn box to frame
-    // If the input image is NULL or doesn't have tracking data, it's returned as it came
+	// If the input image is NULL or doesn't have tracking data, it's returned as it came
 	frame->SetImageCV(frame_image);
 
 	// Set the bounding-box image with the Tracked Object's child clip image
@@ -211,23 +211,23 @@ void Tracker::DrawRectangleRGBA(cv::Mat &frame_image, cv::RotatedRect box, std::
 // Get the indexes and IDs of all visible objects in the given frame
 std::string Tracker::GetVisibleObjects(int64_t frame_number) const{
 
-    // Initialize the JSON objects
-    Json::Value root;
-    root["visible_objects_index"] = Json::Value(Json::arrayValue);
-    root["visible_objects_id"] = Json::Value(Json::arrayValue);
+	// Initialize the JSON objects
+	Json::Value root;
+	root["visible_objects_index"] = Json::Value(Json::arrayValue);
+	root["visible_objects_id"] = Json::Value(Json::arrayValue);
 
-    // Iterate through the tracked objects
-    for (const auto& trackedObject : trackedObjects){
-        // Get the tracked object JSON properties for this frame
-        Json::Value trackedObjectJSON = trackedObject.second->PropertiesJSON(frame_number);
-        if (trackedObjectJSON["visible"]["value"].asBool()){
-            // Save the object's index and ID if it's visible in this frame
-            root["visible_objects_index"].append(trackedObject.first);
-            root["visible_objects_id"].append(trackedObject.second->Id());
-        }
-    }
+	// Iterate through the tracked objects
+	for (const auto& trackedObject : trackedObjects){
+		// Get the tracked object JSON properties for this frame
+		Json::Value trackedObjectJSON = trackedObject.second->PropertiesJSON(frame_number);
+		if (trackedObjectJSON["visible"]["value"].asBool()){
+			// Save the object's index and ID if it's visible in this frame
+			root["visible_objects_index"].append(trackedObject.first);
+			root["visible_objects_id"].append(trackedObject.second->Id());
+		}
+	}
 
-    return root.toStyledString();
+	return root.toStyledString();
 }
 
 // Generate JSON string of this object
@@ -252,12 +252,12 @@ Json::Value Tracker::JsonValue() const {
 
 	// Add trackedObjects IDs to JSON
 	Json::Value objects;
-    for (auto const& trackedObject : trackedObjects){
-        Json::Value trackedObjectJSON = trackedObject.second->JsonValue();
-        // add object json
-        objects[trackedObject.second->Id()] = trackedObjectJSON;
-    }
-    root["objects"] = objects;
+	for (auto const& trackedObject : trackedObjects){
+		Json::Value trackedObjectJSON = trackedObject.second->JsonValue();
+		// add object json
+		objects[trackedObject.second->Id()] = trackedObjectJSON;
+	}
+	root["objects"] = objects;
 
 	// return JsonValue
 	return root;
@@ -313,23 +313,23 @@ void Tracker::SetJsonValue(const Json::Value root) {
 		}
 	}
 
-    if (!root["objects"].isNull()){
-        for (auto const& trackedObject : trackedObjects){
-            std::string obj_id = std::to_string(trackedObject.first);
-            if(!root["objects"][obj_id].isNull()){
-                trackedObject.second->SetJsonValue(root["objects"][obj_id]);
-            }
-        }
+	if (!root["objects"].isNull()){
+		for (auto const& trackedObject : trackedObjects){
+			std::string obj_id = std::to_string(trackedObject.first);
+			if(!root["objects"][obj_id].isNull()){
+				trackedObject.second->SetJsonValue(root["objects"][obj_id]);
+			}
+		}
 	}
 
-    // Set the tracked object's ids
-    if (!root["objects_id"].isNull()){
-        for (auto const& trackedObject : trackedObjects){
-            Json::Value trackedObjectJSON;
-            trackedObjectJSON["box_id"] = root["objects_id"][trackedObject.first].asString();
-            trackedObject.second->SetJsonValue(trackedObjectJSON);
-        }
-    }
+	// Set the tracked object's ids
+	if (!root["objects_id"].isNull()){
+		for (auto const& trackedObject : trackedObjects){
+			Json::Value trackedObjectJSON;
+			trackedObjectJSON["box_id"] = root["objects_id"][trackedObject.first].asString();
+			trackedObject.second->SetJsonValue(trackedObjectJSON);
+		}
+	}
 
 	return;
 }
@@ -345,8 +345,8 @@ std::string Tracker::PropertiesJSON(int64_t requested_frame) const {
 	for (auto const& trackedObject : trackedObjects){
 		Json::Value trackedObjectJSON = trackedObject.second->PropertiesJSON(requested_frame);
 		// add object json
-        objects[trackedObject.second->Id()] = trackedObjectJSON;
-    }
+		objects[trackedObject.second->Id()] = trackedObjectJSON;
+	}
 	root["objects"] = objects;
 
 	// Append effect's properties


### PR DESCRIPTION
Protect `child_clip_id` from accessing NULL `parentClip()` pointer - which causes a crash when OpenShot attempts to update the JSON of an Object Detection effect with a child ID. Also fixing a GitHub CI issue, which is breaking the GitHub Checks/Actions.