### PR TITLE
Adding new MaxDecodeSize functionality to ReaderBase (faster inspection / thumbnails)

### DIFF
--- a/bindings/python/openshot.i
+++ b/bindings/python/openshot.i
@@ -41,6 +41,8 @@
 %shared_ptr(juce::AudioBuffer<float>)
 %shared_ptr(openshot::Frame)
 
+%newobject openshot::Clip::CreateReader;
+
 /* Rename operators to avoid wrapping name collisions */
 %rename(__eq__) operator==;
 %rename(__lt__) operator<;

--- a/bindings/ruby/openshot.i
+++ b/bindings/ruby/openshot.i
@@ -41,6 +41,8 @@
 %shared_ptr(juce::AudioBuffer<float>)
 %shared_ptr(openshot::Frame)
 
+%newobject openshot::Clip::CreateReader;
+
 /* Instantiate the required template specializations */
 %template() std::map<std::string, int>;
 %template() std::pair<int, int>;
@@ -221,5 +223,4 @@
 %include "effects/Saturation.h"
 %include "effects/Shift.h"
 %include "effects/Wave.h"
-
 

--- a/src/Clip.cpp
+++ b/src/Clip.cpp
@@ -226,7 +226,20 @@ Clip::Clip(std::string path) : resampler(NULL), reader(NULL), allocated_reader(N
 {
 	// Init all default settings
 	init_settings();
+	reader = CreateReader(path);
 
+	// Update duration and set parent
+	if (reader) {
+		ClipBase::End(reader->info.duration);
+		reader->ParentClip(this);
+		allocated_reader = reader;
+		// Init reader info struct
+		init_reader_settings();
+	}
+}
+
+ReaderBase* Clip::CreateReader(std::string path, bool inspect_reader)
+{
 	// Get file extension (and convert to lower case)
 	std::string ext = get_file_extension(path);
 	std::transform(ext.begin(), ext.end(), ext.begin(), ::tolower);
@@ -237,48 +250,29 @@ Clip::Clip(std::string path) : resampler(NULL), reader(NULL), allocated_reader(N
 	{
 		try
 		{
-			// Open common video format
-			reader = new openshot::FFmpegReader(path);
-
+			return new openshot::FFmpegReader(path, inspect_reader);
 		} catch(...) { }
 	}
 	if (ext=="osp")
 	{
 		try
 		{
-			// Open common video format
-			reader = new openshot::Timeline(path, true);
-
+			return new openshot::Timeline(path, true);
 		} catch(...) { }
 	}
 
-
 	// If no video found, try each reader
-	if (!reader)
+	try
 	{
+		return new openshot::QtImageReader(path, inspect_reader);
+	} catch(...) {
 		try
 		{
-			// Try an image reader
-			reader = new openshot::QtImageReader(path);
-
-		} catch(...) {
-			try
-			{
-				// Try a video reader
-				reader = new openshot::FFmpegReader(path);
-
-			} catch(...) { }
-		}
+			return new openshot::FFmpegReader(path, inspect_reader);
+		} catch(...) { }
 	}
 
-	// Update duration and set parent
-	if (reader) {
-		ClipBase::End(reader->info.duration);
-		reader->ParentClip(this);
-		allocated_reader = reader;
-		// Init reader info struct
-		init_reader_settings();
-	}
+	return NULL;
 }
 
 // Destructor

--- a/src/Clip.h
+++ b/src/Clip.h
@@ -148,7 +148,7 @@ namespace openshot {
 		QTransform get_transform(std::shared_ptr<Frame> frame, int width, int height);
 
 		/// Get file extension
-		std::string get_file_extension(std::string path);
+		static std::string get_file_extension(std::string path);
 
 		/// Get a frame object or create a blank one
 		std::shared_ptr<openshot::Frame> GetOrCreateFrame(int64_t number, bool enable_time=true);
@@ -194,6 +194,10 @@ namespace openshot {
 		/// @brief Constructor with filepath (reader is automatically created... by guessing file extensions)
 		/// @param path The path of a reader (video file, image file, etc...). The correct reader will be used automatically.
 		Clip(std::string path);
+
+		/// Create the most appropriate reader for a media path.
+		/// The caller owns the returned reader pointer.
+		static openshot::ReaderBase* CreateReader(std::string path, bool inspect_reader=true);
 
 		/// @brief Constructor with reader
 		/// @param new_reader The reader to be used by this clip

--- a/src/FFmpegReader.cpp
+++ b/src/FFmpegReader.cpp
@@ -1944,6 +1944,17 @@ void FFmpegReader::ProcessVideoPacket(int64_t requested_frame) {
 		ApplyCropResizeScale(parent, info.width, info.height, max_width, max_height);
 	}
 
+	if (HasMaxDecodeSize()) {
+		QSize bounded_size(max_width, max_height);
+		const QSize max_decode_size(MaxDecodeWidth(), MaxDecodeHeight());
+		if (bounded_size.width() > max_decode_size.width() ||
+			bounded_size.height() > max_decode_size.height()) {
+			bounded_size.scale(max_decode_size, Qt::KeepAspectRatio);
+			max_width = bounded_size.width();
+			max_height = bounded_size.height();
+		}
+	}
+
 	// Determine if image needs to be scaled (for performance reasons)
 	int original_height = src_height;
 	if (max_width != 0 && max_height != 0 && max_width < width && max_height < height) {

--- a/src/QtImageReader.cpp
+++ b/src/QtImageReader.cpp
@@ -251,6 +251,17 @@ QSize QtImageReader::calculate_max_size() {
         ApplyCropResizeScale(parent, info.width, info.height, max_width, max_height);
     }
 
+    if (HasMaxDecodeSize()) {
+        QSize bounded_size(max_width, max_height);
+        const QSize max_decode_size(MaxDecodeWidth(), MaxDecodeHeight());
+        if (bounded_size.width() > max_decode_size.width() ||
+            bounded_size.height() > max_decode_size.height()) {
+            bounded_size.scale(max_decode_size, Qt::KeepAspectRatio);
+            max_width = bounded_size.width();
+            max_height = bounded_size.height();
+        }
+    }
+
     // Return new QSize of the current max size
     return QSize(max_width, max_height);
 }

--- a/src/ReaderBase.cpp
+++ b/src/ReaderBase.cpp
@@ -12,6 +12,7 @@
 
 #include <iostream>
 #include <iomanip>
+#include <algorithm>
 
 #include "ReaderBase.h"
 #include "ClipBase.h"
@@ -54,6 +55,8 @@ ReaderBase::ReaderBase()
 
 	// Init parent clip
 	clip = NULL;
+	max_decode_width = 0;
+	max_decode_height = 0;
 }
 
 // Display file information
@@ -244,4 +247,21 @@ openshot::ClipBase* ReaderBase::ParentClip() {
 /// Set parent clip object of this reader
 void ReaderBase::ParentClip(openshot::ClipBase* new_clip) {
 	clip = new_clip;
+}
+
+void ReaderBase::SetMaxDecodeSize(int width, int height) {
+	max_decode_width = std::max(0, width);
+	max_decode_height = std::max(0, height);
+}
+
+int ReaderBase::MaxDecodeWidth() const {
+	return max_decode_width;
+}
+
+int ReaderBase::MaxDecodeHeight() const {
+	return max_decode_height;
+}
+
+bool ReaderBase::HasMaxDecodeSize() const {
+	return max_decode_width > 0 && max_decode_height > 0;
 }

--- a/src/ReaderBase.h
+++ b/src/ReaderBase.h
@@ -78,6 +78,8 @@ namespace openshot
 		/// Mutex for multiple threads
 		std::recursive_mutex getFrameMutex;
 		openshot::ClipBase* clip; ///< Pointer to the parent clip instance (if any)
+		int max_decode_width; ///< Optional maximum decoded frame width (0 disables the limit)
+		int max_decode_height; ///< Optional maximum decoded frame height (0 disables the limit)
 
 	public:
 
@@ -92,6 +94,18 @@ namespace openshot
 
 		/// Set parent clip object of this reader
 		void ParentClip(openshot::ClipBase* new_clip);
+
+		/// Set an optional maximum decoded frame size. Use 0,0 to disable the limit.
+		void SetMaxDecodeSize(int width, int height);
+
+		/// Return the current maximum decoded frame width (0 when unlimited).
+		int MaxDecodeWidth() const;
+
+		/// Return the current maximum decoded frame height (0 when unlimited).
+		int MaxDecodeHeight() const;
+
+		/// Return true when a maximum decoded frame size is active.
+		bool HasMaxDecodeSize() const;
 
 		/// Close the reader (and any resources it was consuming)
 		virtual void Close() = 0;

--- a/tests/Clip.cpp
+++ b/tests/Clip.cpp
@@ -75,6 +75,29 @@ TEST_CASE( "path string constructor", "[libopenshot][clip]" )
 	CHECK(c1.End() == Approx(4.4).margin(0.00001));
 }
 
+TEST_CASE( "CreateReader_selects_ffmpeg_reader", "[libopenshot][clip]" )
+{
+	std::stringstream path;
+	path << TEST_MEDIA_PATH << "piano.wav";
+
+	std::unique_ptr<ReaderBase> reader(Clip::CreateReader(path.str()));
+	REQUIRE(reader != nullptr);
+	CHECK(reader->Name() == "FFmpegReader");
+	CHECK(reader->info.has_audio == true);
+}
+
+TEST_CASE( "CreateReader_selects_qt_image_reader", "[libopenshot][clip]" )
+{
+	std::stringstream path;
+	path << TEST_MEDIA_PATH << "front.png";
+
+	std::unique_ptr<ReaderBase> reader(Clip::CreateReader(path.str()));
+	REQUIRE(reader != nullptr);
+	CHECK(reader->Name() == "QtImageReader");
+	CHECK(reader->info.has_video == true);
+	CHECK(reader->info.has_single_image == true);
+}
+
 TEST_CASE( "basic getters and setters", "[libopenshot][clip]" )
 {
 	// Create a empty clip

--- a/tests/FFmpegReader.cpp
+++ b/tests/FFmpegReader.cpp
@@ -189,6 +189,25 @@ TEST_CASE( "Check_Video_File", "[libopenshot][ffmpegreader]" )
 	r.Close();
 }
 
+TEST_CASE( "Max_Decode_Size_FFmpegReader", "[libopenshot][ffmpegreader]" )
+{
+	std::stringstream path;
+	path << TEST_MEDIA_PATH << "test.mp4";
+
+	FFmpegReader r(path.str());
+	r.SetMaxDecodeSize(64, 64);
+	r.Open();
+
+	std::shared_ptr<Frame> f = r.GetFrame(1);
+	REQUIRE(f != nullptr);
+	CHECK(f->GetWidth() <= 64);
+	CHECK(f->GetHeight() <= 64);
+	CHECK(f->GetWidth() < r.info.width);
+	CHECK(f->GetHeight() < r.info.height);
+
+	r.Close();
+}
+
 TEST_CASE( "Seek", "[libopenshot][ffmpegreader]" )
 {
 	// Create a reader

--- a/tests/QtImageReader.cpp
+++ b/tests/QtImageReader.cpp
@@ -110,3 +110,27 @@ TEST_CASE( "Duration_And_Length_QtImageReader", "[libopenshot][qtimagereader]" )
 
 	r.Close();
 }
+
+TEST_CASE( "Max_Decode_Size_QtImageReader", "[libopenshot][qtimagereader]" )
+{
+	std::stringstream path;
+	path << TEST_MEDIA_PATH << "front.png";
+
+	QtImageReader r(path.str());
+	r.Open();
+
+	std::shared_ptr<Frame> full = r.GetFrame(1);
+	REQUIRE(full != nullptr);
+	CHECK(full->GetWidth() == r.info.width);
+	CHECK(full->GetHeight() == r.info.height);
+
+	r.SetMaxDecodeSize(64, 64);
+	std::shared_ptr<Frame> limited = r.GetFrame(2);
+	REQUIRE(limited != nullptr);
+	CHECK(limited->GetWidth() <= 64);
+	CHECK(limited->GetHeight() <= 64);
+	CHECK(limited->GetWidth() < full->GetWidth());
+	CHECK(limited->GetHeight() < full->GetHeight());
+
+	r.Close();
+}

--- a/tests/ReaderBase.cpp
+++ b/tests/ReaderBase.cpp
@@ -48,6 +48,17 @@ TEST_CASE( "derived class", "[libopenshot][readerbase]" )
 
 	// Validate the new class
 	CHECK(t1.Name() == "TestReader");
+	CHECK_FALSE(t1.HasMaxDecodeSize());
+	CHECK(t1.MaxDecodeWidth() == 0);
+	CHECK(t1.MaxDecodeHeight() == 0);
+
+	t1.SetMaxDecodeSize(320, 180);
+	CHECK(t1.HasMaxDecodeSize());
+	CHECK(t1.MaxDecodeWidth() == 320);
+	CHECK(t1.MaxDecodeHeight() == 180);
+
+	t1.SetMaxDecodeSize(0, 0);
+	CHECK_FALSE(t1.HasMaxDecodeSize());
 
 	t1.Close();
 	t1.Open();


### PR DESCRIPTION
Adding new MaxDecodeSize functionality to ReaderBase, which allows FFmpegReader and QtImageReaders to inspect and thumbnail clips much faster, and no longer be forced to do that a full resolution. Also refactoring CreateReader() inside Clip() constructor, so it can be called outside of the constructor, for example, when needing to create a reader for inspection or thumbnailing in openshot-qt.