### PR TITLE
Update FFmpeg macros to use 32-byte alignment for better SIMD performance and libav compatibility

### DIFF
--- a/src/FFmpegReader.cpp
+++ b/src/FFmpegReader.cpp
@@ -1269,7 +1269,11 @@ bool FFmpegReader::GetAVFrame() {
 			frameFinished = 1;
 			packet_status.video_decoded++;
 
-			av_image_alloc(pFrame->data, pFrame->linesize, info.width, info.height, (AVPixelFormat)(pStream->codecpar->format), 1);
+      // align 32 for simd
+			if (av_image_alloc(pFrame->data, pFrame->linesize, info.width,
+						info.height, (AVPixelFormat)(pStream->codecpar->format), 32) <= 0) {
+						throw OutOfMemory("Failed to allocate image buffer", path);
+			}
 			av_image_copy(pFrame->data, pFrame->linesize, (const uint8_t**)next_frame->data, next_frame->linesize,
 										(AVPixelFormat)(pStream->codecpar->format), info.width, info.height);
 

--- a/src/FFmpegReader.cpp
+++ b/src/FFmpegReader.cpp
@@ -1307,10 +1307,9 @@ bool FFmpegReader::GetAVFrame() {
 			frameFinished = 1;
 			packet_status.video_decoded++;
 
-      // align 32 for simd
-			if (av_image_alloc(pFrame->data, pFrame->linesize, info.width,
-						info.height, (AVPixelFormat)(pStream->codecpar->format), 32) <= 0) {
-						throw OutOfMemory("Failed to allocate image buffer", path);
+			// Allocate image (align 32 for simd)
+			if (AV_ALLOCATE_IMAGE(pFrame, (AVPixelFormat)(pStream->codecpar->format), info.width, info.height) <= 0) {
+				throw OutOfMemory("Failed to allocate image buffer", path);
 			}
 			av_image_copy(pFrame->data, pFrame->linesize, (const uint8_t**)next_frame->data, next_frame->linesize,
 										(AVPixelFormat)(pStream->codecpar->format), info.width, info.height);

--- a/src/FFmpegUtilities.h
+++ b/src/FFmpegUtilities.h
@@ -160,7 +160,7 @@ inline static bool ffmpeg_has_alpha(PixelFormat pix_fmt) {
     #define MY_INPUT_BUFFER_PADDING_SIZE AV_INPUT_BUFFER_PADDING_SIZE
     #define AV_ALLOCATE_FRAME() av_frame_alloc()
     #define AV_ALLOCATE_IMAGE(av_frame, pix_fmt, width, height) \
-            av_image_alloc(av_frame->data, av_frame->linesize, width, height, pix_fmt, 1)
+            av_image_alloc(av_frame->data, av_frame->linesize, width, height, pix_fmt, 32)
     #define AV_RESET_FRAME(av_frame) av_frame_unref(av_frame)
     #define AV_FREE_FRAME(av_frame) av_frame_free(av_frame)
     #define AV_FREE_PACKET(av_packet) av_packet_unref(av_packet)
@@ -198,7 +198,7 @@ inline static bool ffmpeg_has_alpha(PixelFormat pix_fmt) {
     #define MY_INPUT_BUFFER_PADDING_SIZE FF_INPUT_BUFFER_PADDING_SIZE
     #define AV_ALLOCATE_FRAME() av_frame_alloc()
     #define AV_ALLOCATE_IMAGE(av_frame, pix_fmt, width, height) \
-            av_image_alloc(av_frame->data, av_frame->linesize, width, height, pix_fmt, 1)
+            av_image_alloc(av_frame->data, av_frame->linesize, width, height, pix_fmt, 32)
     #define AV_RESET_FRAME(av_frame) av_frame_unref(av_frame)
     #define AV_FREE_FRAME(av_frame) av_frame_free(av_frame)
     #define AV_FREE_PACKET(av_packet) av_packet_unref(av_packet)


### PR DESCRIPTION
Based on this PR: https://github.com/OpenShot/libopenshot/pull/987. Some code cleanup, and moving these changes into our FFmpeg macros.
