### PR TITLE
Fixing caption regex to support numeric-only captions

### DIFF
--- a/src/effects/Caption.cpp
+++ b/src/effects/Caption.cpp
@@ -91,7 +91,7 @@ void Caption::process_regex() {
 		}
 
 		// Parse regex and find all matches (i.e. 00:00.000 --> 00:10.000\ncaption-text)
-		QRegularExpression allPathsRegex(QStringLiteral("(\\d{2})?:*(\\d{2}):(\\d{2}).(\\d{2,3})\\s*-->\\s*(\\d{2})?:*(\\d{2}):(\\d{2}).(\\d{2,3})([\\s\\S]*?)(.*?)(?=\\d{2}.\\d{2,3}|\\Z)"), QRegularExpression::MultilineOption);
+		QRegularExpression allPathsRegex(QStringLiteral("(\\d{2})?:*(\\d{2}):(\\d{2}).(\\d{2,3})\\s*-->\\s*(\\d{2})?:*(\\d{2}):(\\d{2}).(\\d{2,3})([\\s\\S]*?)(.*?)(?=\\d{2}:\\d{2,3}|\\Z)"), QRegularExpression::MultilineOption);
 		QRegularExpressionMatchIterator i = allPathsRegex.globalMatch(caption_prepared);
 		while (i.hasNext()) {
 			QRegularExpressionMatch match = i.next();


### PR DESCRIPTION
Our regex which parses the caption text, had a look-ahead pattern for essentially 5 numeric digits (i.e. assuming that was the start of the next time code). I am going to improve this to look for this pattern instead: `##:##`, which should resolve this issue.

Closes https://github.com/OpenShot/openshot-qt/issues/5240