### PR TITLE
Improve "rotation" metadata to auto-rotate and auto-scale vertical videos

### DIFF
--- a/src/Clip.cpp
+++ b/src/Clip.cpp
@@ -111,24 +111,39 @@ void Clip::init_reader_settings() {
 	}
 }
 
-// Init reader's rotation (if any)
 void Clip::init_reader_rotation() {
-	// Dont init rotation if clip has keyframes
+	// Don't init rotation if clip already has keyframes.
 	if (rotation.GetCount() > 0)
 		return;
 
-	// Init rotation
+	// Get rotation from metadata (if any)
+	float rotate_angle = 0.0f;
 	if (reader && reader->info.metadata.count("rotate") > 0) {
-		// Use reader metadata rotation (if any)
-		// This is typical with cell phone videos filmed in different orientations
 		try {
-			float rotate_metadata = strtof(reader->info.metadata["rotate"].c_str(), 0);
-			rotation = Keyframe(rotate_metadata);
-		} catch (const std::exception& e) {}
+			rotate_angle = strtof(reader->info.metadata["rotate"].c_str(), nullptr);
+		} catch (const std::exception& e) {
+			// Leave rotate_angle at default 0.0f
+		}
 	}
-	else
-		// Default no rotation
-		rotation = Keyframe(0.0);
+	rotation = Keyframe(rotate_angle);
+
+	// Compute uniform scale factors for rotated video.
+	// Assume reader->info.width and reader->info.height are the clip's natural dimensions.
+	float w = static_cast<float>(reader->info.width);
+	float h = static_cast<float>(reader->info.height);
+	float rad = rotate_angle * M_PI / 180.0f;
+
+	// Calculate the dimensions of the bounding box for the rotated clip.
+	float new_width  = fabs(w * cos(rad)) + fabs(h * sin(rad));
+	float new_height = fabs(w * sin(rad)) + fabs(h * cos(rad));
+
+	// To have the rotated clip appear the same size as the unrotated clip,
+	// compute a uniform scale factor S that brings the bounding box back to (w, h).
+	float uniform_scale = std::min(w / new_width, h / new_height);
+
+	// Set scale keyframes uniformly.
+	scale_x = Keyframe(uniform_scale);
+	scale_y = Keyframe(uniform_scale);
 }
 
 // Default Constructor for a clip

--- a/src/FFmpegReader.cpp
+++ b/src/FFmpegReader.cpp
@@ -555,12 +555,16 @@ void FFmpegReader::Open() {
 		}
 
 		// If "rotate" isn't already set, extract it from the video stream's side data.
+		// TODO: nb_side_data is depreciated, and I'm not sure the preferred way to do this
 		if (info.metadata.find("rotate") == info.metadata.end()) {
 			for (unsigned int i = 0; i < pFormatCtx->nb_streams; i++) {
 				if (pFormatCtx->streams[i]->codecpar->codec_type == AVMEDIA_TYPE_VIDEO) {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 					for (int j = 0; j < pFormatCtx->streams[i]->nb_side_data; j++) {
-						// Use the address-of operator to get a pointer to the j-th element.
+						// Get the j-th side data element.
 						AVPacketSideData *sd = &pFormatCtx->streams[i]->side_data[j];
+#pragma GCC diagnostic pop
 						if (sd->type == AV_PKT_DATA_DISPLAYMATRIX && sd->size >= 9 * sizeof(int32_t)) {
 							double rotation = -av_display_rotation_get(reinterpret_cast<int32_t *>(sd->data));
 							if (isnan(rotation))

--- a/src/FFmpegReader.cpp
+++ b/src/FFmpegReader.cpp
@@ -554,6 +554,27 @@ void FFmpegReader::Open() {
 			info.metadata[str_key.toStdString()] = str_value.trimmed().toStdString();
 		}
 
+		// If "rotate" isn't already set, extract it from the video stream's side data.
+		if (info.metadata.find("rotate") == info.metadata.end()) {
+			for (unsigned int i = 0; i < pFormatCtx->nb_streams; i++) {
+				if (pFormatCtx->streams[i]->codecpar->codec_type == AVMEDIA_TYPE_VIDEO) {
+					for (int j = 0; j < pFormatCtx->streams[i]->nb_side_data; j++) {
+						// Use the address-of operator to get a pointer to the j-th element.
+						AVPacketSideData *sd = &pFormatCtx->streams[i]->side_data[j];
+						if (sd->type == AV_PKT_DATA_DISPLAYMATRIX && sd->size >= 9 * sizeof(int32_t)) {
+							double rotation = -av_display_rotation_get(reinterpret_cast<int32_t *>(sd->data));
+							if (isnan(rotation))
+								rotation = 0;
+							QString str_value = QString::number(rotation, 'g', 6);
+							info.metadata["rotate"] = str_value.trimmed().toStdString();
+							break;
+						}
+					}
+					break;  // Only process the first video stream.
+				}
+			}
+		}
+
 		// Init previous audio location to zero
 		previous_packet_location.frame = -1;
 		previous_packet_location.sample_start = 0;

--- a/src/FFmpegUtilities.h
+++ b/src/FFmpegUtilities.h
@@ -39,6 +39,7 @@
 extern "C" {
     #include <libavcodec/avcodec.h>
     #include <libavformat/avformat.h>
+    #include <libavutil/display.h>
 
 #if (LIBAVFORMAT_VERSION_MAJOR >= 57)
     #include <libavutil/hwcontext.h> //PM


### PR DESCRIPTION
Read `side data` rotation metadata from mobile videos, so that vertical videos can be auto-rotated and auto-scaled to fit the project size.