### PR TITLE
Fix Deinterlace effect crash (plus CPU improvements for Mask effect)

### DIFF
--- a/src/effects/Deinterlace.cpp
+++ b/src/effects/Deinterlace.cpp
@@ -12,6 +12,7 @@
 
 #include "Deinterlace.h"
 #include "Exceptions.h"
+#include <omp.h>
 
 using namespace openshot;
 
@@ -51,21 +52,35 @@ std::shared_ptr<openshot::Frame> Deinterlace::GetFrame(std::shared_ptr<openshot:
 	int original_width = frame->GetImage()->width();
 	int original_height = frame->GetImage()->height();
 
-	// Get the frame's image
-	std::shared_ptr<QImage> image = frame->GetImage();
+	// Access the current QImage and its raw pixel data
+	auto image           = frame->GetImage();
 	const unsigned char* pixels = image->bits();
+	int line_bytes       = image->bytesPerLine();
 
-	// Create a smaller, new image
-	QImage deinterlaced_image(image->width(), image->height() / 2, QImage::Format_RGBA8888_Premultiplied);
-	const unsigned char* deinterlaced_pixels = deinterlaced_image.bits();
+	// Decide whether to copy even lines (start = 0) or odd lines (start = 1)
+	int start = isOdd ? 1 : 0;
 
-	// Loop through the scanlines of the image (even or odd)
-	int start = 0;
-	if (isOdd)
-		start = 1;
-	for (int row = start; row < image->height(); row += 2) {
-		memcpy((unsigned char*)deinterlaced_pixels, pixels + (row * image->bytesPerLine()), image->bytesPerLine());
-		deinterlaced_pixels += image->bytesPerLine();
+	// Compute how many rows we will end up copying
+	// If start = 0, rows_to_copy = ceil(original_height / 2.0)
+	// If start = 1, rows_to_copy = floor(original_height / 2.0)
+	int rows_to_copy = (original_height - start + 1) / 2;
+
+	// Create a new image with exactly 'rows_to_copy' scanlines
+	QImage deinterlaced_image(
+		original_width,
+		rows_to_copy,
+		QImage::Format_RGBA8888_Premultiplied
+	);
+	unsigned char* deinterlaced_pixels = deinterlaced_image.bits();
+
+	// Copy every other row from the source into the new image
+	// Parallelize over 'i' so each thread writes to a distinct slice of memory
+#pragma omp parallel for
+	for (int i = 0; i < rows_to_copy; i++) {
+		int row = start + 2 * i;
+		const unsigned char* src = pixels + (row * line_bytes);
+		unsigned char* dst       = deinterlaced_pixels + (i * line_bytes);
+		memcpy(dst, src, line_bytes);
 	}
 
 	// Resize deinterlaced image back to original size, and update frame's image
@@ -134,7 +149,7 @@ std::string Deinterlace::PropertiesJSON(int64_t requested_frame) const {
 	Json::Value root = BasePropertiesJSON(requested_frame);
 
 	// Add Is Odd Frame choices (dropdown style)
-	root["isOdd"] = add_property_json("Is Odd Frame", isOdd, "bool", "", NULL, 0, 1, true, requested_frame);
+	root["isOdd"] = add_property_json("Is Odd Frame", isOdd, "bool", "", NULL, 0, 1, false, requested_frame);
 	root["isOdd"]["choices"].append(add_property_choice_json("Yes", true, isOdd));
 	root["isOdd"]["choices"].append(add_property_choice_json("No", false, isOdd));
 

--- a/src/effects/Mask.cpp
+++ b/src/effects/Mask.cpp
@@ -18,6 +18,7 @@
 #include "ChunkReader.h"
 #include "FFmpegReader.h"
 #include "QtImageReader.h"
+#include <omp.h>
 
 #ifdef USE_IMAGEMAGICK
 	#include "ImageReader.h"
@@ -88,52 +89,61 @@ std::shared_ptr<openshot::Frame> Mask::GetFrame(std::shared_ptr<openshot::Frame>
 		}
 	}
 
-	// Refresh no longer needed
+	// Once we've done the necessary resizing, we no longer need to refresh again
 	needs_refresh = false;
 
-	// Get pixel arrays
-	unsigned char *pixels = (unsigned char *) frame_image->bits();
-	unsigned char *mask_pixels = (unsigned char *) original_mask->bits();
+	// Grab raw pointers and dimensions one time
+	unsigned char* pixels      = reinterpret_cast<unsigned char*>(frame_image->bits());
+	unsigned char* mask_pixels = reinterpret_cast<unsigned char*>(original_mask->bits());
+	int width                   = original_mask->width();
+	int height                  = original_mask->height();
+	int num_pixels              = width * height;  // total pixel count
 
-	double contrast_value = (contrast.GetValue(frame_number));
-	double brightness_value = (brightness.GetValue(frame_number));
+	// Evaluate brightness and contrast keyframes just once
+	double contrast_value   = contrast.GetValue(frame_number);
+	double brightness_value = brightness.GetValue(frame_number);
 
-	// Loop through mask pixels, and apply average gray value to frame alpha channel
-	for (int pixel = 0, byte_index=0; pixel < original_mask->width() * original_mask->height(); pixel++, byte_index+=4)
+	int brightness_adj = static_cast<int>(255 * brightness_value);
+	float contrast_factor = 20.0f / std::max(0.00001f, 20.0f - static_cast<float>(contrast_value));
+
+	// Iterate over every pixel in parallel
+#pragma omp parallel for schedule(static)
+	for (int i = 0; i < num_pixels; ++i)
 	{
-		// Get the RGB values from the pixel
-		int R = mask_pixels[byte_index];
-		int G = mask_pixels[byte_index + 1];
-		int B = mask_pixels[byte_index + 2];
-		int A = mask_pixels[byte_index + 3];
+		int idx = i * 4;
 
-		// Get the average luminosity
-		int gray_value = qGray(R, G, B);
+		int R = mask_pixels[idx + 0];
+		int G = mask_pixels[idx + 1];
+		int B = mask_pixels[idx + 2];
+		int A = mask_pixels[idx + 3];
 
-		// Adjust the brightness
-		gray_value += (255 * brightness_value);
+		// Compute base gray, then apply brightness + contrast
+		int gray = qGray(R, G, B);
+		gray += brightness_adj;
+		gray = static_cast<int>(contrast_factor * (gray - 128) + 128);
 
-		// Adjust the contrast
-		float factor = (20 / std::fmax(0.00001, 20.0 - contrast_value));
-		gray_value = (factor * (gray_value - 128) + 128);
+		// Clamp (A - gray) into [0, 255]
+		int diff = A - gray;
+		if (diff < 0) diff = 0;
+		else if (diff > 255) diff = 255;
 
 		// Calculate the % change in alpha
-		float alpha_percent = float(constrain(A - gray_value)) / 255.0;
+		float alpha_percent = static_cast<float>(diff) / 255.0f;
 
 		// Set the alpha channel to the gray value
 		if (replace_image) {
 			// Replace frame pixels with gray value (including alpha channel)
-			pixels[byte_index + 0] = constrain(255 * alpha_percent);
-			pixels[byte_index + 1] = constrain(255 * alpha_percent);
-			pixels[byte_index + 2] = constrain(255 * alpha_percent);
-			pixels[byte_index + 3] = constrain(255 * alpha_percent);
+			auto new_val = static_cast<unsigned char>(diff);
+			pixels[idx + 0] = new_val;
+			pixels[idx + 1] = new_val;
+			pixels[idx + 2] = new_val;
+			pixels[idx + 3] = new_val;
 		} else {
-			// Multiply new alpha value with all the colors (since we are using a premultiplied
-			// alpha format)
-			pixels[byte_index + 0] *= alpha_percent;
-			pixels[byte_index + 1] *= alpha_percent;
-			pixels[byte_index + 2] *= alpha_percent;
-			pixels[byte_index + 3] *= alpha_percent;
+			// Premultiplied RGBA → multiply each channel by alpha_percent
+			pixels[idx + 0] = static_cast<unsigned char>(pixels[idx + 0] * alpha_percent);
+			pixels[idx + 1] = static_cast<unsigned char>(pixels[idx + 1] * alpha_percent);
+			pixels[idx + 2] = static_cast<unsigned char>(pixels[idx + 2] * alpha_percent);
+			pixels[idx + 3] = static_cast<unsigned char>(pixels[idx + 3] * alpha_percent);
 		}
 
 	}


### PR DESCRIPTION
- Fix Deinterlace effect to compute the correct number of rows per update (prevents crash)
  - Also, made isOdd property writable in the UI
- In Mask effect, precompute brightness/contrast adjustments outside the per-pixel loop
  - Cache image dimensions and raw pointers once instead of calling methods each iteration
  - Add #pragma omp parallel for to the pixel loop for multicore speedup
  - Clamp (A – gray) to [0, 255] so alpha_percent never exceeds 1.0 (resolves orange artifacts)