### PR TITLE
fix av_image_alloc alignment && check allocation error

### DIFF
--- a/src/FFmpegReader.cpp
+++ b/src/FFmpegReader.cpp
@@ -1269,7 +1269,11 @@ bool FFmpegReader::GetAVFrame() {
 			frameFinished = 1;
 			packet_status.video_decoded++;
 
-			av_image_alloc(pFrame->data, pFrame->linesize, info.width, info.height, (AVPixelFormat)(pStream->codecpar->format), 1);
+      // align 32 for simd
+			if (av_image_alloc(pFrame->data, pFrame->linesize, info.width,
+						info.height, (AVPixelFormat)(pStream->codecpar->format), 32) <= 0) {
+						throw OutOfMemory("Failed to allocate image buffer", path);
+			}
 			av_image_copy(pFrame->data, pFrame->linesize, (const uint8_t**)next_frame->data, next_frame->linesize,
 										(AVPixelFormat)(pStream->codecpar->format), info.width, info.height);
 


### PR DESCRIPTION
- Add memory allocation error handling to prevent memory corruption
- Libav requires proper alignment for some format.
- Use 32-byte alignment for better SIMD performance and libav compatibility
The changes ensure proper error handling when av_image_alloc() fails and optimize memory alignment for SIMD instructions.