### PR TITLE
Java Swig Support (org.openshot package + wrap shared pointers)

### DIFF
--- a/bindings/java/CMakeLists.txt
+++ b/bindings/java/CMakeLists.txt
@@ -32,6 +32,11 @@ message(STATUS "JNI_LIBRARIES=${JNI_LIBRARIES}")
 set_property(SOURCE openshot.i PROPERTY CPLUSPLUS ON)
 set_property(SOURCE openshot.i PROPERTY SWIG_MODULE_NAME openshot)
 
+### Set the swig package name for the JAR
+set_source_files_properties(openshot.i PROPERTIES
+        SWIG_FLAGS "-package;org.openshot"
+)
+
 ### Suppress a ton of warnings in the generated SWIG C++ code
 set(SWIG_CXX_FLAGS "-Wno-unused-variable -Wno-unused-function \
   -Wno-deprecated-copy -Wno-class-memaccess -Wno-cast-function-type \

--- a/bindings/java/openshot.i
+++ b/bindings/java/openshot.i
@@ -32,14 +32,14 @@
 %include <std_except.i>
 
 /* Include shared pointer code */
-#%include <std_shared_ptr.i>
+%include <std_shared_ptr.i>
 
 /* Mark these classes as shared_ptr classes */
 #ifdef USE_IMAGEMAGICK
-	#%shared_ptr(Magick::Image)
+	%shared_ptr(Magick::Image)
 #endif
-#%shared_ptr(juce::AudioBuffer<float>)
-#%shared_ptr(openshot::Frame)
+%shared_ptr(juce::AudioBuffer<float>)
+%shared_ptr(openshot::Frame)
 
 /* Instantiate the required template specializations */
 %template() std::map<std::string, int>;


### PR DESCRIPTION
Fixing swig java support to generate a package (org.openshot) and correctly wrap the shared pointers for Frame and Audio buffers.