### PR TITLE
use modern FFmpeg API

### DIFF
--- a/src/FFmpegReader.cpp
+++ b/src/FFmpegReader.cpp
@@ -567,8 +567,13 @@ void FFmpegReader::Open() {
 			AVStream* st = pFormatCtx->streams[i];
 			if (st->codecpar->codec_type == AVMEDIA_TYPE_VIDEO) {
 				// Only inspect the first video stream
+#if (LIBAVFORMAT_VERSION_MAJOR < 62)
 				for (int j = 0; j < st->nb_side_data; j++) {
 					AVPacketSideData *sd = &st->side_data[j];
+#else
+				for (int j = 0; j < st->codecpar->nb_coded_side_data; j++) {
+					AVPacketSideData *sd = &st->codecpar->coded_side_data[j];
+#endif
 
 					// Handle rotation metadata (unchanged)
 					if (sd->type == AV_PKT_DATA_DISPLAYMATRIX &&

--- a/src/FFmpegWriter.cpp
+++ b/src/FFmpegWriter.cpp
@@ -1501,7 +1501,7 @@ void FFmpegWriter::open_video(AVFormatContext *oc, AVStream *st) {
 		switch (video_codec_ctx->codec_id) {
 			case AV_CODEC_ID_H264:
 				video_codec_ctx->max_b_frames = 0;  // At least this GPU doesn't support b-frames
-				video_codec_ctx->profile = FF_PROFILE_H264_BASELINE | FF_PROFILE_H264_CONSTRAINED;
+				video_codec_ctx->profile = AV_PROFILE_H264_BASELINE | AV_PROFILE_H264_CONSTRAINED;
 				av_opt_set(video_codec_ctx->priv_data, "preset", "slow", 0);
 				av_opt_set(video_codec_ctx->priv_data, "tune", "zerolatency", 0);
 				av_opt_set(video_codec_ctx->priv_data, "vprofile", "baseline", AV_OPT_SEARCH_CHILDREN);
@@ -2391,6 +2391,10 @@ void FFmpegWriter::AddSphericalMetadata(const std::string& projection, float yaw
 	map->pitch = static_cast<int32_t>(pitch_deg * (1 << 16));
 	map->roll  = static_cast<int32_t>(roll_deg  * (1 << 16));
 
+#if (LIBAVFORMAT_VERSION_MAJOR < 62)
 	av_stream_add_side_data(video_st, AV_PKT_DATA_SPHERICAL, reinterpret_cast<uint8_t*>(map), sd_size);
+#else
+	av_packet_side_data_add(&video_st->codecpar->coded_side_data, &video_st->codecpar->nb_coded_side_data, AV_PKT_DATA_SPHERICAL, reinterpret_cast<uint8_t *>(map), sd_size, 0);
+#endif
 #endif
 }


### PR DESCRIPTION
Fixes build with FFmpeg 8, where `FF_PROFILE_*` enums were replaced with `AV_PROFILE_*` and side_data API was replaced with codecpar.

References:
https://github.com/FFmpeg/FFmpeg/commit/8238bc0b5e3dba271217b1223a901b3f9713dc6e https://github.com/FFmpeg/FFmpeg/commit/5432d2aacad5fa7420fe2d9369ed061d521e92d6

Supersedes #1018 .

Fixes #1028 .