### PR TITLE
Improved Tracker & Object Detector Effects (Faster Drawing, Corner Radius, New Style)

### DIFF
--- a/src/Clip.cpp
+++ b/src/Clip.cpp
@@ -479,6 +479,24 @@ openshot::EffectBase* Clip::GetEffect(const std::string& id)
 	return nullptr;
 }
 
+// Return the associated ParentClip (if any)
+openshot::Clip* Clip::GetParentClip() {
+    if (!parentObjectId.empty() && (!parentClipObject && !parentTrackedObject)) {
+        // Attach parent clip OR object to this clip
+        AttachToObject(parentObjectId);
+    }
+    return parentClipObject;
+}
+
+// Return the associated Parent Tracked Object (if any)
+std::shared_ptr<openshot::TrackedObjectBase> Clip::GetParentTrackedObject() {
+    if (!parentObjectId.empty() && (!parentClipObject && !parentTrackedObject)) {
+        // Attach parent clip OR object to this clip
+        AttachToObject(parentObjectId);
+    }
+    return parentTrackedObject;
+}
+
 // Get file extension
 std::string Clip::get_file_extension(std::string path)
 {
@@ -1409,7 +1427,7 @@ QTransform Clip::get_transform(std::shared_ptr<Frame> frame, int width, int heig
 	float parentObject_rotation = 0.0;
 
 	// Get the parentClipObject properties
-	if (parentClipObject){
+	if (GetParentClip()){
         // Get the start trim position of the parent clip
         long parent_start_offset = parentClipObject->Start() * info.fps.ToDouble();
         long parent_frame_number = frame->number + parent_start_offset;
@@ -1425,7 +1443,7 @@ QTransform Clip::get_transform(std::shared_ptr<Frame> frame, int width, int heig
 	}
 
     // Get the parentTrackedObject properties
-    if (parentTrackedObject){
+    if (GetParentTrackedObject()){
         // Get the attached object's parent clip's properties
         Clip* parentClip = (Clip*) parentTrackedObject->ParentClip();
         if (parentClip)

--- a/src/Clip.cpp
+++ b/src/Clip.cpp
@@ -251,9 +251,11 @@ void Clip::AttachToObject(std::string object_id)
 		// Check for valid tracked object
 		if (trackedObject){
 			SetAttachedObject(trackedObject);
+            parentClipObject = NULL;
 		}
 		else if (clipObject) {
 			SetAttachedClip(clipObject);
+            parentTrackedObject = nullptr;
 		}
 	}
 }

--- a/src/Clip.h
+++ b/src/Clip.h
@@ -131,13 +131,13 @@ namespace openshot {
 		void apply_background(std::shared_ptr<openshot::Frame> frame, std::shared_ptr<openshot::Frame> background_frame);
 
 		/// Apply effects to the source frame (if any)
-		void apply_effects(std::shared_ptr<openshot::Frame> frame, std::shared_ptr<openshot::Frame> background_frame, TimelineInfoStruct* options, bool before_keyframes);
+		void apply_effects(std::shared_ptr<openshot::Frame> frame, int64_t timeline_frame_number, TimelineInfoStruct* options, bool before_keyframes);
 
 		/// Apply keyframes to an openshot::Frame and use an existing background frame (if any)
-		void apply_keyframes(std::shared_ptr<Frame> frame, std::shared_ptr<Frame> background_frame);
+		void apply_keyframes(std::shared_ptr<Frame> frame, QSize timeline_size);
 
 		/// Apply waveform image to an openshot::Frame and use an existing background frame (if any)
-		void apply_waveform(std::shared_ptr<Frame> frame, std::shared_ptr<Frame> background_frame);
+		void apply_waveform(std::shared_ptr<Frame> frame, QSize timeline_size);
 
 		/// Adjust frame number for Clip position and start (which can result in a different number)
 		int64_t adjust_timeline_framenumber(int64_t clip_frame_number);
@@ -154,8 +154,8 @@ namespace openshot {
 		/// Adjust the audio and image of a time mapped frame
 		void apply_timemapping(std::shared_ptr<openshot::Frame> frame);
 
-		/// Compare 2 floating point numbers
-		bool isEqual(double a, double b);
+		/// Compare 2 floating point numbers and return true if they are extremely close
+		bool isNear(double a, double b);
 
 		/// Sort effects by order
 		void sort_effects();

--- a/src/Clip.h
+++ b/src/Clip.h
@@ -224,6 +224,12 @@ namespace openshot {
 		/// Close the internal reader
 		void Close() override;
 
+		/// Return the associated ParentClip (if any)
+		openshot::Clip* GetParentClip();
+
+		/// Return the associated Parent Tracked Object (if any)
+		std::shared_ptr<openshot::TrackedObjectBase> GetParentTrackedObject();
+
 		/// Return the list of effects on the timeline
 		std::list<openshot::EffectBase*> Effects() { return effects; };
 

--- a/src/Clip.h
+++ b/src/Clip.h
@@ -160,9 +160,8 @@ namespace openshot {
 		/// Sort effects by order
 		void sort_effects();
 
-		/// Reverse an audio buffer
-		void reverse_buffer(juce::AudioBuffer<float>* buffer);
-
+		/// Scale a source size to a target size (given a specific scale-type)
+		QSize scale_size(QSize source_size, ScaleType source_scale, int target_width, int target_height);
 
 	public:
 		openshot::GravityType gravity;   ///< The gravity of a clip determines where it snaps to its parent

--- a/src/KeyFrame.cpp
+++ b/src/KeyFrame.cpp
@@ -374,18 +374,25 @@ void Keyframe::SetJsonValue(const Json::Value root) {
 	Points.clear();
 	Points.shrink_to_fit();
 
-	if (!root["Points"].isNull())
-		// loop through points
-		for (const auto existing_point : root["Points"]) {
-			// Create Point
-			Point p;
+	if (root.isObject() && !root["Points"].isNull()) {
+        // loop through points in JSON Object
+        for (const auto existing_point : root["Points"]) {
+            // Create Point
+            Point p;
 
-			// Load Json into Point
-			p.SetJsonValue(existing_point);
+            // Load Json into Point
+            p.SetJsonValue(existing_point);
 
-			// Add Point to Keyframe
-			AddPoint(p);
-		}
+            // Add Point to Keyframe
+            AddPoint(p);
+        }
+    } else if (root.isNumeric()) {
+        // Create Point from Numeric value
+        Point p(root.asFloat());
+
+        // Add Point to Keyframe
+        AddPoint(p);
+	}
 }
 
 // Get the change in Y value (from the previous Y value)

--- a/src/TrackedObjectBBox.cpp
+++ b/src/TrackedObjectBBox.cpp
@@ -314,7 +314,6 @@ Json::Value TrackedObjectBBox::JsonValue() const
 	root["BaseFPS"]["num"] = BaseFps.num;
 	root["BaseFPS"]["den"] = BaseFps.den;
 	root["TimeScale"] = TimeScale;
-	root["child_clip_id"] = ChildClipId();
 
 	// Keyframe's properties
 	root["delta_x"] = delta_x.JsonValue();
@@ -379,11 +378,6 @@ void TrackedObjectBBox::SetJsonValue(const Json::Value root)
 	if (!root["protobuf_data_path"].isNull())
 		protobufDataPath = root["protobuf_data_path"].asString();
 
-	// Set the id of the child clip
-	if (!root["child_clip_id"].isNull() && root["child_clip_id"].asString() != Id()){
-		ChildClipId(root["child_clip_id"].asString());
-	}
-
 	// Set the Keyframes by the given JSON object
 	if (!root["delta_x"].isNull())
 		delta_x.SetJsonValue(root["delta_x"]);
@@ -424,9 +418,6 @@ Json::Value TrackedObjectBBox::PropertiesJSON(int64_t requested_frame) const
 
 	// Add the ID of this object to the JSON object
 	root["box_id"] = add_property_json("Box ID", 0.0, "string", Id(), NULL, -1, -1, true, requested_frame);
-
-	// Add the ID of this object's child clip to the JSON object
-	root["child_clip_id"] = add_property_json("Child Clip ID", 0.0, "string", ChildClipId(), NULL, -1, -1, false, requested_frame);
 
 	// Add the data of given frame bounding-box to the JSON object
 	root["x1"] = add_property_json("X1", box.cx-(box.width/2), "float", "", NULL, 0.0, 1.0, true, requested_frame);

--- a/src/TrackedObjectBBox.cpp
+++ b/src/TrackedObjectBBox.cpp
@@ -34,7 +34,7 @@ TrackedObjectBBox::TrackedObjectBBox(int Red, int Green, int Blue, int Alfa)
 	: delta_x(0.0), delta_y(0.0),
 	  scale_x(1.0), scale_y(1.0), rotation(0.0),
 	  background_alpha(0.0), background_corner(12),
-	  stroke_width(2) , stroke_alpha(0.5),
+	  stroke_width(2) , stroke_alpha(0.70),
 	  stroke(Red, Green, Blue, Alfa),
 	  background(0, 0, 255, Alfa)
 {

--- a/src/TrackedObjectBBox.cpp
+++ b/src/TrackedObjectBBox.cpp
@@ -456,7 +456,7 @@ Json::Value TrackedObjectBBox::PropertiesJSON(int64_t requested_frame) const
 	root["stroke_alpha"] = add_property_json("Stroke alpha", stroke_alpha.GetValue(requested_frame), "float", "", &stroke_alpha, 0.0, 1.0, false, requested_frame);
 
 	root["background_alpha"] = add_property_json("Background Alpha", background_alpha.GetValue(requested_frame), "float", "", &background_alpha, 0.0, 1.0, false, requested_frame);
-	root["background_corner"] = add_property_json("Background Corner Radius", background_corner.GetValue(requested_frame), "int", "", &background_corner, 0.0, 60.0, false, requested_frame);
+	root["background_corner"] = add_property_json("Background Corner Radius", background_corner.GetValue(requested_frame), "int", "", &background_corner, 0.0, 150.0, false, requested_frame);
 
 	root["background"] = add_property_json("Background", 0.0, "color", "", NULL, 0, 255, false, requested_frame);
 	root["background"]["red"] = add_property_json("Red", background.red.GetValue(requested_frame), "float", "", &background.red, 0, 255, false, requested_frame);

--- a/src/TrackedObjectBBox.cpp
+++ b/src/TrackedObjectBBox.cpp
@@ -431,9 +431,7 @@ Json::Value TrackedObjectBBox::PropertiesJSON(int64_t requested_frame) const
 	root["scale_x"] = add_property_json("Scale (Width)", scale_x.GetValue(requested_frame), "float", "", &scale_x, 0.0, 1.0, false, requested_frame);
 	root["scale_y"] = add_property_json("Scale (Height)", scale_y.GetValue(requested_frame), "float", "", &scale_y, 0.0, 1.0, false, requested_frame);
 	root["rotation"] = add_property_json("Rotation", rotation.GetValue(requested_frame), "float", "", &rotation, 0, 360, false, requested_frame);
-	root["visible"] = add_property_json("Visible", visible.GetValue(requested_frame), "int", "", &visible, 0, 1, false, requested_frame);
-    root["visible"]["choices"].append(add_property_choice_json("Yes", true, visible.GetValue(requested_frame)));
-    root["visible"]["choices"].append(add_property_choice_json("No", false, visible.GetValue(requested_frame)));
+	root["visible"] = add_property_json("Visible", visible.GetValue(requested_frame), "int", "", &visible, 0, 1, true, requested_frame);
 
 	root["draw_box"] = add_property_json("Draw Box", draw_box.GetValue(requested_frame), "int", "", &draw_box, 0, 1, false, requested_frame);
     root["draw_box"]["choices"].append(add_property_choice_json("Yes", true, draw_box.GetValue(requested_frame)));

--- a/src/TrackedObjectBBox.cpp
+++ b/src/TrackedObjectBBox.cpp
@@ -34,7 +34,7 @@ TrackedObjectBBox::TrackedObjectBBox(int Red, int Green, int Blue, int Alfa)
 	: delta_x(0.0), delta_y(0.0),
 	  scale_x(1.0), scale_y(1.0), rotation(0.0),
 	  background_alpha(0.0), background_corner(12),
-	  stroke_width(2) , stroke_alpha(0.70),
+	  stroke_width(2) , stroke_alpha(0.7),
 	  stroke(Red, Green, Blue, Alfa),
 	  background(0, 0, 255, Alfa)
 {

--- a/src/TrackedObjectBBox.cpp
+++ b/src/TrackedObjectBBox.cpp
@@ -429,10 +429,10 @@ Json::Value TrackedObjectBBox::PropertiesJSON(int64_t requested_frame) const
 	root["child_clip_id"] = add_property_json("Child Clip ID", 0.0, "string", ChildClipId(), NULL, -1, -1, false, requested_frame);
 
 	// Add the data of given frame bounding-box to the JSON object
-	root["x1"] = add_property_json("X1", box.cx-(box.width/2), "float", "", NULL, 0.0, 1.0, false, requested_frame);
-	root["y1"] = add_property_json("Y1", box.cy-(box.height/2), "float", "", NULL, 0.0, 1.0, false, requested_frame);
-	root["x2"] = add_property_json("X2", box.cx+(box.width/2), "float", "", NULL, 0.0, 1.0, false, requested_frame);
-	root["y2"] = add_property_json("Y2", box.cy+(box.height/2), "float", "", NULL, 0.0, 1.0, false, requested_frame);
+	root["x1"] = add_property_json("X1", box.cx-(box.width/2), "float", "", NULL, 0.0, 1.0, true, requested_frame);
+	root["y1"] = add_property_json("Y1", box.cy-(box.height/2), "float", "", NULL, 0.0, 1.0, true, requested_frame);
+	root["x2"] = add_property_json("X2", box.cx+(box.width/2), "float", "", NULL, 0.0, 1.0, true, requested_frame);
+	root["y2"] = add_property_json("Y2", box.cy+(box.height/2), "float", "", NULL, 0.0, 1.0, true, requested_frame);
 
 	// Add the bounding-box Keyframes to the JSON object
 	root["delta_x"] = add_property_json("Displacement X-axis", delta_x.GetValue(requested_frame), "float", "", &delta_x, -1.0, 1.0, false, requested_frame);

--- a/src/TrackedObjectBBox.cpp
+++ b/src/TrackedObjectBBox.cpp
@@ -26,20 +26,19 @@ using namespace openshot;
 
 // Default Constructor, delegating
 TrackedObjectBBox::TrackedObjectBBox()
-	: TrackedObjectBBox::TrackedObjectBBox(0, 0, 255, 0) {}
+	: TrackedObjectBBox::TrackedObjectBBox(0, 0, 255, 255) {}
 
 // Constructor that takes RGBA values for stroke, and sets the bounding-box
 // displacement as 0 and the scales as 1 for the first frame
 TrackedObjectBBox::TrackedObjectBBox(int Red, int Green, int Blue, int Alfa)
 	: delta_x(0.0), delta_y(0.0),
 	  scale_x(1.0), scale_y(1.0), rotation(0.0),
-	  background_alpha(1.0), background_corner(0),
-	  stroke_width(2) , stroke_alpha(0.0),
+	  background_alpha(0.0), background_corner(12),
+	  stroke_width(2) , stroke_alpha(0.5),
 	  stroke(Red, Green, Blue, Alfa),
-	  background(0, 0, 255, 0)
+	  background(0, 0, 255, Alfa)
 {
 	this->TimeScale = 1.0;
-	return;
 }
 
 // Add a BBox to the BoxVec map
@@ -442,10 +441,12 @@ Json::Value TrackedObjectBBox::PropertiesJSON(int64_t requested_frame) const
 	root["scale_y"] = add_property_json("Scale (Height)", scale_y.GetValue(requested_frame), "float", "", &scale_y, 0.0, 1.0, false, requested_frame);
 	root["rotation"] = add_property_json("Rotation", rotation.GetValue(requested_frame), "float", "", &rotation, 0, 360, false, requested_frame);
 	root["visible"] = add_property_json("Visible", visible.GetValue(requested_frame), "int", "", &visible, 0, 1, false, requested_frame);
+    root["visible"]["choices"].append(add_property_choice_json("Yes", true, visible.GetValue(requested_frame)));
+    root["visible"]["choices"].append(add_property_choice_json("No", false, visible.GetValue(requested_frame)));
 
-	root["draw_box"] = add_property_json("Draw Box", draw_box.GetValue(requested_frame), "int", "", &draw_box, -1, 1.0, false, requested_frame);
-	root["draw_box"]["choices"].append(add_property_choice_json("Off", 0, draw_box.GetValue(requested_frame)));
-	root["draw_box"]["choices"].append(add_property_choice_json("On", 1, draw_box.GetValue(requested_frame)));
+	root["draw_box"] = add_property_json("Draw Box", draw_box.GetValue(requested_frame), "int", "", &draw_box, 0, 1, false, requested_frame);
+    root["draw_box"]["choices"].append(add_property_choice_json("Yes", true, draw_box.GetValue(requested_frame)));
+	root["draw_box"]["choices"].append(add_property_choice_json("No", false, draw_box.GetValue(requested_frame)));
 
 	root["stroke"] = add_property_json("Border", 0.0, "color", "", NULL, 0, 255, false, requested_frame);
 	root["stroke"]["red"] = add_property_json("Red", stroke.red.GetValue(requested_frame), "float", "", &stroke.red, 0, 255, false, requested_frame);

--- a/src/TrackedObjectBBox.cpp
+++ b/src/TrackedObjectBBox.cpp
@@ -522,36 +522,3 @@ std::map<std::string, float> TrackedObjectBBox::GetBoxValues(int64_t frame_numbe
 
 	return boxValues;
 }
-
-// Return a map that contains the properties of this object's parent clip
-std::map<std::string, float> TrackedObjectBBox::GetParentClipProperties(int64_t frame_number) const {
-
-	// Get the parent clip of this object as a Clip pointer
-	Clip* parentClip = (Clip *) ParentClip();
-
-	// Calculate parentClip's frame number
-	long parentClip_start_position = round( parentClip->Position() * parentClip->info.fps.ToDouble() ) + 1;
-	long parentClip_start_frame = ( parentClip->Start() * parentClip->info.fps.ToDouble() ) + 1;
-	float parentClip_frame_number = round(frame_number - parentClip_start_position) + parentClip_start_frame;
-
-	// Get parentClip's Keyframes
-	float parentClip_location_x = parentClip->location_x.GetValue(parentClip_frame_number);
-	float parentClip_location_y = parentClip->location_y.GetValue(parentClip_frame_number);
-	float parentClip_scale_x = parentClip->scale_x.GetValue(parentClip_frame_number);
-	float parentClip_scale_y = parentClip->scale_y.GetValue(parentClip_frame_number);
-	float parentClip_rotation = parentClip->rotation.GetValue(parentClip_frame_number);
-
-	// Initialize the parent clip properties map
-	std::map<std::string, float> parentClipProperties;
-
-	// Set the map properties
-	parentClipProperties["frame_number"] = parentClip_frame_number;
-	parentClipProperties["timeline_frame_number"] = frame_number;
-	parentClipProperties["location_x"] = parentClip_location_x;
-	parentClipProperties["location_y"] = parentClip_location_y;
-	parentClipProperties["scale_x"] = parentClip_scale_x;
-	parentClipProperties["scale_y"] = parentClip_scale_y;
-	parentClipProperties["rotation"] = parentClip_rotation;
-
-	return parentClipProperties;
-}

--- a/src/TrackedObjectBBox.h
+++ b/src/TrackedObjectBBox.h
@@ -211,9 +211,6 @@ namespace openshot
 
 		/// Return a map that contains the bounding box properties and it's keyframes indexed by their names
 		std::map<std::string, float> GetBoxValues(int64_t frame_number) const override;
-		/// Return a map that contains the properties of this object's parent clip
-		std::map<std::string, float> GetParentClipProperties(int64_t frame_number) const override;
-
 	};
 } // namespace openshot
 

--- a/src/TrackedObjectBase.cpp
+++ b/src/TrackedObjectBase.cpp
@@ -23,7 +23,7 @@ namespace openshot
 
 	// Constructor
 	TrackedObjectBase::TrackedObjectBase(std::string _id)
-		: visible(1.0), draw_box(1), id(_id), childClipId("") {}
+		: visible(1.0), draw_box(1), id(_id) {}
 
 	Json::Value TrackedObjectBase::add_property_choice_json(
 		std::string name, int value, int selected_value) const

--- a/src/TrackedObjectBase.h
+++ b/src/TrackedObjectBase.h
@@ -35,8 +35,6 @@ namespace openshot {
 	class TrackedObjectBase {
 	protected:
 		std::string id;
-		std::string childClipId;
-
 		ClipBase* parentClip;
 
 	public:
@@ -60,9 +58,6 @@ namespace openshot {
 		/// Get and set the parentClip of this object
 		ClipBase* ParentClip() const { return parentClip; }
 		void ParentClip(ClipBase* clip) { parentClip = clip; }
-		/// Get and set the Id of the childClip of this object
-		std::string ChildClipId() const { return childClipId; };
-		void ChildClipId(std::string _childClipId) { childClipId = _childClipId; };
 
 		/// Check if there is data for the exact frame number
 		virtual bool ExactlyContains(int64_t frame_number) const { return {}; };

--- a/src/TrackedObjectBase.h
+++ b/src/TrackedObjectBase.h
@@ -66,8 +66,6 @@ namespace openshot {
 		virtual void ScalePoints(double scale) { return; };
 		/// Return the main properties of a TrackedObjectBBox instance - such as position, size and rotation
 		virtual std::map<std::string, float> GetBoxValues(int64_t frame_number) const { std::map<std::string, float> ret; return ret; };
-		/// Return the main properties of the tracked object's parent clip - such as position, size and rotation
-		virtual std::map<std::string, float> GetParentClipProperties(int64_t frame_number) const { std::map<std::string, float> ret; return ret; }
 		/// Add a bounding box to the tracked object's BoxVec map
 		virtual void AddBox(int64_t _frame_num, float _cx, float _cy, float _width, float _height, float _angle) { return; };
 

--- a/src/TrackedObjectBase.h
+++ b/src/TrackedObjectBase.h
@@ -39,7 +39,10 @@ namespace openshot {
 
 	public:
 
+	    /// Keyframe to track if a box is visible in the current frame (read-only)
 		Keyframe visible;
+
+	    /// Keyframe to determine if a specific box is drawn (or hidden)
 		Keyframe draw_box;
 
 		/// Default constructor

--- a/src/effects/ObjectDetection.cpp
+++ b/src/effects/ObjectDetection.cpp
@@ -157,22 +157,6 @@ std::shared_ptr<Frame> ObjectDetection::GetFrame(std::shared_ptr<Frame> frame, i
                             painter.drawText(QPointF(left, top), label);
                         }
                     }
-
-                    // Get the image of the Tracked Object' child clip
-                    if (trackedObject->ChildClipId() != "") {
-                        Timeline* parentTimeline = static_cast<Timeline *>(ParentTimeline());
-                        if (parentTimeline) {
-                            Clip* childClip = parentTimeline->GetClip(trackedObject->ChildClipId());
-                            if (childClip) {
-                                std::shared_ptr<Frame> childClipFrame = childClip->GetFrame(frame_number);
-                                std::shared_ptr<QImage> childClipImage = childClipFrame->GetImage();
-
-                                // Scale the original bounding box to this image
-                                QRectF scaledRect = Tracker::scaleAndCenterRect(QRectF(childClipImage->rect()), boxRect);
-                                painter.drawImage(scaledRect, *childClipImage);
-                            }
-                        }
-                    }
                 }
             }
         }

--- a/src/effects/ObjectDetection.cpp
+++ b/src/effects/ObjectDetection.cpp
@@ -19,11 +19,12 @@
 #include "Exceptions.h"
 #include "Timeline.h"
 #include "objdetectdata.pb.h"
-#include "Tracker.h"
 
 #include <QImage>
 #include <QPainter>
 #include <QRectF>
+#include <QString>
+#include <QStringList>
 using namespace std;
 using namespace openshot;
 
@@ -407,18 +408,24 @@ void ObjectDetection::SetJsonValue(const Json::Value root) {
 	if (!root["display_box_text"].isNull())
 		display_box_text.SetJsonValue(root["display_box_text"]);
 
-	if (!root["class_filter"].isNull()){
-		class_filter = root["class_filter"].asString();
-		std::stringstream ss(class_filter);
-		display_classes.clear();
-		while( ss.good() )
-		{
-			// Parse comma separated string
-			std::string substr;
-			std::getline( ss, substr, ',' );
-			display_classes.push_back( substr );
-		}
-	}
+    if (!root["class_filter"].isNull()) {
+        class_filter = root["class_filter"].asString();
+
+        // Convert the class_filter to a QString
+        QString qClassFilter = QString::fromStdString(root["class_filter"].asString());
+
+        // Split the QString by commas and automatically trim each resulting string
+        QStringList classList = qClassFilter.split(',', QString::SkipEmptyParts);
+        display_classes.clear();
+
+        // Iterate over the QStringList and add each trimmed, non-empty string
+        for (const QString &classItem : classList) {
+            QString trimmedItem = classItem.trimmed();
+            if (!trimmedItem.isEmpty()) {
+                display_classes.push_back(trimmedItem.toStdString());
+            }
+        }
+    }
 
 	if (!root["objects"].isNull()){
 		for (auto const& trackedObject : trackedObjects){

--- a/src/effects/ObjectDetection.cpp
+++ b/src/effects/ObjectDetection.cpp
@@ -109,7 +109,7 @@ std::shared_ptr<Frame> ObjectDetection::GetFrame(std::shared_ptr<Frame> frame, i
 
                     if (trackedObject->draw_box.GetValue(frame_number) == 1) {
                         // Draw bounding box
-                        bool display_text = !display_box_text.GetValue(frame_number);
+                        bool display_text = display_box_text.GetValue(frame_number);
                         std::vector<int> stroke_rgba = trackedObject->stroke.GetColorRGBA(frame_number);
                         std::vector<int> bg_rgba = trackedObject->background.GetColorRGBA(frame_number);
                         int stroke_width = trackedObject->stroke_width.GetValue(frame_number);

--- a/src/effects/ObjectDetection.cpp
+++ b/src/effects/ObjectDetection.cpp
@@ -82,9 +82,6 @@ std::shared_ptr<Frame> ObjectDetection::GetFrame(std::shared_ptr<Frame> frame, i
     painter.setRenderHints(QPainter::Antialiasing | QPainter::SmoothPixmapTransform);
 
     if (detectionsData.find(frame_number) != detectionsData.end()) {
-        float fw = frame_image->width();
-        float fh = frame_image->height();
-
         DetectionData detections = detectionsData[frame_number];
         for (int i = 0; i < detections.boxes.size(); i++) {
             if (detections.confidences.at(i) < confidence_threshold ||
@@ -99,13 +96,13 @@ std::shared_ptr<Frame> ObjectDetection::GetFrame(std::shared_ptr<Frame> frame, i
             if (trackedObject_it != trackedObjects.end()) {
                 std::shared_ptr<TrackedObjectBBox> trackedObject = std::static_pointer_cast<TrackedObjectBBox>(trackedObject_it->second);
 
-                if (trackedObject->Contains(frame_number) && trackedObject->visible.GetValue(frame_number) == 1) {
+                Clip* parentClip = (Clip*) trackedObject->ParentClip();
+                if (parentClip && trackedObject->Contains(frame_number) && trackedObject->visible.GetValue(frame_number) == 1) {
                     BBox trackedBox = trackedObject->GetBox(frame_number);
-
-                    QRectF boxRect((trackedBox.cx - trackedBox.width / 2) * fw,
-                                   (trackedBox.cy - trackedBox.height / 2) * fh,
-                                   trackedBox.width * fw,
-                                   trackedBox.height * fh);
+                    QRectF boxRect((trackedBox.cx - trackedBox.width / 2) * frame_image->width(),
+                                   (trackedBox.cy - trackedBox.height / 2) * frame_image->height(),
+                                   trackedBox.width * frame_image->width(),
+                                   trackedBox.height * frame_image->height());
 
                     if (trackedObject->draw_box.GetValue(frame_number) == 1) {
                         // Draw bounding box

--- a/src/effects/ObjectDetection.cpp
+++ b/src/effects/ObjectDetection.cpp
@@ -420,7 +420,7 @@ void ObjectDetection::SetJsonValue(const Json::Value root) {
 
         // Iterate over the QStringList and add each trimmed, non-empty string
         for (const QString &classItem : classList) {
-            QString trimmedItem = classItem.trimmed();
+            QString trimmedItem = classItem.trimmed().toLower();
             if (!trimmedItem.isEmpty()) {
                 display_classes.push_back(trimmedItem.toStdString());
             }

--- a/src/effects/ObjectDetection.h
+++ b/src/effects/ObjectDetection.h
@@ -62,10 +62,15 @@ namespace openshot
         std::vector<std::string> classNames;
         std::vector<cv::Scalar> classesColor;
 
-        /// Draw class name and confidence score on top of the bounding box
+        /// Draw ALL class name and ID #'s on top of the bounding boxes (or hide all text)
         Keyframe display_box_text;
+
+        /// Draw ALL tracked bounding boxes (or hide all boxes)
+        Keyframe display_boxes;
+
         /// Minimum confidence value to display the detected objects
         float confidence_threshold = 0.5;
+
         /// Contain the user selected classes for visualization
         std::vector<std::string> display_classes;
         std::string class_filter;

--- a/src/effects/ObjectDetection.h
+++ b/src/effects/ObjectDetection.h
@@ -60,7 +60,6 @@ namespace openshot
         std::string protobuf_data_path;
         std::map<size_t, DetectionData> detectionsData;
         std::vector<std::string> classNames;
-
         std::vector<cv::Scalar> classesColor;
 
         /// Draw class name and confidence score on top of the bounding box
@@ -73,12 +72,6 @@ namespace openshot
 
         /// Init effect settings
         void init_effect_details();
-        /// Draw bounding box with class and score text
-        void drawPred(int classId, float conf, cv::Rect2d box, cv::Mat& frame, int objectNumber, std::vector<int> color, float alpha,
-                        int thickness, bool is_background, bool draw_text);
-        /// Draw rotated rectangle with alpha channel
-        void DrawRectangleRGBA(cv::Mat &frame_image, cv::RotatedRect box, std::vector<int> color, float alpha, int thickness, bool is_background);
-
 
     public:
         /// Index of the Tracked Object that was selected to modify it's properties

--- a/src/effects/Tracker.cpp
+++ b/src/effects/Tracker.cpp
@@ -128,25 +128,6 @@ std::shared_ptr<Frame> Tracker::GetFrame(std::shared_ptr<Frame> frame, int64_t f
             painter.drawRoundedRect(boxRect, bg_corner, bg_corner);
         }
 
-        // Get the image of the Tracked Object' child clip
-        if (trackedData->ChildClipId() != ""){
-            // Cast the parent timeline of this effect
-            Timeline* parentTimeline = static_cast<Timeline *>(ParentTimeline());
-            if (parentTimeline){
-                // Get the Tracked Object's child clip
-                Clip* childClip = parentTimeline->GetClip(trackedData->ChildClipId());
-                if (childClip){
-                    // Get the image of the child clip for this frame
-                    std::shared_ptr<Frame> childClipFrame = childClip->GetFrame(frame_number);
-                    std::shared_ptr<QImage> childClipImage = childClipFrame->GetImage();
-
-                    // Scale the original bounding box to this image
-                    QRectF scaledRect = scaleAndCenterRect(QRectF(childClipImage->rect()), boxRect);
-                    painter.drawImage(scaledRect, *childClipImage);
-                }
-            }
-        }
-
         painter.end();
     }
 

--- a/src/effects/Tracker.cpp
+++ b/src/effects/Tracker.cpp
@@ -13,7 +13,6 @@
 
 #include <string>
 #include <memory>
-#include <fstream>
 #include <iostream>
 
 #include "effects/Tracker.h"
@@ -25,6 +24,8 @@
 
 #include <QImage>
 #include <QPainter>
+#include <QPen>
+#include <QBrush>
 #include <QRectF>
 
 using namespace std;
@@ -83,129 +84,100 @@ void Tracker::init_effect_details()
 
 // This method is required for all derived classes of EffectBase, and returns a
 // modified openshot::Frame object
-std::shared_ptr<Frame> Tracker::GetFrame(std::shared_ptr<Frame> frame, int64_t frame_number)
-{
-	// Get the frame's image
-	cv::Mat frame_image = frame->GetImageCV();
+std::shared_ptr<Frame> Tracker::GetFrame(std::shared_ptr<Frame> frame, int64_t frame_number) {
+    // Get the frame's QImage
+    std::shared_ptr<QImage> frame_image = frame->GetImage();
 
-	// Initialize the Qt rectangle that will hold the positions of the bounding-box
-	QRectF boxRect;
-	// Initialize the image of the TrackedObject child clip
-	std::shared_ptr<QImage> childClipImage = nullptr;
+    // Check if frame isn't NULL
+    if(frame_image && !frame_image->isNull() &&
+       trackedData->Contains(frame_number) &&
+       trackedData->visible.GetValue(frame_number) == 1) {
+        QPainter painter(frame_image.get());
 
-	// Check if frame isn't NULL
-	if(!frame_image.empty() &&
-		trackedData->Contains(frame_number) &&
-		trackedData->visible.GetValue(frame_number) == 1)
-	{
-		// Get the width and height of the image
-		float fw = frame_image.size().width;
-		float fh = frame_image.size().height;
+        // Get the bounding-box of the given frame
+        BBox fd = trackedData->GetBox(frame_number);
 
-		// Get the bounding-box of given frame
-		BBox fd = trackedData->GetBox(frame_number);
+        // Create a QRectF for the bounding box
+        QRectF boxRect((fd.cx - fd.width / 2) * frame_image->width(),
+                       (fd.cy - fd.height / 2) * frame_image->height(),
+                       fd.width * frame_image->width(),
+                       fd.height * frame_image->height());
 
-		// Check if track data exists for the requested frame
-		if (trackedData->draw_box.GetValue(frame_number) == 1)
-		{
-			std::vector<int> stroke_rgba = trackedData->stroke.GetColorRGBA(frame_number);
-			int stroke_width = trackedData->stroke_width.GetValue(frame_number);
-			float stroke_alpha = trackedData->stroke_alpha.GetValue(frame_number);
-			std::vector<int> bg_rgba = trackedData->background.GetColorRGBA(frame_number);
-			float bg_alpha = trackedData->background_alpha.GetValue(frame_number);
+        // Check if track data exists for the requested frame
+        if (trackedData->draw_box.GetValue(frame_number) == 1) {
+            painter.setRenderHints(QPainter::Antialiasing | QPainter::SmoothPixmapTransform);
 
-			// Create a rotated rectangle object that holds the bounding box
-			cv::RotatedRect box ( cv::Point2f( (int)(fd.cx*fw), (int)(fd.cy*fh) ),
-								  cv::Size2f( (int)(fd.width*fw), (int)(fd.height*fh) ),
-								  (int) (fd.angle) );
+            // Get trackedObjectBox keyframes
+            std::vector<int> stroke_rgba = trackedData->stroke.GetColorRGBA(frame_number);
+            int stroke_width = trackedData->stroke_width.GetValue(frame_number);
+            float stroke_alpha = trackedData->stroke_alpha.GetValue(frame_number);
+            std::vector<int> bg_rgba = trackedData->background.GetColorRGBA(frame_number);
+            float bg_alpha = trackedData->background_alpha.GetValue(frame_number);
+            float bg_corner = trackedData->background_corner.GetValue(frame_number);
 
-			DrawRectangleRGBA(frame_image, box, bg_rgba, bg_alpha, 1, true);
-			DrawRectangleRGBA(frame_image, box, stroke_rgba, stroke_alpha, stroke_width, false);
-		}
+            // Set the pen for the border
+            QPen pen(QColor(stroke_rgba[0], stroke_rgba[1], stroke_rgba[2], 255 * stroke_alpha));
+            pen.setWidth(stroke_width);
+            painter.setPen(pen);
 
-		// Get the image of the Tracked Object' child clip
-		if (trackedData->ChildClipId() != ""){
-			// Cast the parent timeline of this effect
-			Timeline* parentTimeline = static_cast<Timeline *>(ParentTimeline());
-			if (parentTimeline){
-				// Get the Tracked Object's child clip
-				Clip* childClip = parentTimeline->GetClip(trackedData->ChildClipId());
-				if (childClip){
-					// Get the image of the child clip for this frame
-					std::shared_ptr<Frame> childClipFrame = childClip->GetFrame(frame_number);
-					childClipImage = childClipFrame->GetImage();
+            // Set the brush for the background
+            QBrush brush(QColor(bg_rgba[0], bg_rgba[1], bg_rgba[2], 255 * bg_alpha));
+            painter.setBrush(brush);
 
-					// Set the Qt rectangle with the bounding-box properties
-					boxRect.setRect((int)((fd.cx-fd.width/2)*fw),
-									(int)((fd.cy - fd.height/2)*fh),
-									(int)(fd.width*fw),
-									(int)(fd.height*fh) );
-				}
-			}
-		}
+            // Draw the rounded rectangle
+            painter.drawRoundedRect(boxRect, bg_corner, bg_corner);
+        }
 
-	}
+        // Get the image of the Tracked Object' child clip
+        if (trackedData->ChildClipId() != ""){
+            // Cast the parent timeline of this effect
+            Timeline* parentTimeline = static_cast<Timeline *>(ParentTimeline());
+            if (parentTimeline){
+                // Get the Tracked Object's child clip
+                Clip* childClip = parentTimeline->GetClip(trackedData->ChildClipId());
+                if (childClip){
+                    // Get the image of the child clip for this frame
+                    std::shared_ptr<Frame> childClipFrame = childClip->GetFrame(frame_number);
+                    std::shared_ptr<QImage> childClipImage = childClipFrame->GetImage();
 
-	// Set image with drawn box to frame
-	// If the input image is NULL or doesn't have tracking data, it's returned as it came
-	frame->SetImageCV(frame_image);
+                    // Scale the original bounding box to this image
+                    QRectF scaledRect = scaleAndCenterRect(QRectF(childClipImage->rect()), boxRect);
+                    QImage scaledImage = childClipImage->scaled(scaledRect.size().toSize(), Qt::KeepAspectRatio, Qt::SmoothTransformation);
 
-	// Set the bounding-box image with the Tracked Object's child clip image
-	if (childClipImage){
-		// Get the frame image
-		QImage frameImage = *(frame->GetImage());
+                    // Draw the child clip image inside the bounding-box
+                    painter.drawImage(scaledRect, *childClipImage);
+                }
+            }
+        }
 
-		// Set a Qt painter to the frame image
-		QPainter painter(&frameImage);
+        painter.end();
+    }
 
-		// Draw the child clip image inside the bounding-box
-		painter.drawImage(boxRect, *childClipImage);
-
-		// Set the frame image as the composed image
-		frame->AddImage(std::make_shared<QImage>(frameImage));
-	}
-
-	return frame;
+    // No need to set the image back to the frame, as we directly modified the frame's QImage
+    return frame;
 }
 
-void Tracker::DrawRectangleRGBA(cv::Mat &frame_image, cv::RotatedRect box, std::vector<int> color, float alpha, int thickness, bool is_background){
-	// Get the bouding box vertices
-	cv::Point2f vertices2f[4];
-	box.points(vertices2f);
+QRectF Tracker::scaleAndCenterRect(const QRectF& sourceRect, const QRectF& targetRect) {
+    float sourceAspectRatio = sourceRect.width() / sourceRect.height();
+    float targetWidth = targetRect.width();
+    float targetHeight = targetRect.height();
+    float newWidth, newHeight;
 
-	// TODO: take a rectangle of frame_image by refencence and draw on top of that to improve speed
-	// select min enclosing rectangle to draw on a small portion of the image
-	// cv::Rect rect  = box.boundingRect();
-	// cv::Mat image = frame_image(rect)
+    if (sourceAspectRatio > targetRect.width() / targetRect.height()) {
+        // Source is wider relative to target, so it's constrained by target's width
+        newWidth = targetWidth;
+        newHeight = newWidth / sourceAspectRatio;
+    } else {
+        // Source is taller relative to target, so it's constrained by target's height
+        newHeight = targetHeight;
+        newWidth = newHeight * sourceAspectRatio;
+    }
 
-	if(is_background){
-		cv::Mat overlayFrame;
-		frame_image.copyTo(overlayFrame);
+    // Center the new rectangle within the target rectangle
+    float newX = targetRect.left() + (targetWidth - newWidth) / 2.0;
+    float newY = targetRect.top() + (targetHeight - newHeight) / 2.0;
 
-		// draw bounding box background
-		cv::Point vertices[4];
-		for(int i = 0; i < 4; ++i){
-			vertices[i] = vertices2f[i];}
-
-		cv::Rect rect  = box.boundingRect();
-		cv::fillConvexPoly(overlayFrame, vertices, 4, cv::Scalar(color[2],color[1],color[0]), cv::LINE_AA);
-		// add opacity
-		cv::addWeighted(overlayFrame, 1-alpha, frame_image, alpha, 0, frame_image);
-	}
-	else{
-		cv::Mat overlayFrame;
-		frame_image.copyTo(overlayFrame);
-
-		// Draw bounding box
-		for (int i = 0; i < 4; i++)
-		{
-			cv::line(overlayFrame, vertices2f[i], vertices2f[(i+1)%4], cv::Scalar(color[2],color[1],color[0]),
-						thickness, cv::LINE_AA);
-		}
-
-		// add opacity
-		cv::addWeighted(overlayFrame, 1-alpha, frame_image, alpha, 0, frame_image);
-	}
+    return QRectF(newX, newY, newWidth, newHeight);
 }
 
 // Get the indexes and IDs of all visible objects in the given frame

--- a/src/effects/Tracker.cpp
+++ b/src/effects/Tracker.cpp
@@ -142,9 +142,6 @@ std::shared_ptr<Frame> Tracker::GetFrame(std::shared_ptr<Frame> frame, int64_t f
 
                     // Scale the original bounding box to this image
                     QRectF scaledRect = scaleAndCenterRect(QRectF(childClipImage->rect()), boxRect);
-                    QImage scaledImage = childClipImage->scaled(scaledRect.size().toSize(), Qt::KeepAspectRatio, Qt::SmoothTransformation);
-
-                    // Draw the child clip image inside the bounding-box
                     painter.drawImage(scaledRect, *childClipImage);
                 }
             }

--- a/src/effects/Tracker.cpp
+++ b/src/effects/Tracker.cpp
@@ -135,29 +135,6 @@ std::shared_ptr<Frame> Tracker::GetFrame(std::shared_ptr<Frame> frame, int64_t f
     return frame;
 }
 
-QRectF Tracker::scaleAndCenterRect(const QRectF& sourceRect, const QRectF& targetRect) {
-    float sourceAspectRatio = sourceRect.width() / sourceRect.height();
-    float targetWidth = targetRect.width();
-    float targetHeight = targetRect.height();
-    float newWidth, newHeight;
-
-    if (sourceAspectRatio > targetRect.width() / targetRect.height()) {
-        // Source is wider relative to target, so it's constrained by target's width
-        newWidth = targetWidth;
-        newHeight = newWidth / sourceAspectRatio;
-    } else {
-        // Source is taller relative to target, so it's constrained by target's height
-        newHeight = targetHeight;
-        newWidth = newHeight * sourceAspectRatio;
-    }
-
-    // Center the new rectangle within the target rectangle
-    float newX = targetRect.left() + (targetWidth - newWidth) / 2.0;
-    float newY = targetRect.top() + (targetHeight - newHeight) / 2.0;
-
-    return QRectF(newX, newY, newWidth, newHeight);
-}
-
 // Get the indexes and IDs of all visible objects in the given frame
 std::string Tracker::GetVisibleObjects(int64_t frame_number) const{
 

--- a/src/effects/Tracker.h
+++ b/src/effects/Tracker.h
@@ -44,6 +44,9 @@ namespace openshot
         /// Init effect settings
         void init_effect_details();
 
+        /// Find a rectangle inside another (centered)
+        QRectF scaleAndCenterRect(const QRectF& sourceRect, const QRectF& targetRect);
+
         Fraction BaseFPS;
         double TimeScale;
 
@@ -70,8 +73,6 @@ namespace openshot
 
         /// Get the indexes and IDs of all visible objects in the given frame
         std::string GetVisibleObjects(int64_t frame_number) const override;
-
-        void DrawRectangleRGBA(cv::Mat &frame_image, cv::RotatedRect box, std::vector<int> color, float alpha, int thickness, bool is_background);
 
         // Get and Set JSON methods
 

--- a/src/effects/Tracker.h
+++ b/src/effects/Tracker.h
@@ -44,9 +44,6 @@ namespace openshot
         /// Init effect settings
         void init_effect_details();
 
-        /// Find a rectangle inside another (centered)
-        QRectF scaleAndCenterRect(const QRectF& sourceRect, const QRectF& targetRect);
-
         Fraction BaseFPS;
         double TimeScale;
 
@@ -73,6 +70,9 @@ namespace openshot
 
         /// Get the indexes and IDs of all visible objects in the given frame
         std::string GetVisibleObjects(int64_t frame_number) const override;
+
+        /// Find a rectangle inside another (centered)
+        static QRectF scaleAndCenterRect(const QRectF& sourceRect, const QRectF& targetRect);
 
         // Get and Set JSON methods
 

--- a/src/effects/Tracker.h
+++ b/src/effects/Tracker.h
@@ -71,9 +71,6 @@ namespace openshot
         /// Get the indexes and IDs of all visible objects in the given frame
         std::string GetVisibleObjects(int64_t frame_number) const override;
 
-        /// Find a rectangle inside another (centered)
-        static QRectF scaleAndCenterRect(const QRectF& sourceRect, const QRectF& targetRect);
-
         // Get and Set JSON methods
 
         /// Generate JSON string of this object

--- a/tests/KeyFrame.cpp
+++ b/tests/KeyFrame.cpp
@@ -583,10 +583,10 @@ TEST_CASE( "TrackedObjectBBox init", "[libopenshot][keyframe]" )
 	CHECK(kfb.rotation.GetInt(1) == 0);
 
 	CHECK(kfb.stroke_width.GetInt(1) == 2);
-	CHECK(kfb.stroke_alpha.GetInt(1) == 0);
+    CHECK(kfb.stroke_alpha.GetValue(1) == Approx(0.7f).margin(0.0001));
 
-	CHECK(kfb.background_alpha .GetInt(1)== 1);
-	CHECK(kfb.background_corner.GetInt(1) == 0);
+	CHECK(kfb.background_alpha .GetInt(1) == 0);
+	CHECK(kfb.background_corner.GetInt(1) == 12);
 
 	CHECK(kfb.stroke.red.GetInt(1) == 62);
 	CHECK(kfb.stroke.green.GetInt(1) == 143);
@@ -596,8 +596,7 @@ TEST_CASE( "TrackedObjectBBox init", "[libopenshot][keyframe]" )
 	CHECK(kfb.background.red.GetInt(1) == 0);
 	CHECK(kfb.background.green.GetInt(1) == 0);
 	CHECK(kfb.background.blue.GetInt(1) == 255);
-	CHECK(kfb.background.alpha.GetInt(1) == 0);
-
+	CHECK(kfb.background.alpha.GetInt(1) == 212);
 }
 
 TEST_CASE( "TrackedObjectBBox AddBox and RemoveBox", "[libopenshot][keyframe]" )


### PR DESCRIPTION
Related to this PR: https://github.com/OpenShot/openshot-qt/pull/5430

**Improvements:**
- Added "Parent" badge to any clip with a parent set (on timeline for clarity)
- Fixed `class_filter` in property window to allow for:
  - empty (to reset the filter)
  - commas between classes work better (i.e. "truck, person")
  - allow spaces on either side of the class names (i.e. "  truck  ,  person  ")
  - Ignore case of class names entered by user
- Background Corner Radius: allow up to 150
- Updated Object Detector to output "class_name: object id" as the format (instead of confidence decimal) - easier to identify and select object in properties.
- Removed "Child Clip ID" from Tracker and Object Detector Effect. "Parent" is now the only supported method of attaching clips to tracked objects.
- Made certain properties read-only (X1, X2, Y1, Y2, etc...)
- Fixed invalid background_alpha and stroke_alpha properties (reversed range... it was backwards)
- Added new Display All Boxes property, which affects all Object Detector tracked boxes with a single property
- Lots of refactoring and simplifying (i've removed 2 times as much code as I've added in this PR)

- Refactored clip caching:
  - Prevent black backgrounds (however, when using "Parent" to a tracked object, the timeline Track order does matter. Example, if you want something on top of the tracked object, it must be on a layer above the tracked object. If you have a clip below a tracked object, it will be drawn under it (and might be hidden). 
  - Simplified some caching code (much easier to follow)
  - Clips still cache their Frame object, but no longer cache them flattened with the previous timeline layers

**Refactor Object Detector** with QPainter (support for corner radius, faster drawing performance)
![OpenShot-Object-Detector-Radius](https://github.com/OpenShot/openshot-qt/assets/5551883/8f53f896-115e-4e4a-8043-1e2d50ed689d)

**Refactor Tracker** with QPainter (support for corner radius, faster drawing performance)
![OpenShot-Tracker-Radius](https://github.com/OpenShot/openshot-qt/assets/5551883/bf8ddbd2-ab99-4407-8a01-99d1198eba7e)
