### PR TITLE
Release PR for version 0.3.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,8 +24,8 @@ For more information, please visit <http://www.openshot.org/>.
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/Modules")
 
 ################ PROJECT VERSION ####################
-set(PROJECT_VERSION_FULL "0.3.2")
-set(PROJECT_SO_VERSION 25)
+set(PROJECT_VERSION_FULL "0.3.3")
+set(PROJECT_SO_VERSION 26)
 
 # Remove the dash and anything following, to get the #.#.# version for project()
 STRING(REGEX REPLACE "\-.*$" "" VERSION_NUM "${PROJECT_VERSION_FULL}")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -176,7 +176,7 @@ target_include_directories(openshot
 # Find JUCE-based openshot Audio libraries
 if(NOT TARGET OpenShot::Audio)
   # Only load if necessary (not for integrated builds)
-  find_package(OpenShotAudio 0.3.0...0.3.2 REQUIRED)
+  find_package(OpenShotAudio 0.3.0...0.3.3 REQUIRED)
 endif()
 target_link_libraries(openshot PUBLIC OpenShot::Audio)
 


### PR DESCRIPTION
Bump version to 0.3.3, SO Version 26
*This is part of the OpenShot Video Editor 3.2.0 release.*

Release / Tag: https://github.com/OpenShot/libopenshot/releases/tag/v0.3.3