### PR TITLE
Release 0.3.2 (SO 25)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,8 +24,8 @@ For more information, please visit <http://www.openshot.org/>.
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/Modules")
 
 ################ PROJECT VERSION ####################
-set(PROJECT_VERSION_FULL "0.3.1")
-set(PROJECT_SO_VERSION 24)
+set(PROJECT_VERSION_FULL "0.3.2")
+set(PROJECT_SO_VERSION 25)
 
 # Remove the dash and anything following, to get the #.#.# version for project()
 STRING(REGEX REPLACE "\-.*$" "" VERSION_NUM "${PROJECT_VERSION_FULL}")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -176,7 +176,7 @@ target_include_directories(openshot
 # Find JUCE-based openshot Audio libraries
 if(NOT TARGET OpenShot::Audio)
   # Only load if necessary (not for integrated builds)
-  find_package(OpenShotAudio 0.3.0...0.3.1 REQUIRED)
+  find_package(OpenShotAudio 0.3.0...0.3.2 REQUIRED)
 endif()
 target_link_libraries(openshot PUBLIC OpenShot::Audio)
 

--- a/src/Clip.cpp
+++ b/src/Clip.cpp
@@ -232,6 +232,9 @@ Clip::~Clip()
 		delete resampler;
 		resampler = NULL;
 	}
+
+	// Close clip
+	Close();
 }
 
 // Attach clip to bounding box
@@ -335,16 +338,16 @@ void Clip::Open()
 // Close the internal reader
 void Clip::Close()
 {
-	is_open = false;
-	if (reader) {
+	if (is_open && reader) {
 		ZmqLogger::Instance()->AppendDebugMethod("Clip::Close");
 
 		// Close the reader
 		reader->Close();
 	}
-	else
-		// Throw error if reader not initialized
-		throw ReaderClosed("No Reader has been initialized for this Clip.  Call Reader(*reader) before calling this method.");
+
+	// Clear cache
+	final_cache.Clear();
+	is_open = false;
 }
 
 // Get end position of clip (trim end of video), which can be affected by the time curve.

--- a/src/Qt/AudioPlaybackThread.cpp
+++ b/src/Qt/AudioPlaybackThread.cpp
@@ -19,10 +19,12 @@
 #include "../AudioReaderSource.h"
 #include "../AudioDevices.h"
 #include "../Settings.h"
+#include "../ZmqLogger.h"
 
 #include <mutex>
 #include <thread>	// for std::this_thread::sleep_for
 #include <chrono>	// for std::chrono::milliseconds
+#include <sstream>
 
 using namespace juce;
 
@@ -52,6 +54,12 @@ namespace openshot
 			m_pInstance->currentAudioDevice.name = "";
 			m_pInstance->currentAudioDevice.type = "";
 			m_pInstance->defaultSampleRate = 0.0;
+
+			std::stringstream constructor_title;
+			constructor_title << "AudioDeviceManagerSingleton::Instance (default audio device type: " <<
+			Settings::Instance()->PLAYBACK_AUDIO_DEVICE_TYPE << ", default audio device name: " <<
+			Settings::Instance()->PLAYBACK_AUDIO_DEVICE_NAME << ")";
+			ZmqLogger::Instance()->AppendDebugMethod(constructor_title.str(), "channels", channels);
 
 			// Get preferred audio device type and name (if any - these can be blank)
 			openshot::AudioDeviceInfo requested_device = {Settings::Instance()->PLAYBACK_AUDIO_DEVICE_TYPE,
@@ -102,6 +110,10 @@ namespace openshot
 				// do not support 48000 causing no audio device to be found.
 				int possible_rates[] { rate, 48000, 44100, 22050 };
 				for(int attempt_rate : possible_rates) {
+					std::stringstream title_rate;
+					title_rate << "AudioDeviceManagerSingleton::Instance (attempt audio device name: " <<  attempt_device.name << ")";
+					ZmqLogger::Instance()->AppendDebugMethod(title_rate.str(), "rate", attempt_rate, "channels", channels);
+
 					// Update the audio device setup for the current sample rate
 					m_pInstance->defaultSampleRate = attempt_rate;
 					deviceSetup.sampleRate = attempt_rate;
@@ -121,11 +133,22 @@ namespace openshot
 					// Persist any errors detected
 					m_pInstance->initialise_error = audio_error.toStdString();
 
+					if (!m_pInstance->initialise_error.empty()) {
+						std::stringstream title_error;
+						title_error << "AudioDeviceManagerSingleton::Instance (audio device error: " <<
+						m_pInstance->initialise_error << ")";
+						ZmqLogger::Instance()->AppendDebugMethod(title_error.str(), "rate", attempt_rate, "channels", channels);
+					}
+
 					// Determine if audio device was opened successfully, and matches the attempted sample rate
 					// If all rates fail to match, a default audio device and sample rate will be opened if possible
 					foundAudioIODevice = m_pInstance->audioDeviceManager.getCurrentAudioDevice();
 					if (foundAudioIODevice && foundAudioIODevice->getCurrentSampleRate() == attempt_rate) {
 						// Successfully tested a sample rate
+						std::stringstream title_found;
+						title_found << "AudioDeviceManagerSingleton::Instance (successful audio device found: " <<
+						foundAudioIODevice->getTypeName() << ", name: " << foundAudioIODevice->getName() << ")";
+						ZmqLogger::Instance()->AppendDebugMethod(title_found.str(), "rate", attempt_rate, "channels", channels);
 						break;
 					}
 				}
@@ -136,6 +159,7 @@ namespace openshot
 				}
 			}
 
+			ZmqLogger::Instance()->AppendDebugMethod("AudioDeviceManagerSingleton::Instance (audio device initialization completed)");
 		}
 		return m_pInstance;
 	}

--- a/src/Qt/AudioPlaybackThread.cpp
+++ b/src/Qt/AudioPlaybackThread.cpp
@@ -210,6 +210,8 @@ namespace openshot
 		sampleRate = reader->info.sample_rate;
 		numChannels = reader->info.channels;
 
+        ZmqLogger::Instance()->AppendDebugMethod("AudioPlaybackThread::Reader", "rate", sampleRate, "channel", numChannels);
+
 		// Set video cache thread
 		source->setVideoCache(videoCache);
 

--- a/src/Timeline.cpp
+++ b/src/Timeline.cpp
@@ -1096,6 +1096,9 @@ std::vector<Clip*> Timeline::find_intersecting_clips(int64_t requested_frame, in
 
 // Set the cache object used by this reader
 void Timeline::SetCache(CacheBase* new_cache) {
+	// Get lock (prevent getting frames while this happens)
+	const std::lock_guard<std::recursive_mutex> lock(getFrameMutex);
+
 	// Destroy previous cache (if managed by timeline)
 	if (managed_cache && final_cache) {
 		delete final_cache;

--- a/tests/FFmpegReader.cpp
+++ b/tests/FFmpegReader.cpp
@@ -253,6 +253,9 @@ TEST_CASE( "verify parent Timeline", "[libopenshot][ffmpegreader]" )
 	// Check size of frame image (it should now match the parent timeline)
 	CHECK(r.GetFrame(1)->GetImage()->width() == 640);
 	CHECK(r.GetFrame(1)->GetImage()->height() == 360);
+
+	c1.Close();
+	t1.Close();
 }
 
 TEST_CASE( "DisplayInfo", "[libopenshot][ffmpegreader]" )


### PR DESCRIPTION
Part of the OpenShot Video Editor 3.1.1 Release: https://github.com/OpenShot/openshot-qt/pull/5218

**Fixed:**
- Improved logging on audio thread initialization
- Fixed huge memory leak on `Clip::Close()` - not clearing clip cache
- Added lock around `timeline::SetCache()`, which I believe is causing many crashes reported by Sentry.io