### PR TITLE
fix babl detection

### DIFF
--- a/cmake/Modules/Findbabl.cmake
+++ b/cmake/Modules/Findbabl.cmake
@@ -20,7 +20,7 @@ function(_babl_GET_VERSION _header)
 endfunction()
 
 find_package(PkgConfig)
-pkg_check_modules(PC_BABL babl)
+pkg_check_modules(PC_BABL babl-0.1)
 
 set(babl_VERSION ${PC_BABL_VERSION})
 


### PR DESCRIPTION
It looks like babl doesn't get installed in Linux CI builds, so this has gone unnoticed for a while.

NOTE: the pkg-config file of babl is: `/usr/lib64/pkgconfig/babl-0.1.pc`.