### PR TITLE
Fixing Cmake fallback python folder detection (to not return /usr/local)

### DIFF
--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -116,12 +116,8 @@ if (NOT DEFINED PYTHON_MODULE_PATH)
 
     if (NOT EXISTS "${CMAKE_INSTALL_PREFIX}/${PYTHON_MODULE_PATH}")
       ### Calculate the python module path (prefer sysconfig, fallback to distutils for compatibility)
-      execute_process(COMMAND ${PYTHON_EXECUTABLE} -c "\
-try:
-  import sysconfig; print(sysconfig.get_path('platlib'))
-except ImportError:
-  from distutils.sysconfig import get_python_lib; \
-  print(get_python_lib(plat_specific=True, prefix=''))"
+      execute_process(
+              COMMAND ${PYTHON_EXECUTABLE} -c "import sysconfig; print(sysconfig.get_path('platlib', scheme='posix_prefix')[1:])"
               OUTPUT_VARIABLE PYTHON_MODULE_PATH
               OUTPUT_STRIP_TRAILING_WHITESPACE)
     endif()


### PR DESCRIPTION
Changing python install detected folder, to be relative folder. This is breaking on some Launchpad build servers, due to returning an absolute path that is installed outside of the install prefix. Just tightening up the python fallback when looking for the correct folder.