### PR TITLE
Adding GetMinTime & GetMinFrame methods to Timeline

### DIFF
--- a/src/Timeline.cpp
+++ b/src/Timeline.cpp
@@ -812,6 +812,7 @@ void Timeline::calculate_max_duration() {
 	// If no clips or effects exist, set min_time to 0
 	if (clips.empty() && effects.empty()) {
 		min_time = 0.0;
+		max_time = 0.0;
 	}
 }
 
@@ -1301,6 +1302,10 @@ void Timeline::SetJsonValue(const Json::Value root) {
 	// Update preview settings
 	preview_width = info.width;
 	preview_height = info.height;
+
+	// Resort (and recalculate min/max duration)
+	sort_clips();
+	sort_effects();
 
 	// Re-open if needed
 	if (was_open)

--- a/src/Timeline.h
+++ b/src/Timeline.h
@@ -160,7 +160,8 @@ namespace openshot {
 		bool managed_cache; ///< Does this timeline instance manage the cache object
 		std::string path; ///< Optional path of loaded UTF-8 OpenShot JSON project file
 		int max_concurrent_frames; ///< Max concurrent frames to process at one time
-		double max_time; ///> The max duration (in seconds) of the timeline, based on all the clips
+		double max_time; ///> The max duration (in seconds) of the timeline, based on the furthest clip (right edge)
+		double min_time; ///> The min duration (in seconds) of the timeline, based on the position of the first clip (left edge)
 
 		std::map<std::string, std::shared_ptr<openshot::TrackedObjectBase>> tracked_objects; ///< map of TrackedObjectBBoxes and their IDs
 
@@ -285,6 +286,11 @@ namespace openshot {
 		double GetMaxTime();
 		/// Look up the end frame number of the latest element on the timeline
 		int64_t GetMaxFrame();
+
+		/// Look up the position/start time of the first timeline element
+		double GetMinTime();
+		/// Look up the start frame number of the first element on the timeline
+		int64_t GetMinFrame();
 
 		/// Close the timeline reader (and any resources it was consuming)
 		void Close() override;


### PR DESCRIPTION
These are used to get the start time and position of the first element on the timeline. This will be a new UI function in the next version of OpenShot, so an export can quickly trim the start or end to the clips/effects on the timeline.