### PR TITLE
Adding missing <sstream> includes

### DIFF
--- a/examples/Example_opencv.cpp
+++ b/examples/Example_opencv.cpp
@@ -13,6 +13,7 @@
 #include <fstream>
 #include <iostream>
 #include <memory>
+#include <sstream>
 #include "CVTracker.h"
 #include "CVStabilization.h"
 #include "CVObjectDetection.h"

--- a/src/CacheDisk.cpp
+++ b/src/CacheDisk.cpp
@@ -15,6 +15,7 @@
 #include "Frame.h"
 #include "QtUtilities.h"
 
+#include <sstream>
 #include <Qt>
 #include <QString>
 #include <QTextStream>

--- a/src/ChunkReader.cpp
+++ b/src/ChunkReader.cpp
@@ -11,6 +11,7 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
 #include <fstream>
+#include <sstream>
 
 #include "ChunkReader.h"
 #include "Exceptions.h"

--- a/src/ChunkWriter.cpp
+++ b/src/ChunkWriter.cpp
@@ -14,6 +14,8 @@
 #include "Exceptions.h"
 #include "Frame.h"
 
+#include <sstream>
+
 using namespace openshot;
 
 ChunkWriter::ChunkWriter(std::string path, ReaderBase *reader) :

--- a/src/Clip.cpp
+++ b/src/Clip.cpp
@@ -24,6 +24,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <sstream>
 
 #ifdef USE_IMAGEMAGICK
 	#include "MagickUtilities.h"

--- a/src/FFmpegReader.cpp
+++ b/src/FFmpegReader.cpp
@@ -17,6 +17,7 @@
 #include <chrono>	// for std::chrono::milliseconds
 #include <algorithm>
 #include <cmath>
+#include <sstream>
 #include <unistd.h>
 
 #include "FFmpegUtilities.h"

--- a/src/FFmpegWriter.cpp
+++ b/src/FFmpegWriter.cpp
@@ -17,6 +17,7 @@
 #include <iostream>
 #include <cmath>
 #include <ctime>
+#include <sstream>
 #include <unistd.h>
 
 #include "FFmpegUtilities.h"

--- a/src/WriterBase.cpp
+++ b/src/WriterBase.cpp
@@ -13,6 +13,7 @@
 #include <iostream>
 #include <iomanip>
 #include <memory>
+#include <sstream>
 
 #include "WriterBase.h"
 #include "Exceptions.h"

--- a/tests/AudioWaveformer.cpp
+++ b/tests/AudioWaveformer.cpp
@@ -22,6 +22,7 @@
 #include <cmath>
 #include <future>
 #include <thread>
+#include <sstream>
 
 
 using namespace openshot;

--- a/tests/Caption.cpp
+++ b/tests/Caption.cpp
@@ -12,6 +12,7 @@
 
 
 #include <vector>
+#include <sstream>
 #include "openshot_catch.h"
 #include <QApplication>
 #include <QFontDatabase>

--- a/tests/DummyReader.cpp
+++ b/tests/DummyReader.cpp
@@ -19,6 +19,7 @@
 #include "CacheMemory.h"
 #include "Fraction.h"
 #include "Frame.h"
+#include <sstream>
 
 TEST_CASE( "Default constructor", "[libopenshot][dummyreader]" ) {
 	openshot::DummyReader r;

--- a/tests/FrameMapper.cpp
+++ b/tests/FrameMapper.cpp
@@ -21,6 +21,7 @@
 #include "Frame.h"
 #include "FrameMapper.h"
 #include "Timeline.h"
+#include <sstream>
 
 using namespace openshot;
 

--- a/tests/ImageReader.cpp
+++ b/tests/ImageReader.cpp
@@ -15,6 +15,7 @@
 #include "ImageReader.h"
 #include "Exceptions.h"
 #include "Frame.h"
+#include <sstream>
 
 using namespace openshot;
 

--- a/tests/QtImageReader.cpp
+++ b/tests/QtImageReader.cpp
@@ -13,6 +13,7 @@
 #include "openshot_catch.h"
 
 #include <QGuiApplication>
+#include <sstream>
 
 #include "QtImageReader.h"
 #include "Clip.h"


### PR DESCRIPTION
They should be included - and were not failing on more modern compilers, so a little hard to catch.