### PR TITLE
Audio Transitions (Equal-Power Cross-fade)

### DIFF
--- a/src/FrameMapper.cpp
+++ b/src/FrameMapper.cpp
@@ -561,9 +561,8 @@ std::shared_ptr<Frame> FrameMapper::GetFrame(int64_t requested_frame)
 		// Determine if the wrapped reader actually supplied audio on this frame.
 		// Video-only readers can still be mapped onto an audio-enabled timeline,
 		// which yields frames with default audio metadata but no sample data.
-		const bool reader_has_audio = reader->info.has_audio &&
-			frame->SampleRate() > 0 &&
-			frame->GetAudioChannelsCount() > 0 &&
+		const bool reader_has_audio = mapped_frame->SampleRate() > 0 &&
+			mapped_frame->GetAudioChannelsCount() > 0 &&
 			mapped_frame->GetAudioSamplesCount() > 0;
 
 		// Resample audio on frame (if needed)

--- a/src/FrameMapper.cpp
+++ b/src/FrameMapper.cpp
@@ -558,8 +558,13 @@ std::shared_ptr<Frame> FrameMapper::GetFrame(int64_t requested_frame)
 				frame->AddImage(std::make_shared<QImage>(*even_frame->GetImage()), false);
 		}
 
-		// Determine if reader contains audio samples
-		bool reader_has_audio = frame->SampleRate() > 0 && frame->GetAudioChannelsCount() > 0;
+		// Determine if the wrapped reader actually supplied audio on this frame.
+		// Video-only readers can still be mapped onto an audio-enabled timeline,
+		// which yields frames with default audio metadata but no sample data.
+		const bool reader_has_audio = reader->info.has_audio &&
+			frame->SampleRate() > 0 &&
+			frame->GetAudioChannelsCount() > 0 &&
+			mapped_frame->GetAudioSamplesCount() > 0;
 
 		// Resample audio on frame (if needed)
 		bool need_resampling = false;
@@ -603,7 +608,7 @@ std::shared_ptr<Frame> FrameMapper::GetFrame(int64_t requested_frame)
 		// Copy the samples
 		int samples_copied = 0;
 		int64_t starting_frame = copy_samples.frame_start;
-		while (info.has_audio && samples_copied < copy_samples.total)
+		while (reader_has_audio && samples_copied < copy_samples.total)
 		{
 			// Init number of samples to copy this iteration
 			int remaining_samples = copy_samples.total - samples_copied;
@@ -616,6 +621,8 @@ std::shared_ptr<Frame> FrameMapper::GetFrame(int64_t requested_frame)
 			}
 
 			int original_samples = original_frame->GetAudioSamplesCount();
+			if (original_samples <= 0)
+				break;
 
 			// Loop through each channel
 			for (int channel = 0; channel < channels_in_frame; channel++)

--- a/src/Timeline.cpp
+++ b/src/Timeline.cpp
@@ -18,6 +18,7 @@
 #include "CrashHandler.h"
 #include "FrameMapper.h"
 #include "Exceptions.h"
+#include "effects/Mask.h"
 
 #include <algorithm>
 #include <QDir>
@@ -672,11 +673,16 @@ void Timeline::add_layer(std::shared_ptr<Frame> new_frame, Clip* source_clip, in
 				new_frame->ResizeAudio(info.channels, source_frame->GetAudioSamplesCount(), info.sample_rate, info.channel_layout);
 			}
 
+			// Apply transition-driven equal-power audio fades for clips covered by a Mask transition.
+			const auto transition_audio_gains = ResolveTransitionAudioGains(source_clip, new_frame->number, is_top_clip);
+
 			for (int channel = 0; channel < source_frame->GetAudioChannelsCount(); channel++)
 			{
 				// Get volume from previous frame and this frame
 				float previous_volume = source_clip->volume.GetValue(clip_frame_number - 1);
 				float volume = source_clip->volume.GetValue(clip_frame_number);
+				previous_volume *= transition_audio_gains.first;
+				volume *= transition_audio_gains.second;
 				int channel_filter = source_clip->channel_filter.GetInt(clip_frame_number); // optional channel to filter (if not -1)
 				int channel_mapping = source_clip->channel_mapping.GetInt(clip_frame_number); // optional channel to map this channel to (if not -1)
 
@@ -1827,4 +1833,123 @@ void Timeline::SetMaxSize(int width, int height) {
 	// Update preview settings
 	preview_width = display_ratio_size.width();
 	preview_height = display_ratio_size.height();
+}
+
+// Resolve equal-power audio gains from transition placement relative to the clip edges.
+std::pair<float, float> Timeline::ResolveTransitionAudioGains(Clip* source_clip, int64_t timeline_frame_number, bool is_top_clip) const
+{
+	constexpr double half_pi = 1.57079632679489661923;
+
+	if (!source_clip)
+		return {1.0f, 1.0f};
+
+	const double fpsD = info.fps.ToDouble();
+	Mask* active_mask = nullptr;
+	int64_t effect_start_position = 0;
+	int64_t effect_end_position = 0;
+
+	// Find the single active transition on this layer that requested overlapping audio fades.
+	for (auto effect : effects) {
+		if (effect->Layer() != source_clip->Layer())
+			continue;
+
+		auto* mask = dynamic_cast<Mask*>(effect);
+		if (!mask || !mask->fade_audio_hint)
+			continue;
+
+		const int64_t start_pos = static_cast<int64_t>(std::llround(effect->Position() * fpsD)) + 1;
+		const int64_t end_pos = static_cast<int64_t>(std::llround((effect->Position() + effect->Duration()) * fpsD));
+		if (start_pos > timeline_frame_number || end_pos < timeline_frame_number)
+			continue;
+
+		if (active_mask)
+			return {1.0f, 1.0f};
+
+		active_mask = mask;
+		effect_start_position = start_pos;
+		effect_end_position = end_pos;
+	}
+
+	if (!active_mask)
+		return {1.0f, 1.0f};
+
+	struct AudibleClipInfo {
+		Clip* clip;
+		int64_t start_pos;
+		int64_t end_pos;
+	};
+
+	std::vector<AudibleClipInfo> audible_clips;
+	audible_clips.reserve(2);
+
+	// Collect the audible clips covered by this transition on the current layer.
+	for (auto clip : clips) {
+		if (clip->Layer() != source_clip->Layer())
+			continue;
+		if (!clip->Reader() || !clip->Reader()->info.has_audio)
+			continue;
+
+		const int64_t clip_start_pos = static_cast<int64_t>(std::llround(clip->Position() * fpsD)) + 1;
+		const int64_t clip_end_pos = static_cast<int64_t>(std::llround((clip->Position() + clip->Duration()) * fpsD));
+		if (clip_start_pos > timeline_frame_number || clip_end_pos < timeline_frame_number)
+			continue;
+
+		const int64_t clip_start_frame = static_cast<int64_t>(std::llround(clip->Start() * fpsD)) + 1;
+		const int64_t clip_frame_number = timeline_frame_number - clip_start_pos + clip_start_frame;
+		if (clip->has_audio.GetInt(clip_frame_number) == 0)
+			continue;
+
+		audible_clips.push_back({clip, clip_start_pos, clip_end_pos});
+		if (audible_clips.size() > 2)
+			return {1.0f, 1.0f};
+	}
+
+	if (audible_clips.empty())
+		return {1.0f, 1.0f};
+
+	// Skip clips that are not actually participating in this transition audio decision.
+	const auto source_it = std::find_if(
+		audible_clips.begin(),
+		audible_clips.end(),
+		[source_clip](const AudibleClipInfo& info) {
+			return info.clip == source_clip;
+		});
+	if (source_it == audible_clips.end())
+		return {1.0f, 1.0f};
+
+	// Keep the current top/non-top clip routing intact when two clips overlap.
+	if (audible_clips.size() == 2) {
+		auto top_it = std::max_element(
+			audible_clips.begin(),
+			audible_clips.end(),
+			[](const AudibleClipInfo& lhs, const AudibleClipInfo& rhs) {
+				if (lhs.start_pos != rhs.start_pos)
+					return lhs.start_pos < rhs.start_pos;
+				return std::less<Clip*>()(lhs.clip, rhs.clip);
+			});
+		if ((is_top_clip && source_clip != top_it->clip) || (!is_top_clip && source_clip == top_it->clip))
+			return {1.0f, 1.0f};
+	}
+
+	// Infer fade direction from which transition edge is closer to this clip.
+	const int64_t left_distance = std::llabs(effect_start_position - source_it->start_pos);
+	const int64_t right_distance = std::llabs(effect_end_position - source_it->end_pos);
+	const bool clip_fades_in = left_distance <= right_distance;
+
+	// Evaluate the current frame and previous frame so Timeline can preserve per-frame gain ramps.
+	const auto compute_gain = [&](int64_t frame_number) -> float {
+		if (effect_end_position <= effect_start_position)
+			return 1.0f;
+
+		const double span = static_cast<double>(effect_end_position - effect_start_position);
+		double t = static_cast<double>(frame_number - effect_start_position) / span;
+		if (t < 0.0)
+			t = 0.0;
+		else if (t > 1.0)
+			t = 1.0;
+
+		return static_cast<float>(clip_fades_in ? std::sin(t * half_pi) : std::cos(t * half_pi));
+	};
+
+	return {compute_gain(timeline_frame_number - 1), compute_gain(timeline_frame_number)};
 }

--- a/src/Timeline.h
+++ b/src/Timeline.h
@@ -18,6 +18,7 @@
 #include <set>
 #include <atomic>
 #include <cstdint>
+#include <utility>
 
 #include "TimelineBase.h"
 #include "ReaderBase.h"
@@ -172,6 +173,9 @@ namespace openshot {
 
 		/// Process a new layer of video or audio
 		void add_layer(std::shared_ptr<openshot::Frame> new_frame, openshot::Clip* source_clip, int64_t clip_frame_number, bool is_top_clip, bool force_safe_composite, float max_volume);
+
+		/// Resolve equal-power audio gains for one clip under a transition on the current timeline frame.
+		std::pair<float, float> ResolveTransitionAudioGains(openshot::Clip* source_clip, int64_t timeline_frame_number, bool is_top_clip) const;
 
 		/// Apply a FrameMapper to a clip which matches the settings of this timeline
 		void apply_mapper_to_clip(openshot::Clip* clip);

--- a/src/effects/Mask.cpp
+++ b/src/effects/Mask.cpp
@@ -21,14 +21,14 @@
 using namespace openshot;
 
 /// Blank constructor, useful when using Json to load the effect properties
-Mask::Mask() : replace_image(false) {
+Mask::Mask() : replace_image(false), fade_audio_hint(false) {
 	// Init effect properties
 	init_effect_details();
 }
 
 // Default constructor
 Mask::Mask(ReaderBase *mask_reader, Keyframe mask_brightness, Keyframe mask_contrast) :
-		brightness(mask_brightness), contrast(mask_contrast), replace_image(false)
+		brightness(mask_brightness), contrast(mask_contrast), replace_image(false), fade_audio_hint(false)
 {
 	// Init effect properties
 	init_effect_details();
@@ -180,6 +180,7 @@ Json::Value Mask::JsonValue() const {
 	root["brightness"] = brightness.JsonValue();
 	root["contrast"] = contrast.JsonValue();
 	root["replace_image"] = replace_image;
+	root["fade_audio_hint"] = fade_audio_hint;
 
 	// return JsonValue
 	return root;
@@ -215,6 +216,8 @@ void Mask::SetJsonValue(const Json::Value root) {
 	// Set data from Json (if key is found)
 	if (!normalized_root["replace_image"].isNull())
 		replace_image = normalized_root["replace_image"].asBool();
+	if (!normalized_root["fade_audio_hint"].isNull())
+		fade_audio_hint = normalized_root["fade_audio_hint"].asBool();
 	if (!normalized_root["brightness"].isNull())
 		brightness.SetJsonValue(normalized_root["brightness"]);
 	if (!normalized_root["contrast"].isNull())
@@ -232,6 +235,10 @@ std::string Mask::PropertiesJSON(int64_t requested_frame) const {
 	root["replace_image"] = add_property_json("Replace Image", replace_image, "int", "", NULL, 0, 1, false, requested_frame);
 	root["replace_image"]["choices"].append(add_property_choice_json("Yes", true, replace_image));
 	root["replace_image"]["choices"].append(add_property_choice_json("No", false, replace_image));
+
+	root["fade_audio_hint"] = add_property_json("Fade Audio", fade_audio_hint, "int", "", NULL, 0, 1, false, requested_frame);
+	root["fade_audio_hint"]["choices"].append(add_property_choice_json("Yes", true, fade_audio_hint));
+	root["fade_audio_hint"]["choices"].append(add_property_choice_json("No", false, fade_audio_hint));
 
 	// Keyframes
 	root["brightness"] = add_property_json("Brightness", brightness.GetValue(requested_frame), "float", "", &brightness, -1.0, 1.0, false, requested_frame);

--- a/src/effects/Mask.h
+++ b/src/effects/Mask.h
@@ -44,6 +44,7 @@ namespace openshot
 
 	public:
 		bool replace_image;		///< Replace the frame image with a grayscale image representing the mask. Great for debugging a mask.
+		bool fade_audio_hint;	///< Timeline-only hint requesting equal-power audio crossfade for overlapping clips when this Mask is used as a global transition.
 		Keyframe brightness;	///< Brightness keyframe to control the wipe / mask effect. A constant value here will prevent animation.
 		Keyframe contrast;		///< Contrast keyframe to control the hardness of the wipe effect / mask.
 

--- a/tests/Mask.cpp
+++ b/tests/Mask.cpp
@@ -136,6 +136,28 @@ TEST_CASE("Mask legacy start and end json load into base trim", "[effect][mask_e
 	CHECK(mask.JsonValue()["end"].asDouble() == Approx(1.25).margin(0.00001));
 }
 
+TEST_CASE("Mask fade_audio_hint json and properties round-trip", "[effect][mask_effect][json][audio]") {
+	Mask mask;
+	mask.fade_audio_hint = true;
+
+	const Json::Value json = mask.JsonValue();
+	CHECK(json["fade_audio_hint"].asBool());
+
+	Mask loaded;
+	loaded.SetJsonValue(json);
+	CHECK(loaded.fade_audio_hint);
+
+	const Json::Value properties = openshot::stringToJson(loaded.PropertiesJSON(1));
+	CHECK(properties["fade_audio_hint"]["value"].asBool());
+}
+
+TEST_CASE("Mask fade_audio_hint defaults to false when omitted", "[effect][mask_effect][json][audio][default]") {
+	Mask mask;
+	mask.SetJsonValue(Json::Value(Json::objectValue));
+
+	CHECK_FALSE(mask.fade_audio_hint);
+}
+
 TEST_CASE("Mask ProcessFrame brightness 1.0 fully clears output", "[effect][mask_effect][process][brightness]") {
 	auto frame = std::make_shared<Frame>(1, 2, 1, "#000000");
 	auto image = frame->GetImage();

--- a/tests/Timeline.cpp
+++ b/tests/Timeline.cpp
@@ -31,6 +31,7 @@
 #include "Exceptions.h"
 #include "effects/Blur.h"
 #include "effects/Bars.h"
+#include "effects/Mask.h"
 #include "effects/Negate.h"
 
 using namespace openshot;
@@ -149,6 +150,241 @@ public:
 	void SetJson(const std::string value) override { (void) value; }
 	void SetJsonValue(const Json::Value root) override { ReaderBase::SetJsonValue(root); }
 };
+
+class TimelineConstantAudioReader : public ReaderBase {
+private:
+	bool is_open = false;
+	CacheMemory cache;
+	float sample_value = 0.0f;
+
+public:
+	TimelineConstantAudioReader(int width, int height,
+	                            int fps_num, int fps_den,
+	                            int sample_rate, int channels,
+	                            int64_t length_frames, float fill_sample)
+		: sample_value(fill_sample) {
+		info.has_video = true;
+		info.has_audio = true;
+		info.width = width;
+		info.height = height;
+		info.fps = Fraction(fps_num, fps_den);
+		info.video_length = length_frames;
+		info.duration = static_cast<float>(length_frames / info.fps.ToDouble());
+		info.sample_rate = sample_rate;
+		info.channels = channels;
+		info.channel_layout = LAYOUT_STEREO;
+		info.audio_stream_index = 0;
+	}
+
+	openshot::CacheBase* GetCache() override { return &cache; }
+	bool IsOpen() override { return is_open; }
+	std::string Name() override { return "TimelineConstantAudioReader"; }
+	void Open() override { is_open = true; }
+	void Close() override { is_open = false; }
+
+	std::shared_ptr<openshot::Frame> GetFrame(int64_t number) override {
+		const int sample_count = Frame::GetSamplesPerFrame(number, info.fps, info.sample_rate, info.channels);
+		auto frame = std::make_shared<Frame>(number, info.width, info.height, "#000000", sample_count, info.channels);
+		std::vector<float> samples(sample_count, sample_value);
+		for (int channel = 0; channel < info.channels; ++channel)
+			frame->AddAudio(true, channel, 0, samples.data(), sample_count, 1.0f);
+		return frame;
+	}
+
+	std::string Json() const override { return JsonValue().toStyledString(); }
+	Json::Value JsonValue() const override {
+		Json::Value root = ReaderBase::JsonValue();
+		root["type"] = "TimelineConstantAudioReader";
+		root["path"] = "";
+		return root;
+	}
+	void SetJson(const std::string value) override { (void) value; }
+	void SetJsonValue(const Json::Value root) override { ReaderBase::SetJsonValue(root); }
+};
+
+static double expected_equal_power_gain(int64_t frame_number, int64_t start_frame, int64_t end_frame, bool fades_in) {
+	constexpr double kHalfPi = 1.57079632679489661923;
+	if (end_frame <= start_frame)
+		return 1.0;
+	const double span = static_cast<double>(end_frame - start_frame);
+	double t = static_cast<double>(frame_number - start_frame) / span;
+	if (t < 0.0)
+		t = 0.0;
+	else if (t > 1.0)
+		t = 1.0;
+	return fades_in ? std::sin(t * kHalfPi) : std::cos(t * kHalfPi);
+}
+
+TEST_CASE("Timeline honors Mask fade_audio_hint with equal-power overlapping audio", "[libopenshot][timeline][audio][transition]") {
+	const Fraction fps(30, 1);
+	const int sample_rate = 48000;
+	const int channels = 2;
+	const int64_t length_frames = 90;
+	const int64_t overlap_start_frame = 31;
+	const int64_t overlap_end_frame = 60;
+
+	Timeline t(320, 180, fps, sample_rate, channels, LAYOUT_STEREO);
+
+	TimelineConstantAudioReader bottom_reader(320, 180, fps.num, fps.den, sample_rate, channels, length_frames, 1.0f);
+	TimelineConstantAudioReader top_reader(320, 180, fps.num, fps.den, sample_rate, channels, length_frames, 1.0f);
+
+	Clip bottom_clip;
+	bottom_clip.Reader(&bottom_reader);
+	bottom_clip.Layer(0);
+	bottom_clip.Position(0.0);
+	bottom_clip.Start(0.0);
+	bottom_clip.End(2.0);
+	bottom_clip.channel_filter = Keyframe(0.0);
+
+	Clip top_clip;
+	top_clip.Reader(&top_reader);
+	top_clip.Layer(0);
+	top_clip.Position(1.0);
+	top_clip.Start(0.0);
+	top_clip.End(2.0);
+	top_clip.channel_filter = Keyframe(1.0);
+
+	TimelineTrackingMaskReader mask_reader(fps.num, fps.den, overlap_end_frame - overlap_start_frame + 1);
+	Mask transition;
+	transition.Reader(&mask_reader);
+	transition.Layer(0);
+	transition.Position(1.0);
+	transition.Start(0.0);
+	transition.End(1.0);
+	transition.brightness = Keyframe();
+	transition.brightness.AddPoint(1, 1.0, BEZIER);
+	transition.brightness.AddPoint(overlap_end_frame - overlap_start_frame + 1, -1.0, BEZIER);
+	transition.contrast = Keyframe(3.0);
+
+	t.AddClip(&bottom_clip);
+	t.AddClip(&top_clip);
+	t.AddEffect(&transition);
+	t.Open();
+
+	SECTION("disabled hint keeps raw overlap audio") {
+		transition.fade_audio_hint = false;
+		auto frame = t.GetFrame(45);
+		const int last_sample = frame->GetAudioSamplesCount() - 1;
+		CHECK(frame->GetAudioSamples(0)[0] == Approx(1.0).margin(0.0001));
+		CHECK(frame->GetAudioSamples(1)[0] == Approx(1.0).margin(0.0001));
+		CHECK(frame->GetAudioSamples(0)[last_sample] == Approx(1.0).margin(0.0001));
+		CHECK(frame->GetAudioSamples(1)[last_sample] == Approx(1.0).margin(0.0001));
+	}
+
+	SECTION("enabled hint fades bottom out and top in") {
+		transition.fade_audio_hint = true;
+
+		auto start_frame = t.GetFrame(overlap_start_frame);
+		CHECK(start_frame->GetAudioSamples(0)[0] == Approx(1.0).margin(0.0001));
+		CHECK(start_frame->GetAudioSamples(1)[0] == Approx(0.0).margin(0.0001));
+
+		auto middle_frame = t.GetFrame(45);
+		const int middle_last_sample = middle_frame->GetAudioSamplesCount() - 1;
+		const double expected_prev_bottom = expected_equal_power_gain(44, overlap_start_frame, overlap_end_frame, false);
+		const double expected_prev_top = expected_equal_power_gain(44, overlap_start_frame, overlap_end_frame, true);
+		const double expected_bottom = expected_equal_power_gain(45, overlap_start_frame, overlap_end_frame, false);
+		const double expected_top = expected_equal_power_gain(45, overlap_start_frame, overlap_end_frame, true);
+		CHECK(middle_frame->GetAudioSamples(0)[0] == Approx(expected_prev_bottom).margin(0.0002));
+		CHECK(middle_frame->GetAudioSamples(1)[0] == Approx(expected_prev_top).margin(0.0002));
+		CHECK(middle_frame->GetAudioSamples(0)[middle_last_sample] == Approx(expected_bottom).margin(0.002));
+		CHECK(middle_frame->GetAudioSamples(1)[middle_last_sample] == Approx(expected_top).margin(0.002));
+
+		auto end_frame = t.GetFrame(overlap_end_frame);
+		const int end_last_sample = end_frame->GetAudioSamplesCount() - 1;
+		CHECK(end_frame->GetAudioSamples(0)[end_last_sample] == Approx(0.0).margin(0.002));
+		CHECK(end_frame->GetAudioSamples(1)[end_last_sample] == Approx(1.0).margin(0.002));
+	}
+
+	SECTION("reversed brightness does not affect geometry-based fade directions") {
+		transition.fade_audio_hint = true;
+		transition.brightness = Keyframe();
+		transition.brightness.AddPoint(1, -1.0, BEZIER);
+		transition.brightness.AddPoint(overlap_end_frame - overlap_start_frame + 1, 1.0, BEZIER);
+
+		auto start_frame = t.GetFrame(overlap_start_frame);
+		CHECK(start_frame->GetAudioSamples(0)[0] == Approx(1.0).margin(0.0001));
+		CHECK(start_frame->GetAudioSamples(1)[0] == Approx(0.0).margin(0.0001));
+
+		auto middle_frame = t.GetFrame(45);
+		const int middle_last_sample = middle_frame->GetAudioSamplesCount() - 1;
+		const double expected_prev_bottom = expected_equal_power_gain(44, overlap_start_frame, overlap_end_frame, false);
+		const double expected_prev_top = expected_equal_power_gain(44, overlap_start_frame, overlap_end_frame, true);
+		const double expected_bottom = expected_equal_power_gain(45, overlap_start_frame, overlap_end_frame, false);
+		const double expected_top = expected_equal_power_gain(45, overlap_start_frame, overlap_end_frame, true);
+		CHECK(middle_frame->GetAudioSamples(0)[0] == Approx(expected_prev_bottom).margin(0.0002));
+		CHECK(middle_frame->GetAudioSamples(1)[0] == Approx(expected_prev_top).margin(0.0002));
+		CHECK(middle_frame->GetAudioSamples(0)[middle_last_sample] == Approx(expected_bottom).margin(0.002));
+		CHECK(middle_frame->GetAudioSamples(1)[middle_last_sample] == Approx(expected_top).margin(0.002));
+
+		auto end_frame = t.GetFrame(overlap_end_frame);
+		const int end_last_sample = end_frame->GetAudioSamplesCount() - 1;
+		CHECK(end_frame->GetAudioSamples(0)[end_last_sample] == Approx(0.0).margin(0.002));
+		CHECK(end_frame->GetAudioSamples(1)[end_last_sample] == Approx(1.0).margin(0.002));
+	}
+
+	t.Close();
+}
+
+TEST_CASE("Timeline uses transition edge proximity for single-clip fade audio", "[libopenshot][timeline][audio][transition][single]") {
+	const Fraction fps(30, 1);
+	const int sample_rate = 48000;
+	const int channels = 2;
+	const int64_t length_frames = 90;
+
+	Timeline t(320, 180, fps, sample_rate, channels, LAYOUT_STEREO);
+
+	TimelineConstantAudioReader clip_reader(320, 180, fps.num, fps.den, sample_rate, channels, length_frames, 1.0f);
+	Clip clip;
+	clip.Reader(&clip_reader);
+	clip.Layer(0);
+	clip.Position(1.0);
+	clip.Start(0.0);
+	clip.End(2.0);
+
+	TimelineTrackingMaskReader mask_reader(fps.num, fps.den, 30);
+	Mask transition;
+	transition.Reader(&mask_reader);
+	transition.Layer(0);
+	transition.Start(0.0);
+	transition.End(1.0);
+	transition.fade_audio_hint = true;
+	transition.brightness = Keyframe(0.0);
+	transition.contrast = Keyframe(0.0);
+
+	t.AddClip(&clip);
+	t.AddEffect(&transition);
+	t.Open();
+
+	SECTION("left edge proximity fades in") {
+		transition.Position(1.0);
+		auto start_frame = t.GetFrame(31);
+		auto end_frame = t.GetFrame(60);
+		const int end_last_sample = end_frame->GetAudioSamplesCount() - 1;
+		CHECK(start_frame->GetAudioSamples(0)[0] == Approx(0.0).margin(0.0001));
+		CHECK(end_frame->GetAudioSamples(0)[end_last_sample] == Approx(1.0).margin(0.002));
+	}
+
+	SECTION("right edge proximity fades out") {
+		transition.Position(2.0);
+		auto start_frame = t.GetFrame(61);
+		auto end_frame = t.GetFrame(90);
+		const int end_last_sample = end_frame->GetAudioSamplesCount() - 1;
+		CHECK(start_frame->GetAudioSamples(0)[0] == Approx(1.0).margin(0.0001));
+		CHECK(end_frame->GetAudioSamples(0)[end_last_sample] == Approx(0.0).margin(0.002));
+	}
+
+	SECTION("equal distance defaults to fade in") {
+		transition.Position(1.5);
+		transition.End(1.0);
+		auto start_frame = t.GetFrame(46);
+		auto end_frame = t.GetFrame(75);
+		const int end_last_sample = end_frame->GetAudioSamplesCount() - 1;
+		CHECK(start_frame->GetAudioSamples(0)[0] == Approx(0.0).margin(0.0001));
+		CHECK(end_frame->GetAudioSamples(0)[end_last_sample] == Approx(1.0).margin(0.002));
+	}
+
+	t.Close();
+}
 
 TEST_CASE( "constructor", "[libopenshot][timeline]" )
 {


### PR DESCRIPTION
- Timeline now fades audio based on transition placement (global Mask effect)
- Mask position on same layer as clip (left side of clip fades audio in, right side of clip fades audio out, overlapping 2 clips cross-fades both clips)
- Added unit tests