### PR TITLE
Prevent crash with concurrent change_mapping (FrameMapper audio resample context)

### DIFF
--- a/src/FrameMapper.cpp
+++ b/src/FrameMapper.cpp
@@ -820,6 +820,10 @@ void FrameMapper::SetJsonValue(const Json::Value root) {
 // Change frame rate or audio mapping details
 void FrameMapper::ChangeMapping(Fraction target_fps, PulldownType target_pulldown,  int target_sample_rate, int target_channels, ChannelLayout target_channel_layout)
 {
+	// Prevent concurrent GetFrame()/Init()/Close() calls from using or freeing
+	// the resampler while this mapping update is in progress.
+	const std::lock_guard<std::recursive_mutex> lock(getFrameMutex);
+
 	ZmqLogger::Instance()->AppendDebugMethod(
 		"FrameMapper::ChangeMapping",
 		"target_fps.num", target_fps.num,
@@ -861,6 +865,13 @@ void FrameMapper::ChangeMapping(Fraction target_fps, PulldownType target_pulldow
 		SWR_FREE(&avr);
 		avr = NULL;
 	}
+
+	// Reset direction/resampler continuity after a mapping change.
+	previous_frame = 0;
+	const std::lock_guard<std::recursive_mutex> direction_lock(directionMutex);
+	have_hint = false;
+	last_dir_initialized = false;
+	last_is_increasing = true;
 }
 
 // Resample audio and map channels (if needed)

--- a/src/Timeline.cpp
+++ b/src/Timeline.cpp
@@ -500,6 +500,9 @@ double Timeline::GetMinTime() {
 // Apply a FrameMapper to a clip which matches the settings of this timeline
 void Timeline::apply_mapper_to_clip(Clip* clip)
 {
+	// Serialize mapper replacement/reconfiguration with active frame generation.
+	const std::lock_guard<std::recursive_mutex> guard(getFrameMutex);
+
 	// Determine type of reader
 	ReaderBase* clip_reader = NULL;
 	if (clip->Reader()->Name() == "FrameMapper")

--- a/tests/FrameMapper.cpp
+++ b/tests/FrameMapper.cpp
@@ -21,7 +21,9 @@
 #include "Frame.h"
 #include "FrameMapper.h"
 #include "Timeline.h"
+#include <atomic>
 #include <sstream>
+#include <thread>
 
 using namespace openshot;
 
@@ -244,6 +246,53 @@ TEST_CASE( "resample_audio_48000_to_41000", "[libopenshot][framemapper]" )
 
 	// Close mapper
 	map.Close();
+}
+
+TEST_CASE( "concurrent_change_mapping_and_getframe_is_safe", "[libopenshot][framemapper][audio][threading]" )
+{
+	std::stringstream path;
+	path << TEST_MEDIA_PATH << "sintel_trailer-720p.mp4";
+	FFmpegReader reader(path.str());
+
+	FrameMapper map(&reader, Fraction(30, 1), PULLDOWN_NONE, 44100, 2, LAYOUT_STEREO);
+	map.Open();
+
+	std::atomic<bool> failed{false};
+
+	std::thread frame_thread([&]() {
+		try {
+			for (int i = 0; i < 120; ++i) {
+				const int64_t frame_number = (i % 60) + 1;
+				auto frame = map.GetFrame(frame_number);
+				REQUIRE(frame != nullptr);
+				REQUIRE(frame->GetAudioChannelsCount() >= 1);
+				REQUIRE(frame->GetAudioSamplesCount() >= 0);
+			}
+		} catch (...) {
+			failed = true;
+		}
+	});
+
+	std::thread remap_thread([&]() {
+		try {
+			for (int i = 0; i < 60; ++i) {
+				if (i % 2 == 0)
+					map.ChangeMapping(Fraction(30, 1), PULLDOWN_NONE, 44100, 2, LAYOUT_STEREO);
+				else
+					map.ChangeMapping(Fraction(24, 1), PULLDOWN_NONE, 48000, 2, LAYOUT_STEREO);
+			}
+		} catch (...) {
+			failed = true;
+		}
+	});
+
+	frame_thread.join();
+	remap_thread.join();
+
+	CHECK(failed == false);
+
+	map.Close();
+	reader.Close();
 }
 
 TEST_CASE( "resample_audio_mapper", "[libopenshot][framemapper]" ) {


### PR DESCRIPTION
Prevent crash with concurrent change_mapping. We need a mutex for protection when applying mappers to clips.