### PR TITLE
Add GetSamplesPerFrame to QtTextReader and QtHtmlReader

### DIFF
--- a/src/QtTextReader.cpp
+++ b/src/QtTextReader.cpp
@@ -114,6 +114,7 @@ void QtTextReader::Open()
 		// Update image properties
 		info.has_audio = false;
 		info.has_video = true;
+		info.has_single_image = true;
 		info.file_size = 0;
 		info.vcodec = "QImage";
 		info.width = width;
@@ -162,12 +163,17 @@ void QtTextReader::Close()
 // Get an openshot::Frame object for a specific frame number of this reader.
 std::shared_ptr<Frame> QtTextReader::GetFrame(int64_t requested_frame)
 {
+	// Create a scoped lock, allowing only a single thread to run the following code at one time
+	const std::lock_guard<std::recursive_mutex> lock(getFrameMutex);
+
+	auto sample_count = Frame::GetSamplesPerFrame(requested_frame, info.fps, info.sample_rate, info.channels);
+
 	if (image)
 	{
 		// Create or get frame object
 		auto image_frame = std::make_shared<Frame>(
 			requested_frame, image->size().width(), image->size().height(),
-			background_color, 0, 2);
+			background_color, sample_count, info.channels);
 
 		// Add Image data to frame
 		image_frame->AddImage(image);
@@ -176,12 +182,11 @@ std::shared_ptr<Frame> QtTextReader::GetFrame(int64_t requested_frame)
 		return image_frame;
 	} else {
 		// return empty frame
-		auto image_frame = std::make_shared<Frame>(1, 640, 480, background_color, 0, 2);
+		auto image_frame = std::make_shared<Frame>(1, 640, 480, background_color, sample_count, info.channels);
 
 		// return frame object
 		return image_frame;
 	}
-
 }
 
 // Generate JSON string of this object


### PR DESCRIPTION
It looks like QtTextReader and QtHtmlReader were omitted when the GetSamplePerFrame functionality was added to other readers. Without the sample_count bad things happen to the audio, see: #913 

This fix adds the same functionality, copied from the QtImageReader, to get the sample_count, and the audio issues reported in #913 seem to be resolved.