### PR TITLE
Revert "Support for New Linux Build Server + glibc Wrapping"

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -36,7 +36,7 @@ linux-builder:
   except:
   - tags
   tags:
-    - linux-bionic
+    - linux-focal
 
 mac-builder:
   stage: build-libopenshot

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -36,7 +36,7 @@ linux-builder:
   except:
   - tags
   tags:
-    - linux-focal
+    - linux-bionic
 
 mac-builder:
   stage: build-libopenshot

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,21 +63,16 @@ option(ENABLE_IWYU "Enable 'Include What You Use' scanner (CMake 3.3+)" OFF)
 option(ENABLE_PARALLEL_CTEST "Run CTest using multiple processors" ON)
 option(VERBOSE_TESTS "Run CTest with maximum verbosity" OFF)
 option(ENABLE_COVERAGE "Scan test coverage using gcov and report" OFF)
+
 option(ENABLE_LIB_DOCS "Build API documentation (requires Doxygen)" ON)
+
 option(APPIMAGE_BUILD "Build to install in an AppImage (Linux only)" OFF)
+
 option(USE_SYSTEM_JSONCPP "Use system installed JsonCpp, if found" ON)
 option(DISABLE_BUNDLED_JSONCPP "Don't fall back to bundled JsonCpp" OFF)
 option(ENABLE_MAGICK "Use ImageMagick, if available" ON)
 option(ENABLE_OPENCV "Build with OpenCV algorithms (requires Boost, Protobuf 3)" ON)
 option(USE_HW_ACCEL "Enable hardware-accelerated encoding-decoding with FFmpeg 3.4+" ON)
-
-if (APPIMAGE_BUILD)
-  # Force older version of glibc and -pthread flag when building AppImage
-  # for better backwards compatibility (i.e older distros)
-  message("Wrapping libc for compatibility with version glibc_2.23")
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -include /usr/local/include/force_link_glibc_2.23.h -static-libgcc")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -include /usr/local/include/force_link_glibc_2.23.h -static-libgcc")
-endif()
 
 # Legacy commandline override
 if (DISABLE_TESTS)

--- a/src/Fraction.cpp
+++ b/src/Fraction.cpp
@@ -65,6 +65,9 @@ int Fraction::GreatestCommonDenominator() {
 void Fraction::Reduce() {
 	// Get the greatest common denominator
 	int GCD = GreatestCommonDenominator();
+	if (GCD == 0) {
+		return;
+	}
 
 	// Reduce this fraction to the smallest possible whole numbers
 	num = num / GCD;

--- a/src/Fraction.cpp
+++ b/src/Fraction.cpp
@@ -65,9 +65,6 @@ int Fraction::GreatestCommonDenominator() {
 void Fraction::Reduce() {
 	// Get the greatest common denominator
 	int GCD = GreatestCommonDenominator();
-	if (GCD == 0) {
-	    return;
-	}
 
 	// Reduce this fraction to the smallest possible whole numbers
 	num = num / GCD;


### PR DESCRIPTION
Reverts OpenShot/libopenshot#878
Related to https://github.com/OpenShot/libopenshot-audio/pull/153

I have reason to believe this change might be responsible for certain crashes in our AppImage. Reverting this for now, to do some testing.