### PR TITLE
Ignore NULL nodes in JSON arrays (clips, effects). 

### DIFF
--- a/src/Clip.cpp
+++ b/src/Clip.cpp
@@ -1040,6 +1040,11 @@ void Clip::SetJsonValue(const Json::Value root) {
 
 		// loop through effects
 		for (const auto existing_effect : root["effects"]) {
+			// Skip NULL nodes
+			if (existing_effect.isNull()) {
+				continue;
+			}
+
 			// Create Effect
 			EffectBase *e = NULL;
 			if (!existing_effect["type"].isNull()) {

--- a/src/Timeline.cpp
+++ b/src/Timeline.cpp
@@ -1193,6 +1193,11 @@ void Timeline::SetJsonValue(const Json::Value root) {
 
 		// loop through clips
 		for (const Json::Value existing_clip : root["clips"]) {
+			// Skip NULL nodes
+			if (existing_clip.isNull()) {
+				continue;
+			}
+
 			// Create Clip
 			Clip *c = new Clip();
 
@@ -1220,6 +1225,11 @@ void Timeline::SetJsonValue(const Json::Value root) {
 
 		// loop through effects
 		for (const Json::Value existing_effect :root["effects"]) {
+			// Skip NULL nodes
+			if (existing_effect.isNull()) {
+				continue;
+			}
+
 			// Create Effect
 			EffectBase *e = NULL;
 


### PR DESCRIPTION
This can happen sometimes (for an unknown reason), and it currently crashes OpenShot when attempting to Export a video.