### PR TITLE
Fixing Clip Memory Issues (Speed & Corruption)

### DIFF
--- a/src/Clip.cpp
+++ b/src/Clip.cpp
@@ -513,6 +513,18 @@ std::shared_ptr<Frame> Clip::GetFrame(std::shared_ptr<openshot::Frame> backgroun
             final_cache.Add(frame);
         }
 
+		// Timeline composition can paint directly into the timeline-owned background
+		// without mutating the cached clip frame.
+		if (options) {
+			if (!background_frame) {
+				background_frame = std::make_shared<Frame>(frame->number, frame->GetWidth(), frame->GetHeight(),
+														   "#00000000", frame->GetAudioSamplesCount(),
+														   frame->GetAudioChannelsCount());
+			}
+			apply_background(frame, background_frame, false);
+			return frame;
+		}
+
 		// No background: return the frame directly.
 		if (!background_frame) {
 			return frame;

--- a/src/Clip.cpp
+++ b/src/Clip.cpp
@@ -513,33 +513,12 @@ std::shared_ptr<Frame> Clip::GetFrame(std::shared_ptr<openshot::Frame> backgroun
             final_cache.Add(frame);
         }
 
-		const bool has_external_background = (background_frame != nullptr);
-
-		// Timeline path.
-		if (options) {
-			if (!background_frame) {
-				// Create a transparent background if missing.
-				background_frame = std::make_shared<Frame>(frame->number, frame->GetWidth(), frame->GetHeight(),
-														   "#00000000", frame->GetAudioSamplesCount(),
-														   frame->GetAudioChannelsCount());
-			}
-			if (options->force_safe_composite) {
-				// Edit mode: composite without mutating cached frame pixels.
-				apply_background(frame, background_frame, false);
-				return frame;
-			}
-
-			// Playback mode: keep original fast path.
-			apply_background(frame, background_frame, true);
-			return frame;
-		}
-
 		// No background: return the frame directly.
-		if (!has_external_background) {
+		if (!background_frame) {
 			return frame;
 		}
 
-		// External background: composite on a copy.
+		// Always composite on a copy so cached frame pixels remain immutable.
 		auto output = std::make_shared<Frame>(*frame.get());
 		apply_background(output, background_frame, true);
 		return output;

--- a/src/Clip.cpp
+++ b/src/Clip.cpp
@@ -478,40 +478,33 @@ std::shared_ptr<Frame> Clip::GetFrame(std::shared_ptr<openshot::Frame> backgroun
 		// Get frame object
 		std::shared_ptr<Frame> frame = NULL;
 
-		// Check cache
-		frame = final_cache.GetFrame(clip_frame_number);
-		if (!frame) {
-            // Generate clip frame
-            frame = GetOrCreateFrame(clip_frame_number);
+		// Generate clip frame
+		frame = GetOrCreateFrame(clip_frame_number);
 
-            // Get frame size and frame #
-            int64_t timeline_frame_number = clip_frame_number;
-            QSize timeline_size(frame->GetWidth(), frame->GetHeight());
-            if (background_frame) {
-                // If a background frame is provided, use it instead
-                timeline_frame_number = background_frame->number;
-                timeline_size.setWidth(background_frame->GetWidth());
-                timeline_size.setHeight(background_frame->GetHeight());
-            }
+		// Get frame size and frame #
+		int64_t timeline_frame_number = clip_frame_number;
+		QSize timeline_size(frame->GetWidth(), frame->GetHeight());
+		if (background_frame) {
+			// If a background frame is provided, use it instead
+			timeline_frame_number = background_frame->number;
+			timeline_size.setWidth(background_frame->GetWidth());
+			timeline_size.setHeight(background_frame->GetHeight());
+		}
 
-            // Get time mapped frame object (used to increase speed, change direction, etc...)
-            apply_timemapping(frame);
+		// Get time mapped frame object (used to increase speed, change direction, etc...)
+		apply_timemapping(frame);
 
-            // Apply waveform image (if any)
-            apply_waveform(frame, timeline_size);
+		// Apply waveform image (if any)
+		apply_waveform(frame, timeline_size);
 
-            // Apply effects BEFORE applying keyframes (if any local or global effects are used)
-            apply_effects(frame, timeline_frame_number, options, true);
+		// Apply effects BEFORE applying keyframes (if any local or global effects are used)
+		apply_effects(frame, timeline_frame_number, options, true);
 
-            // Apply keyframe / transforms to current clip image
-            apply_keyframes(frame, timeline_size);
+		// Apply keyframe / transforms to current clip image
+		apply_keyframes(frame, timeline_size);
 
-            // Apply effects AFTER applying keyframes (if any local or global effects are used)
-            apply_effects(frame, timeline_frame_number, options, false);
-
-            // Add final frame to cache (before flattening into background_frame)
-            final_cache.Add(frame);
-        }
+		// Apply effects AFTER applying keyframes (if any local or global effects are used)
+		apply_effects(frame, timeline_frame_number, options, false);
 
 		// Timeline composition can paint directly into the timeline-owned background
 		// without mutating the cached clip frame.

--- a/src/Clip.h
+++ b/src/Clip.h
@@ -111,7 +111,7 @@ namespace openshot {
 		std::shared_ptr<openshot::TrackedObjectBase> parentTrackedObject; ///< Tracked object this clip is attached to
 		openshot::Clip* parentClipObject; ///< Clip object this clip is attached to
 
-		/// Final cache object used to hold final frames
+		/// Final cache object used to hold final frames (currently unused for clip frame caching)
 		CacheMemory final_cache;
 		
 		// Audio resampler (if time mapping)

--- a/src/FFmpegReader.cpp
+++ b/src/FFmpegReader.cpp
@@ -1432,6 +1432,9 @@ std::shared_ptr<Frame> FFmpegReader::ReadStream(int64_t requested_frame) {
 		if (frame) {
 			// Copy and return the largest processed frame (assuming it was the last in the video file)
 			std::shared_ptr<Frame> f = CreateFrame(largest_frame_processed);
+			if (frame->has_image_data) {
+				f->AddImage(std::make_shared<QImage>(frame->GetImage()->copy()));
+			}
 
 			// Use solid color (if no image data found)
 			if (!frame->has_image_data) {
@@ -1439,9 +1442,9 @@ std::shared_ptr<Frame> FFmpegReader::ReadStream(int64_t requested_frame) {
 				f->AddColor(info.width, info.height, "#000");
 			}
 			// Silence audio data (if any), since we are repeating the last frame
-			frame->AddAudioSilence(samples_in_frame);
+			f->AddAudioSilence(samples_in_frame);
 
-			return frame;
+			return f;
 		} else {
 			// The largest processed frame is no longer in cache. Prefer the most recent
 			// finalized image first, then decoded image, to avoid black flashes.

--- a/src/Timeline.cpp
+++ b/src/Timeline.cpp
@@ -32,7 +32,7 @@ using namespace openshot;
 
 // Default Constructor for the timeline (which sets the canvas width and height)
 Timeline::Timeline(int width, int height, Fraction fps, int sample_rate, int channels, ChannelLayout channel_layout) :
-		is_open(false), auto_map_clips(true), managed_cache(true), path(""), max_time(0.0), cache_epoch(0), safe_edit_frames_remaining(0)
+		is_open(false), auto_map_clips(true), managed_cache(true), path(""), max_time(0.0), cache_epoch(0)
 {
 	// Create CrashHandler and Attach (incase of errors)
 	CrashHandler::Instance();
@@ -83,7 +83,7 @@ Timeline::Timeline(const ReaderInfo info) : Timeline::Timeline(
 
 // Constructor for the timeline (which loads a JSON structure from a file path, and initializes a timeline)
 Timeline::Timeline(const std::string& projectPath, bool convert_absolute_paths) :
-		is_open(false), auto_map_clips(true), managed_cache(true), path(projectPath), max_time(0.0), cache_epoch(0), safe_edit_frames_remaining(0) {
+		is_open(false), auto_map_clips(true), managed_cache(true), path(projectPath), max_time(0.0), cache_epoch(0) {
 
 	// Create CrashHandler and Attach (incase of errors)
 	CrashHandler::Instance();
@@ -634,13 +634,12 @@ std::shared_ptr<Frame> Timeline::GetOrCreateFrame(std::shared_ptr<Frame> backgro
 }
 
 // Process a new layer of video or audio
-void Timeline::add_layer(std::shared_ptr<Frame> new_frame, Clip* source_clip, int64_t clip_frame_number, bool is_top_clip, bool force_safe_composite, float max_volume)
+void Timeline::add_layer(std::shared_ptr<Frame> new_frame, Clip* source_clip, int64_t clip_frame_number, bool is_top_clip, float max_volume)
 {
 	// Create timeline options (with details about this current frame request)
 	TimelineInfoStruct options{};
 	options.is_top_clip = is_top_clip;
 	options.is_before_clip_keyframes = true;
-	options.force_safe_composite = force_safe_composite;
 
 	// Get the clip's frame, composited on top of the current timeline frame
 	std::shared_ptr<Frame> source_frame;
@@ -1070,11 +1069,6 @@ std::shared_ptr<Frame> Timeline::GetFrame(int64_t requested_frame)
 			}
 
 			// Compose intersecting clips in a single pass
-			const int safe_remaining = safe_edit_frames_remaining.load(std::memory_order_relaxed);
-			const bool force_safe_composite = (safe_remaining > 0);
-			if (force_safe_composite) {
-				safe_edit_frames_remaining.fetch_sub(1, std::memory_order_relaxed);
-			}
 			for (const auto& ci : clip_infos) {
 				// Debug output
 				ZmqLogger::Instance()->AppendDebugMethod(
@@ -1105,7 +1099,7 @@ std::shared_ptr<Frame> Timeline::GetFrame(int64_t requested_frame)
 							"clip_frame_number", clip_frame_number);
 
 					// Add clip's frame as layer
-					add_layer(new_frame, ci.clip, clip_frame_number, is_top_clip, force_safe_composite, max_volume_sum);
+					add_layer(new_frame, ci.clip, clip_frame_number, is_top_clip, max_volume_sum);
 
 				} else {
 					// Debug output
@@ -1397,8 +1391,6 @@ void Timeline::ApplyJsonDiff(std::string value) {
 
 		// Timeline content changed: notify cache clients to rescan active window.
 		if (!root.empty()) {
-			// After edits, force safe composition for a short window.
-			safe_edit_frames_remaining.store(240, std::memory_order_relaxed);
 			BumpCacheEpoch();
 		}
 	}

--- a/src/Timeline.h
+++ b/src/Timeline.h
@@ -167,12 +167,11 @@ namespace openshot {
 		double max_time; ///> The max duration (in seconds) of the timeline, based on the furthest clip (right edge)
 		double min_time; ///> The min duration (in seconds) of the timeline, based on the position of the first clip (left edge)
 		std::atomic<uint64_t> cache_epoch; ///< Cache invalidation epoch for external observers.
-		std::atomic<int> safe_edit_frames_remaining; ///< Remaining composed frames forced into safe edit composition.
 
 		std::map<std::string, std::shared_ptr<openshot::TrackedObjectBase>> tracked_objects; ///< map of TrackedObjectBBoxes and their IDs
 
 		/// Process a new layer of video or audio
-		void add_layer(std::shared_ptr<openshot::Frame> new_frame, openshot::Clip* source_clip, int64_t clip_frame_number, bool is_top_clip, bool force_safe_composite, float max_volume);
+		void add_layer(std::shared_ptr<openshot::Frame> new_frame, openshot::Clip* source_clip, int64_t clip_frame_number, bool is_top_clip, float max_volume);
 
 		/// Resolve equal-power audio gains for one clip under a transition on the current timeline frame.
 		std::pair<float, float> ResolveTransitionAudioGains(openshot::Clip* source_clip, int64_t timeline_frame_number, bool is_top_clip) const;
@@ -322,7 +321,6 @@ namespace openshot {
 
 		/// Return the current cache invalidation epoch.
 		uint64_t CacheEpoch() const { return cache_epoch.load(std::memory_order_relaxed); };
-		int SafeEditFramesRemaining() const { return safe_edit_frames_remaining.load(std::memory_order_relaxed); };
 
 		/// Get an openshot::Frame object for a specific frame number of this timeline.
 		///

--- a/src/TimelineBase.h
+++ b/src/TimelineBase.h
@@ -33,7 +33,6 @@ namespace openshot {
 	{
 		bool is_top_clip;				 ///< Is clip on top (if overlapping another clip)
 		bool is_before_clip_keyframes;	///< Is this before clip keyframes are applied
-		bool force_safe_composite;      ///< If true, avoid mutating cached clip images during composition
 	};
 
 	/**

--- a/tests/Clip.cpp
+++ b/tests/Clip.cpp
@@ -865,6 +865,57 @@ TEST_CASE( "cached_frame_not_mutated_by_background_compositing", "[libopenshot][
 	CHECK(c2.blue()  == Approx(0).margin(8));
 }
 
+TEST_CASE( "timeline_background_compositing_mutates_only_timeline_canvas", "[libopenshot][clip][timeline][cache]" )
+{
+	openshot::CacheMemory cache;
+	auto src = std::make_shared<openshot::Frame>(1, 64, 64, "#000000", 0, 2);
+	src->AddColor(QColor(Qt::red));
+	cache.Add(src);
+
+	openshot::DummyReader dummy(openshot::Fraction(30,1), 64, 64, 44100, 2, 1.0, &cache);
+	dummy.Open();
+
+	openshot::Clip clip;
+	clip.Reader(&dummy);
+	clip.Open();
+	clip.display = openshot::FRAME_DISPLAY_NONE;
+	clip.alpha.AddPoint(1, 0.5);
+
+	openshot::TimelineInfoStruct options{};
+	options.is_top_clip = true;
+	options.is_before_clip_keyframes = true;
+
+	auto bg_blue = std::make_shared<openshot::Frame>(1, 64, 64, "#000000", 0, 2);
+	bg_blue->AddColor(QColor(Qt::blue));
+	auto out_blue = clip.GetFrame(bg_blue, 1, &options);
+
+	QColor cached_pixel = out_blue->GetImage()->pixelColor(32, 32);
+	CHECK(cached_pixel.alpha() == Approx(127).margin(10));
+	CHECK(cached_pixel.red()   == Approx(255).margin(2));
+	CHECK(cached_pixel.green() == Approx(0).margin(2));
+	CHECK(cached_pixel.blue()  == Approx(0).margin(2));
+
+	QColor blue_canvas = bg_blue->GetImage()->pixelColor(32, 32);
+	CHECK(blue_canvas.red()   == Approx(127).margin(14));
+	CHECK(blue_canvas.green() == Approx(0).margin(8));
+	CHECK(blue_canvas.blue()  == Approx(127).margin(14));
+
+	auto bg_green = std::make_shared<openshot::Frame>(1, 64, 64, "#000000", 0, 2);
+	bg_green->AddColor(QColor(Qt::green));
+	auto out_green = clip.GetFrame(bg_green, 1, &options);
+
+	QColor cached_pixel_again = out_green->GetImage()->pixelColor(32, 32);
+	CHECK(cached_pixel_again.alpha() == Approx(127).margin(10));
+	CHECK(cached_pixel_again.red()   == Approx(255).margin(2));
+	CHECK(cached_pixel_again.green() == Approx(0).margin(2));
+	CHECK(cached_pixel_again.blue()  == Approx(0).margin(2));
+
+	QColor green_canvas = bg_green->GetImage()->pixelColor(32, 32);
+	CHECK(green_canvas.red()   == Approx(127).margin(14));
+	CHECK(green_canvas.green() == Approx(127).margin(14));
+	CHECK(green_canvas.blue()  == Approx(0).margin(8));
+}
+
 TEST_CASE("all_composite_modes_simple_colors", "[libopenshot][clip][composite]")
 {
 	// Source clip: solid red

--- a/tests/Timeline.cpp
+++ b/tests/Timeline.cpp
@@ -1615,54 +1615,6 @@ TEST_CASE( "ApplyJSONDiff alpha updates refresh fixed-frame preview content", "[
 	}
 }
 
-TEST_CASE( "ApplyJSONDiff enables and drains edit safety window", "[libopenshot][timeline][edit]" )
-{
-	TimelineSolidColorReader reader(
-		/*width=*/64, /*height=*/64, /*fps_num=*/30, /*fps_den=*/1, /*length_frames=*/300,
-		QColor(220, 30, 180, 255)
-	);
-
-	Clip clip(&reader);
-	clip.Id("EDIT_WINDOW_CLIP");
-	clip.Layer(0);
-	clip.Position(0.0);
-	clip.End(10.0);
-
-	Timeline t(64, 64, Fraction(30, 1), 44100, 2, LAYOUT_STEREO);
-	t.AddClip(&clip);
-	t.Open();
-
-	CHECK(t.SafeEditFramesRemaining() == 0);
-
-	Json::Value root(Json::arrayValue);
-	Json::Value change(Json::objectValue);
-	change["type"] = "update";
-	change["partial"] = true;
-
-	Json::Value key(Json::arrayValue);
-	key.append("clips");
-	Json::Value key_id(Json::objectValue);
-	key_id["id"] = clip.Id();
-	key.append(key_id);
-	change["key"] = key;
-
-	Json::Value value(Json::objectValue);
-	value["rotation"] = Keyframe(10.0).JsonValue();
-	change["value"] = value;
-	root.append(change);
-
-	t.ApplyJsonDiff(root.toStyledString());
-	CHECK(t.SafeEditFramesRemaining() == 240);
-
-	(void)t.GetFrame(1);
-	CHECK(t.SafeEditFramesRemaining() == 239);
-
-	for (int64_t frame = 2; frame <= 240; ++frame) {
-		(void)t.GetFrame(frame);
-	}
-	CHECK(t.SafeEditFramesRemaining() == 0);
-}
-
 TEST_CASE( "ApplyJSONDiff clip Bars effect updates refresh fixed-frame preview content", "[libopenshot][timeline][effect][bars]" )
 {
 	TimelineSolidColorReader base_reader(

--- a/tests/Timeline.cpp
+++ b/tests/Timeline.cpp
@@ -1595,23 +1595,23 @@ TEST_CASE( "ApplyJSONDiff alpha updates refresh fixed-frame preview content", "[
 	std::shared_ptr<Frame> initial = t.GetFrame(frame_number);
 	REQUIRE(initial != nullptr);
 	REQUIRE(t.GetCache() != nullptr);
-	REQUIRE(overlay_clip.GetCache() != nullptr);
 	REQUIRE(t.GetCache()->Contains(frame_number));
-	REQUIRE(overlay_clip.GetCache()->Count() > 0);
+	QColor previous_color = initial->GetImage()->pixelColor(20, 20);
 
-	// Repeated alpha updates at the same frame must invalidate both timeline and
-	// clip caches, preventing stale preview frames from being reused.
+	// Repeated alpha updates at the same frame must invalidate the timeline cache
+	// and refresh the composited preview content.
 	const std::vector<double> alpha_steps = {0.9, 0.8, 0.7, 0.6, 0.5};
 	for (double alpha_value : alpha_steps) {
 		apply_alpha(alpha_value);
 		CHECK(!t.GetCache()->Contains(frame_number));
-		CHECK(overlay_clip.GetCache()->Count() == 0);
 
-		// Re-request frame to repopulate caches before next update.
+		// Re-request frame to repopulate the timeline cache before next update.
 		std::shared_ptr<Frame> refreshed = t.GetFrame(frame_number);
 		REQUIRE(refreshed != nullptr);
 		CHECK(t.GetCache()->Contains(frame_number));
-		CHECK(overlay_clip.GetCache()->Count() > 0);
+		QColor refreshed_color = refreshed->GetImage()->pixelColor(20, 20);
+		CHECK(refreshed_color != previous_color);
+		previous_color = refreshed_color;
 	}
 }
 


### PR DESCRIPTION
Disabling clip cache after lots of testing and benchmarking - cost of caching is greater than the benefit.