### PR TITLE
Improving Support for Newer FFMPEG versions

### DIFF
--- a/src/FFmpegReader.cpp
+++ b/src/FFmpegReader.cpp
@@ -695,6 +695,16 @@ void FFmpegReader::UpdateAudioInfo() {
 	info.channels = AV_GET_CODEC_ATTRIBUTES(aStream, aCodecCtx)->channels;
 	info.channel_layout = (ChannelLayout) AV_GET_CODEC_ATTRIBUTES(aStream, aCodecCtx)->channel_layout;
 #endif
+
+	// If channel layout is not set, guess based on the number of channels
+	if (info.channel_layout == 0) {
+		if (info.channels == 1) {
+			info.channel_layout = openshot::LAYOUT_MONO;
+		} else if (info.channels == 2) {
+			info.channel_layout = openshot::LAYOUT_STEREO;
+		}
+	}
+
 	info.sample_rate = AV_GET_CODEC_ATTRIBUTES(aStream, aCodecCtx)->sample_rate;
 	info.audio_bit_rate = AV_GET_CODEC_ATTRIBUTES(aStream, aCodecCtx)->bit_rate;
 	if (info.audio_bit_rate <= 0) {

--- a/src/FFmpegWriter.cpp
+++ b/src/FFmpegWriter.cpp
@@ -2233,7 +2233,6 @@ bool FFmpegWriter::write_video_packet(std::shared_ptr<Frame> frame, AVFrame *fra
 				ret = avcodec_receive_packet(video_codec_ctx, pkt);
 
 				if (ret == AVERROR(EAGAIN) || ret == AVERROR_EOF) {
-					avcodec_flush_buffers(video_codec_ctx);
 					got_packet_ptr = 0;
 					break;
 				}


### PR DESCRIPTION
- Fixing Audio Channel Layout detection for WAV (and other formats) that don't include a channel layout in the header (fallback for STEREO and MONO layouts based on # of channels)
- Fixed crashing Caption unit tests, and made them more resilient to pixel variations and font variations
- Removed a "flush encoders" call in FFmpegWriter, which was breaking exports on newer versions of FFMPEG and breaking some hardware acceleration