### PR TITLE
Fix Frame::GetSamplesPerFrame when channels = 0

### DIFF
--- a/src/Frame.cpp
+++ b/src/Frame.cpp
@@ -455,6 +455,10 @@ void Frame::SetFrameNumber(int64_t new_number)
 // Calculate the # of samples per video frame (for a specific frame number and frame rate)
 int Frame::GetSamplesPerFrame(int64_t number, Fraction fps, int sample_rate, int channels)
 {
+	// Directly return 0 if there are no channels
+	// so that we do not need to deal with NaNs later
+	if (channels == 0) return 0;
+
 	// Get the total # of samples for the previous frame, and the current frame (rounded)
 	double fps_rate = fps.Reciprocal().ToDouble();
 


### PR DESCRIPTION
This function is relying on the implementation defined behavior of x86_64 to work properly.

On x86_64,  `fmod` returns -NaN when `channels = 0`, it is handled by  `if (samples_per_frame < 0)`.

But on other architectures(like riscv64), `fmod` may return a positive NaN which will cause this function to return a bad value.

It is causing several tests to spin forever on riscv64.

This PR fixes it by directly return 0 when `channels == 0` so that we do not need to deal with NaNs.