### PR TITLE
Audio Files should have NO image data (allowing lower layers to show through)

### DIFF
--- a/src/Clip.cpp
+++ b/src/Clip.cpp
@@ -438,7 +438,7 @@ std::shared_ptr<Frame> Clip::GetFrame(std::shared_ptr<openshot::Frame> backgroun
 		apply_timemapping(frame);
 
 		// Apply waveform image (if any)
-		apply_waveform(frame, background_frame->GetImage());
+		apply_waveform(frame, background_frame);
 
 		// Apply local effects to the frame (if any)
 		apply_effects(frame);
@@ -453,7 +453,7 @@ std::shared_ptr<Frame> Clip::GetFrame(std::shared_ptr<openshot::Frame> backgroun
 		}
 
 		// Apply keyframe / transforms
-		apply_keyframes(frame, background_frame->GetImage());
+		apply_keyframes(frame, background_frame);
 
 		// Add final frame to cache
 		final_cache.Add(frame);
@@ -1224,7 +1224,7 @@ bool Clip::isEqual(double a, double b)
 }
 
 // Apply keyframes to the source frame (if any)
-void Clip::apply_keyframes(std::shared_ptr<Frame> frame, std::shared_ptr<QImage> background_canvas) {
+void Clip::apply_keyframes(std::shared_ptr<Frame> frame, std::shared_ptr<Frame> background_frame) {
 	// Skip out if video was disabled or only an audio frame (no visualisation in use)
 	if (!frame->has_image_data) {
 		// Skip the rest of the image processing for performance reasons
@@ -1233,6 +1233,7 @@ void Clip::apply_keyframes(std::shared_ptr<Frame> frame, std::shared_ptr<QImage>
 
 	// Get image from clip
 	std::shared_ptr<QImage> source_image = frame->GetImage();
+	std::shared_ptr<QImage> background_canvas = background_frame->GetImage();
 
 	// Get transform from clip's keyframes
 	QTransform transform = get_transform(frame, background_canvas->width(), background_canvas->height());
@@ -1291,7 +1292,7 @@ void Clip::apply_keyframes(std::shared_ptr<Frame> frame, std::shared_ptr<QImage>
 }
 
 // Apply apply_waveform image to the source frame (if any)
-void Clip::apply_waveform(std::shared_ptr<Frame> frame, std::shared_ptr<QImage> background_canvas) {
+void Clip::apply_waveform(std::shared_ptr<Frame> frame, std::shared_ptr<Frame> background_frame) {
 
 	if (!Waveform()) {
 		// Exit if no waveform is needed
@@ -1300,6 +1301,7 @@ void Clip::apply_waveform(std::shared_ptr<Frame> frame, std::shared_ptr<QImage> 
 
 	// Get image from clip
 	std::shared_ptr<QImage> source_image = frame->GetImage();
+	std::shared_ptr<QImage> background_canvas = background_frame->GetImage();
 
 	// Debug output
 	ZmqLogger::Instance()->AppendDebugMethod(

--- a/src/Clip.h
+++ b/src/Clip.h
@@ -37,8 +37,6 @@
 #include "KeyFrame.h"
 #include "TrackedObjectBase.h"
 
-#include <QImage>
-
 namespace openshot {
 	class AudioResampler;
 	class EffectInfo;
@@ -132,11 +130,11 @@ namespace openshot {
 		/// Apply effects to the source frame (if any)
 		void apply_effects(std::shared_ptr<openshot::Frame> frame);
 
-		/// Apply keyframes to an openshot::Frame and use an existing QImage as a background image (if any)
-		void apply_keyframes(std::shared_ptr<Frame> frame, std::shared_ptr<QImage> background_canvas);
+		/// Apply keyframes to an openshot::Frame and use an existing background frame (if any)
+		void apply_keyframes(std::shared_ptr<Frame> frame, std::shared_ptr<Frame> background_frame);
 
-		/// Apply waveform image to an openshot::Frame and use an existing QImage as a background image (if any)
-		void apply_waveform(std::shared_ptr<Frame> frame, std::shared_ptr<QImage> background_canvas);
+		/// Apply waveform image to an openshot::Frame and use an existing background frame (if any)
+		void apply_waveform(std::shared_ptr<Frame> frame, std::shared_ptr<Frame> background_frame);
 
 		/// Adjust frame number for Clip position and start (which can result in a different number)
 		int64_t adjust_timeline_framenumber(int64_t clip_frame_number);

--- a/src/FrameMapper.cpp
+++ b/src/FrameMapper.cpp
@@ -513,13 +513,13 @@ std::shared_ptr<Frame> FrameMapper::GetFrame(int64_t requested_frame)
 		// Copy the image from the odd field
 		std::shared_ptr<Frame> odd_frame = mapped_frame;
 
-		if (odd_frame)
+		if (odd_frame && odd_frame->has_image_data)
 			frame->AddImage(std::make_shared<QImage>(*odd_frame->GetImage()), true);
 		if (mapped.Odd.Frame != mapped.Even.Frame) {
 			// Add even lines (if different than the previous image)
 			std::shared_ptr<Frame> even_frame;
 			even_frame = GetOrCreateFrame(mapped.Even.Frame);
-			if (even_frame)
+			if (even_frame && even_frame->has_image_data)
 				frame->AddImage(std::make_shared<QImage>(*even_frame->GetImage()), false);
 		}
 

--- a/src/Timeline.cpp
+++ b/src/Timeline.cpp
@@ -706,8 +706,8 @@ void Timeline::add_layer(std::shared_ptr<Frame> new_frame, Clip* source_clip, in
 	ZmqLogger::Instance()->AppendDebugMethod(
 		"Timeline::add_layer (Transform: Composite Image Layer: Completed)",
 		"source_frame->number", source_frame->number,
-		"new_frame->GetImage()->width()", new_frame->GetImage()->width(),
-		"new_frame->GetImage()->height()", new_frame->GetImage()->height());
+		"new_frame->GetImage()->width()", new_frame->GetWidth(),
+		"new_frame->GetImage()->height()", new_frame->GetHeight());
 }
 
 // Update the list of 'opened' clips

--- a/src/effects/Caption.cpp
+++ b/src/effects/Caption.cpp
@@ -114,6 +114,7 @@ std::shared_ptr<openshot::Frame> Caption::GetFrame(std::shared_ptr<openshot::Fra
 	Clip* clip = (Clip*) ParentClip();
 	Timeline* timeline = NULL;
 	Fraction fps;
+	QSize image_size(1, 1);
 
 	if (clip && clip->ParentTimeline() != NULL) {
 		timeline = (Timeline*) clip->ParentTimeline();
@@ -124,8 +125,15 @@ std::shared_ptr<openshot::Frame> Caption::GetFrame(std::shared_ptr<openshot::Fra
 	// Get the FPS from the parent object (Timeline or Clip's Reader)
 	if (timeline != NULL) {
 		fps = timeline->info.fps;
+		image_size = QSize(timeline->info.width, timeline->info.height);
 	} else if (clip != NULL && clip->Reader() != NULL) {
 		fps = clip->Reader()->info.fps;
+		image_size = QSize(clip->Reader()->info.width, clip->Reader()->info.height);
+	}
+
+	if (!frame->has_image_data) {
+		// Give audio-only files a full frame image of solid color
+		frame->AddColor(image_size.width(), image_size.height(), "#000000");
 	}
 
 	// Get the frame's image
@@ -133,7 +141,7 @@ std::shared_ptr<openshot::Frame> Caption::GetFrame(std::shared_ptr<openshot::Fra
 
 	// Calculate scale factor, to keep different resolutions from
 	// having dramatically different font sizes
-	double timeline_scale_factor = frame->GetImage()->width() / 600.0;
+	double timeline_scale_factor = frame_image->width() / 600.0;
 
 	// Load timeline's new frame image into a QPainter
 	QPainter painter(frame_image.get());


### PR DESCRIPTION
Small refactor to ensure that audio files have no image data - and allow videos below them to show through...