### PR TITLE
Improved Benchmarking + new optimizations

### DIFF
--- a/src/FrameScope.cpp
+++ b/src/FrameScope.cpp
@@ -28,10 +28,6 @@ static int clamp_int(int value, int min_value, int max_value) {
 	return std::max(min_value, std::min(max_value, value));
 }
 
-static int byte_bin(float value) {
-	return clamp_int(static_cast<int>(std::round(value * 255.0f)), 0, 255);
-}
-
 static const std::array<float, 256>& inv_alpha_lut() {
 	static const std::array<float, 256> lut = [] {
 		std::array<float, 256> values{};
@@ -167,9 +163,13 @@ void FrameScope::rebuild_waveform_column_map(int width) {
 		return;
 
 	waveform_column_map.resize(static_cast<size_t>(width));
+	waveform_offset_map.resize(static_cast<size_t>(width));
 	const int waveform_column_limit = waveform_columns - 1;
-	for (int x = 0; x < width; ++x)
-		waveform_column_map[static_cast<size_t>(x)] = clamp_int((x * waveform_columns) / std::max(1, width), 0, waveform_column_limit);
+	for (int x = 0; x < width; ++x) {
+		const int col = clamp_int((x * waveform_columns) / std::max(1, width), 0, waveform_column_limit);
+		waveform_column_map[static_cast<size_t>(x)] = col;
+		waveform_offset_map[static_cast<size_t>(x)] = static_cast<size_t>(col) * static_cast<size_t>(waveform_bins);
+	}
 
 	waveform_column_map_width = width;
 	waveform_column_map_columns = waveform_columns;
@@ -258,7 +258,7 @@ void FrameScope::analyze_video() {
 	ensure_video_buffers();
 
 	double luma_sum = 0.0;
-	double pixel_total = 0.0;
+	int64_t pixel_count = 0;
 	clipped_shadows = 0;
 	clipped_highlights = 0;
 	clipped_red = 0;
@@ -273,9 +273,11 @@ void FrameScope::analyze_video() {
 	const float vectorscope_scale = vectorscope_center;
 
 	for (int y = start_y; y < end_y; ++y) {
-		const unsigned char* row = bits + (static_cast<size_t>(y) * bytes_per_line);
-		for (int x = start_x; x < end_x; ++x) {
-			const unsigned char* pixel = row + (static_cast<size_t>(x) * 4);
+		// Use pointer increment instead of per-pixel index arithmetic (x * 4).
+		const unsigned char* pixel = bits + (static_cast<size_t>(y) * bytes_per_line)
+		                                   + (static_cast<size_t>(start_x) * 4);
+		int roi_column = 0;
+		for (int x = start_x; x < end_x; ++x, ++roi_column, pixel += 4) {
 			const int red   = pixel[0];  // RGBA8888: [R=0, G=1, B=2, A=3]
 			const int green = pixel[1];
 			const int blue  = pixel[2];
@@ -283,33 +285,43 @@ void FrameScope::analyze_video() {
 			if (alpha <= 0)
 				continue;
 
-			float redf = 0.0f;
-			float greenf = 0.0f;
-			float bluef = 0.0f;
+			int red_idx, green_idx, blue_idx;
+			float redf, greenf, bluef;
 			if (alpha == 255) {
-				redf = red * kInv255;
+				redf   = red   * kInv255;
 				greenf = green * kInv255;
-				bluef = blue * kInv255;
+				bluef  = blue  * kInv255;
+				// For fully-opaque pixels the bin index is just the raw byte
+				// value — no float rounding needed (round(byte/255 * 255) == byte).
+				red_idx   = red;
+				green_idx = green;
+				blue_idx  = blue;
 			} else {
-				const float unpremultiply = inv_alpha[alpha];
-				redf = std::min(1.0f, (red * unpremultiply) * kInv255);
-				greenf = std::min(1.0f, (green * unpremultiply) * kInv255);
-				bluef = std::min(1.0f, (blue * unpremultiply) * kInv255);
+				const float inv_a = inv_alpha[alpha];
+				redf   = std::min(1.0f, (red   * inv_a) * kInv255);
+				greenf = std::min(1.0f, (green * inv_a) * kInv255);
+				bluef  = std::min(1.0f, (blue  * inv_a) * kInv255);
+				// All values clamped to [0,1], so val*255+0.5 ∈ [0,255.5] — cast is safe.
+				red_idx   = static_cast<int>(redf   * 255.0f + 0.5f);
+				green_idx = static_cast<int>(greenf * 255.0f + 0.5f);
+				blue_idx  = static_cast<int>(bluef  * 255.0f + 0.5f);
 			}
-			const float luma = (0.299f * redf) + (0.587f * greenf) + (0.114f * bluef);
+			const float luma = 0.299f * redf + 0.587f * greenf + 0.114f * bluef;
+			// luma ∈ [0,1] (weighted sum of [0,1] values), so luma*255+0.5 ∈ [0,255.5].
+			const int luma_idx = static_cast<int>(luma * 255.0f + 0.5f);
 
-			const int luma_idx = byte_bin(luma);
-			const int red_idx = byte_bin(redf);
-			const int green_idx = byte_bin(greenf);
-			const int blue_idx = byte_bin(bluef);
-			const int roi_column = x - start_x;
-			const size_t waveform_offset = static_cast<size_t>(waveform_column_map[static_cast<size_t>(roi_column)]) * static_cast<size_t>(waveform_bins);
+			// Pre-multiplied offset: eliminates a runtime multiply per pixel.
+			const size_t waveform_offset = waveform_offset_map[static_cast<size_t>(roi_column)];
+
 			const float u = -0.14713f * redf - 0.28886f * greenf + 0.43600f * bluef;
-			const float v = 0.61500f * redf - 0.51499f * greenf - 0.10001f * bluef;
+			const float v =  0.61500f * redf - 0.51499f * greenf - 0.10001f * bluef;
 			const float normalized_u = u / kVectorscopeUMax;
 			const float normalized_v = v / kVectorscopeVMax;
-			const int vector_x = clamp_int(static_cast<int>(std::round(vectorscope_center + (normalized_u * vectorscope_scale))), 0, vectorscope_size - 1);
-			const int vector_y = clamp_int(static_cast<int>(std::round(vectorscope_center - (normalized_v * vectorscope_scale))), 0, vectorscope_size - 1);
+			// vectorscope_center + normalized_{u,v} * vectorscope_scale is always in
+			// [0, vectorscope_size-1]; adding 0.5 before truncation equals std::round
+			// for all non-negative values.
+			const int vector_x = clamp_int(static_cast<int>(vectorscope_center + (normalized_u * vectorscope_scale) + 0.5f), 0, vectorscope_size - 1);
+			const int vector_y = clamp_int(static_cast<int>(vectorscope_center - (normalized_v * vectorscope_scale) + 0.5f), 0, vectorscope_size - 1);
 			const size_t vector_offset = (static_cast<size_t>(vector_y) * static_cast<size_t>(vectorscope_size)) + static_cast<size_t>(vector_x);
 
 			histogram_luma[luma_idx]++;
@@ -323,21 +335,16 @@ void FrameScope::analyze_video() {
 			vectorscope[vector_offset]++;
 
 			luma_sum += luma;
-			pixel_total += 1.0;
-			if (luma_idx <= 2)
-				clipped_shadows++;
-			if (luma_idx >= 253)
-				clipped_highlights++;
-			if (red_idx >= 253)
-				clipped_red++;
-			if (green_idx >= 253)
-				clipped_green++;
-			if (blue_idx >= 253)
-				clipped_blue++;
+			++pixel_count;
+			if (luma_idx <= 2)   ++clipped_shadows;
+			if (luma_idx >= 253) ++clipped_highlights;
+			if (red_idx   >= 253) ++clipped_red;
+			if (green_idx >= 253) ++clipped_green;
+			if (blue_idx  >= 253) ++clipped_blue;
 		}
 	}
 
-	avg_luma = pixel_total > 0.0 ? (luma_sum / pixel_total) : 0.0;
+	avg_luma = pixel_count > 0 ? (luma_sum / static_cast<double>(pixel_count)) : 0.0;
 }
 
 void FrameScope::analyze_audio() {

--- a/src/FrameScope.h
+++ b/src/FrameScope.h
@@ -52,6 +52,7 @@ namespace openshot {
 		int video_height;
 		int waveform_bins;
 		std::vector<int> waveform_column_map;
+		std::vector<size_t> waveform_offset_map;  // pre-multiplied: waveform_column_map[x] * waveform_bins
 		int waveform_column_map_width;
 		int waveform_column_map_columns;
 		double avg_luma;

--- a/src/effects/Blur.cpp
+++ b/src/effects/Blur.cpp
@@ -134,59 +134,99 @@ void Blur::ApplyCustomMaskBlend(std::shared_ptr<QImage> original_image, std::sha
 // Credit: http://blog.ivank.net/fastest-gaussian-blur.html (MIT License)
 // Modified to process all four channels in a pixel array
 void Blur::boxBlurH(unsigned char *scl, unsigned char *tcl, int w, int h, int r) {
-	float iarr = 1.0 / (r + r + 1);
+	const float iarr = 1.0f / (r + r + 1);
 
-	#pragma omp parallel for shared (scl, tcl)
+	#pragma omp parallel for shared(scl, tcl)
 	for (int i = 0; i < h; ++i) {
-		for (int ch = 0; ch < 4; ++ch) {
-			int ti = i * w, li = ti, ri = ti + r;
-			int fv = scl[ti * 4 + ch], lv = scl[(ti + w - 1) * 4 + ch], val = (r + 1) * fv;
-			for (int j = 0; j < r; ++j) {
-				val += scl[(ti + j) * 4 + ch];
+		const unsigned char* src = scl + i * w * 4;
+		unsigned char* dst = tcl + i * w * 4;
+
+		const unsigned char* first = src;
+		const unsigned char* last  = src + (w - 1) * 4;
+
+		int val[4];
+		for (int c = 0; c < 4; ++c)
+			val[c] = (r + 1) * first[c];
+		for (int j = 0; j < r; ++j) {
+			const unsigned char* p = src + j * 4;
+			for (int c = 0; c < 4; ++c)
+				val[c] += p[c];
+		}
+
+		int li = 0, ri = r;
+		for (int j = 0; j <= r; ++j, ++ri) {
+			const unsigned char* add = src + ri * 4;
+			unsigned char* out = dst + j * 4;
+			for (int c = 0; c < 4; ++c) {
+				val[c] += add[c] - first[c];
+				out[c] = (unsigned char)(val[c] * iarr + 0.5f);
 			}
-			for (int j = 0; j <= r; ++j) {
-				val += scl[ri++ * 4 + ch] - fv;
-				tcl[ti++ * 4 + ch] = round(val * iarr);
+		}
+		for (int j = r + 1; j < w - r; ++j, ++li, ++ri) {
+			const unsigned char* add = src + ri * 4;
+			const unsigned char* sub = src + li * 4;
+			unsigned char* out = dst + j * 4;
+			for (int c = 0; c < 4; ++c) {
+				val[c] += add[c] - sub[c];
+				out[c] = (unsigned char)(val[c] * iarr + 0.5f);
 			}
-			for (int j = r + 1; j < w - r; ++j) {
-				val += scl[ri++ * 4 + ch] - scl[li++ * 4 + ch];
-				tcl[ti++ * 4 + ch] = round(val * iarr);
-			}
-			for (int j = w - r; j < w; ++j) {
-				val += lv - scl[li++ * 4 + ch];
-				tcl[ti++ * 4 + ch] = round(val * iarr);
+		}
+		for (int j = w - r; j < w; ++j, ++li) {
+			const unsigned char* sub = src + li * 4;
+			unsigned char* out = dst + j * 4;
+			for (int c = 0; c < 4; ++c) {
+				val[c] += last[c] - sub[c];
+				out[c] = (unsigned char)(val[c] * iarr + 0.5f);
 			}
 		}
 	}
 }
 
 void Blur::boxBlurT(unsigned char *scl, unsigned char *tcl, int w, int h, int r) {
-	float iarr = 1.0 / (r + r + 1);
+	const float iarr = 1.0f / (r + r + 1);
+	const int stride = w * 4;
 
-	#pragma omp parallel for shared (scl, tcl)
-	for (int i = 0; i < w; i++) {
-		for (int ch = 0; ch < 4; ++ch) {
-			int ti = i, li = ti, ri = ti + r * w;
-			int fv = scl[ti * 4 + ch], lv = scl[(ti + w * (h - 1)) * 4 + ch], val = (r + 1) * fv;
-			for (int j = 0; j < r; j++) val += scl[(ti + j * w) * 4 + ch];
-			for (int j = 0; j <= r; j++) {
-				val += scl[ri * 4 + ch] - fv;
-				tcl[ti * 4 + ch] = round(val * iarr);
-				ri += w;
-				ti += w;
+	#pragma omp parallel for shared(scl, tcl)
+	for (int i = 0; i < w; ++i) {
+		const unsigned char* col_src = scl + i * 4;
+		unsigned char* col_dst = tcl + i * 4;
+
+		const unsigned char* first = col_src;
+		const unsigned char* last  = col_src + (h - 1) * stride;
+
+		int val[4];
+		for (int c = 0; c < 4; ++c)
+			val[c] = (r + 1) * first[c];
+		for (int j = 0; j < r; ++j) {
+			const unsigned char* p = col_src + j * stride;
+			for (int c = 0; c < 4; ++c)
+				val[c] += p[c];
+		}
+
+		int li = 0, ri = r;
+		for (int j = 0; j <= r; ++j, ++ri) {
+			const unsigned char* add = col_src + ri * stride;
+			unsigned char* out = col_dst + j * stride;
+			for (int c = 0; c < 4; ++c) {
+				val[c] += add[c] - first[c];
+				out[c] = (unsigned char)(val[c] * iarr + 0.5f);
 			}
-			for (int j = r + 1; j < h - r; j++) {
-				val += scl[ri * 4 + ch] - scl[li * 4 + ch];
-				tcl[ti * 4 + ch] = round(val * iarr);
-				li += w;
-				ri += w;
-				ti += w;
+		}
+		for (int j = r + 1; j < h - r; ++j, ++li, ++ri) {
+			const unsigned char* add = col_src + ri * stride;
+			const unsigned char* sub = col_src + li * stride;
+			unsigned char* out = col_dst + j * stride;
+			for (int c = 0; c < 4; ++c) {
+				val[c] += add[c] - sub[c];
+				out[c] = (unsigned char)(val[c] * iarr + 0.5f);
 			}
-			for (int j = h - r; j < h; j++) {
-				val += lv - scl[li * 4 + ch];
-				tcl[ti * 4 + ch] = round(val * iarr);
-				li += w;
-				ti += w;
+		}
+		for (int j = h - r; j < h; ++j, ++li) {
+			const unsigned char* sub = col_src + li * stride;
+			unsigned char* out = col_dst + j * stride;
+			for (int c = 0; c < 4; ++c) {
+				val[c] += last[c] - sub[c];
+				out[c] = (unsigned char)(val[c] * iarr + 0.5f);
 			}
 		}
 	}

--- a/src/effects/ColorGrade.cpp
+++ b/src/effects/ColorGrade.cpp
@@ -29,19 +29,19 @@ struct WheelBiasParams {
 	float blue_delta;
 };
 
-static float clamp01(float value) {
+static inline float clamp01(float value) {
 	return std::max(0.0f, std::min(1.0f, value));
 }
 
-static int clampByte(float value) {
+static inline int clampByte(float value) {
 	if (value <= 0.0f)
 		return 0;
 	if (value >= 255.0f)
 		return 255;
-	return static_cast<int>(std::round(value));
+	return static_cast<int>(value + 0.5f);
 }
 
-static float smooth_midtones(float luma) {
+static inline float smooth_midtones(float luma) {
 	const float centered = std::abs(luma - 0.5f) * 2.0f;
 	return clamp01(1.0f - centered * centered);
 }
@@ -66,7 +66,7 @@ static std::array<float, 256> build_curve_lut(const AnimatedCurve& curve, int64_
 }
 
 static float sample_curve_lut(const std::array<float, 256>& lut, float value) {
-	return lut[clampByte(clamp01(value) * 255.0f)];
+	return lut[static_cast<int>(value * 255.0f + 0.5f)];
 }
 
 static WheelBiasParams build_wheel_bias(const ColorGradeWheelEntry& wheel, int64_t frame_number) {
@@ -234,13 +234,28 @@ std::shared_ptr<openshot::Frame> ColorGrade::GetFrame(std::shared_ptr<openshot::
 	const float vibrance_value = std::max(-1.0f, std::min(1.0f, static_cast<float>(vibrance.GetValue(frame_number))));
 	const float mix_value = std::max(0.0f, std::min(1.0f, static_cast<float>(mix.GetValue(frame_number))));
 	const float inverse_mix = 1.0f - mix_value;
+	const bool wheels_enabled = wheels.IsEnabled(frame_number);
+	if (temperature_value == 0.0f && tint_value == 0.0f &&
+		exposure_value == 0.0f && contrast_value == 0.0f &&
+		highlights_value == 0.0f && shadows_value == 0.0f &&
+		saturation_value == 1.0f && vibrance_value == 0.0f &&
+		mix_value == 1.0f && !wheels_enabled &&
+		curve_all.enabled.GetValue(frame_number) < 0.5 &&
+		curve_red.enabled.GetValue(frame_number) < 0.5 &&
+		curve_green.enabled.GetValue(frame_number) < 0.5 &&
+		curve_blue.enabled.GetValue(frame_number) < 0.5) {
+		if (!lut_path.empty() && lut_intensity.GetValue(frame_number) > 0.0) {
+			sync_lut_effect();
+			return lut_effect.GetFrame(frame, frame_number);
+		}
+		return frame;
+	}
 	const float exposure_gain = std::pow(2.0f, exposure_value);
 	const float contrast_factor = std::max(0.0f, 1.0f + contrast_value);
 	const std::array<float, 256> curve_all_lut = build_curve_lut(curve_all, frame_number);
 	const std::array<float, 256> curve_red_lut = build_curve_lut(curve_red, frame_number);
 	const std::array<float, 256> curve_green_lut = build_curve_lut(curve_green, frame_number);
 	const std::array<float, 256> curve_blue_lut = build_curve_lut(curve_blue, frame_number);
-	const bool wheels_enabled = wheels.IsEnabled(frame_number);
 	const WheelBiasParams global_wheel = wheels_enabled ? build_wheel_bias(wheels.global, frame_number) : WheelBiasParams{0.0f, 0.0f, 0.0f};
 	const WheelBiasParams shadows_wheel = wheels_enabled ? build_wheel_bias(wheels.shadows, frame_number) : WheelBiasParams{0.0f, 0.0f, 0.0f};
 	const WheelBiasParams midtones_wheel = wheels_enabled ? build_wheel_bias(wheels.midtones, frame_number) : WheelBiasParams{0.0f, 0.0f, 0.0f};

--- a/src/effects/Sharpen.cpp
+++ b/src/effects/Sharpen.cpp
@@ -123,58 +123,52 @@ static void blur_axis(const QImage& src, QImage& dst, int r, bool vertical)
   const uchar* in  = src.bits();
   uchar*       out = dst.bits();
   int window = 2*r + 1;
+  const float inv_w = 1.0f / window;
 
   if (!vertical) {
     #pragma omp parallel for
     for (int y = 0; y < H; ++y) {
       const uchar* rowIn  = in  + y*bpl;
       uchar*       rowOut = out + y*bpl;
-      double sB = rowIn[0]*(r+1), sG = rowIn[1]*(r+1),
-             sR = rowIn[2]*(r+1), sA = rowIn[3]*(r+1);
+      int sB = rowIn[0]*(r+1), sG = rowIn[1]*(r+1), sR = rowIn[2]*(r+1);
       for (int x = 1; x <= r; ++x) {
         const uchar* p = rowIn + std::min(x, W-1)*4;
-        sB += p[0]; sG += p[1]; sR += p[2]; sA += p[3];
+        sB += p[0]; sG += p[1]; sR += p[2];
       }
       for (int x = 0; x < W; ++x) {
         uchar* o = rowOut + x*4;
-        o[0] = uchar(sB / window + 0.5);
-        o[1] = uchar(sG / window + 0.5);
-        o[2] = uchar(sR / window + 0.5);
-        o[3] = uchar(sA / window + 0.5);
+        o[0] = uchar(sB * inv_w + 0.5f);
+        o[1] = uchar(sG * inv_w + 0.5f);
+        o[2] = uchar(sR * inv_w + 0.5f);
 
         const uchar* addP = rowIn + std::min(x+r+1, W-1)*4;
         const uchar* subP = rowIn + std::max(x-r,     0)*4;
         sB += addP[0] - subP[0];
         sG += addP[1] - subP[1];
         sR += addP[2] - subP[2];
-        sA += addP[3] - subP[3];
       }
     }
   }
   else {
     #pragma omp parallel for
     for (int x = 0; x < W; ++x) {
-      double sB = 0, sG = 0, sR = 0, sA = 0;
       const uchar* p0 = in + x*4;
-      sB = p0[0]*(r+1); sG = p0[1]*(r+1);
-      sR = p0[2]*(r+1); sA = p0[3]*(r+1);
+      int sB = p0[0]*(r+1), sG = p0[1]*(r+1), sR = p0[2]*(r+1);
       for (int y = 1; y <= r; ++y) {
         const uchar* p = in + std::min(y, H-1)*bpl + x*4;
-        sB += p[0]; sG += p[1]; sR += p[2]; sA += p[3];
+        sB += p[0]; sG += p[1]; sR += p[2];
       }
       for (int y = 0; y < H; ++y) {
         uchar* o = out + y*bpl + x*4;
-        o[0] = uchar(sB / window + 0.5);
-        o[1] = uchar(sG / window + 0.5);
-        o[2] = uchar(sR / window + 0.5);
-        o[3] = uchar(sA / window + 0.5);
+        o[0] = uchar(sB * inv_w + 0.5f);
+        o[1] = uchar(sG * inv_w + 0.5f);
+        o[2] = uchar(sR * inv_w + 0.5f);
 
         const uchar* addP = in + std::min(y+r+1, H-1)*bpl + x*4;
         const uchar* subP = in + std::max(y-r,     0)*bpl + x*4;
         sB += addP[0] - subP[0];
         sG += addP[1] - subP[1];
         sR += addP[2] - subP[2];
-        sA += addP[3] - subP[3];
       }
     }
   }
@@ -199,12 +193,12 @@ static void box_blur(const QImage& src, QImage& dst, double rf, bool vertical)
     const uchar* pa = a.bits();
     const uchar* pb = b.bits();
     uchar*       pd = dst.bits();
+    const float ff = float(f);
+    const float ff1 = 1.0f - ff;
     #pragma omp parallel for
     for (int i = 0; i < pixels; ++i) {
-      for (int c = 0; c < 4; ++c) {
-        pd[i*4+c] = uchar((1.0 - f) * pa[i*4+c]
-                        + f         * pb[i*4+c]
-                        + 0.5);
+      for (int c = 0; c < 3; ++c) {
+        pd[i*4+c] = uchar(ff1 * pa[i*4+c] + ff * pb[i*4+c] + 0.5f);
       }
     }
   }
@@ -251,6 +245,9 @@ std::shared_ptr<Frame> Sharpen::GetFrame(
   double rpx   = radius.GetValue(frame_number);    // px
   double thrUI = threshold.GetValue(frame_number); // 0–1
 
+  if (amt == 0.0 || rpx <= 0.0)
+    return frame;
+
   // Sigma scaled against 720p reference
   double sigma = std::max(0.1, rpx * H / 720.0);
 
@@ -264,23 +261,25 @@ std::shared_ptr<Frame> Sharpen::GetFrame(
   uchar* sBits = img->bits();
   uchar* bBits = blur.bits();
 
-  double maxDY = 0.0;
-  #pragma omp parallel for reduction(max:maxDY)
-  for (int y = 0; y < H; ++y) {
-    uchar* sRow = sBits + y * bplS;
-    uchar* bRow = bBits + y * bplB;
-    for (int x = 0; x < W; ++x) {
-      double dB = double(sRow[x*4+0]) - double(bRow[x*4+0]);
-      double dG = double(sRow[x*4+1]) - double(bRow[x*4+1]);
-      double dR = double(sRow[x*4+2]) - double(bRow[x*4+2]);
-      double dY = std::abs(0.114*dB + 0.587*dG + 0.299*dR);
-      maxDY = std::max(maxDY, dY);
+  float maxDY = 0.0f;
+  if (thrUI > 0.0) {
+    #pragma omp parallel for reduction(max:maxDY)
+    for (int y = 0; y < H; ++y) {
+      uchar* sRow = sBits + y * bplS;
+      uchar* bRow = bBits + y * bplB;
+      for (int x = 0; x < W; ++x) {
+        float dB = float(sRow[x*4+0]) - float(bRow[x*4+0]);
+        float dG = float(sRow[x*4+1]) - float(bRow[x*4+1]);
+        float dR = float(sRow[x*4+2]) - float(bRow[x*4+2]);
+        float dY = std::abs(0.114f*dB + 0.587f*dG + 0.299f*dR);
+        maxDY = std::max(maxDY, dY);
+      }
     }
   }
 
   // Compute actual threshold in luma units
-  double thr = thrUI * maxDY;
-
+  const float thr = float(thrUI) * maxDY;
+  const float famt = float(amt);
   // Process pixels
   #pragma omp parallel for
   for (int y = 0; y < H; ++y) {
@@ -291,80 +290,74 @@ std::shared_ptr<Frame> Sharpen::GetFrame(
       uchar* bp = bRow + x*4;
 
       // Detail per channel
-      double dB = double(sp[0]) - double(bp[0]);
-      double dG = double(sp[1]) - double(bp[1]);
-      double dR = double(sp[2]) - double(bp[2]);
-      double dY = 0.114*dB + 0.587*dG + 0.299*dR;
+      float dB = float(sp[0]) - float(bp[0]);
+      float dG = float(sp[1]) - float(bp[1]);
+      float dR = float(sp[2]) - float(bp[2]);
+      float dY = 0.114f*dB + 0.587f*dG + 0.299f*dR;
 
       // Skip if below adaptive threshold
       if (std::abs(dY) < thr)
         continue;
 
       // Halo limiter
-      auto halo = [](double d) {
-        return (255.0 - std::abs(d)) / 255.0;
+      auto halo = [](float d) {
+        return (255.0f - std::abs(d)) * (1.0f / 255.0f);
       };
 
-      double outC[3];
+      float outC[3];
 
       if (mode == 1) {
-        // HighPass: base = blurred image
-        // detail = original – blurred
-        // no halo limiter
-
-        // precompute normalized luma weights
-        const double wB = 0.114, wG = 0.587, wR = 0.299;
+        // HighPass: base = blurred image, detail = original – blurred, no halo limiter
+        const float wB = 0.114f, wG = 0.587f, wR = 0.299f;
 
         if (channel == 1) {
           // Luma only: add back luma detail weighted per channel
-          double lumaInc = amt * dY;
+          float lumaInc = famt * dY;
           outC[0] = bp[0] + lumaInc * wB;
           outC[1] = bp[1] + lumaInc * wG;
           outC[2] = bp[2] + lumaInc * wR;
         }
         else if (channel == 2) {
           // Chroma only: subtract luma from detail, add chroma back
-          double lumaDetail = dY;
-          double chromaB    = dB - lumaDetail * wB;
-          double chromaG    = dG - lumaDetail * wG;
-          double chromaR    = dR - lumaDetail * wR;
-          outC[0] = bp[0] + amt * chromaB;
-          outC[1] = bp[1] + amt * chromaG;
-          outC[2] = bp[2] + amt * chromaR;
+          float chromaB = dB - dY * wB;
+          float chromaG = dG - dY * wG;
+          float chromaR = dR - dY * wR;
+          outC[0] = bp[0] + famt * chromaB;
+          outC[1] = bp[1] + famt * chromaG;
+          outC[2] = bp[2] + famt * chromaR;
         }
         else {
           // All channels: add full per-channel detail
-          outC[0] = bp[0] + amt * dB;
-          outC[1] = bp[1] + amt * dG;
-          outC[2] = bp[2] + amt * dR;
+          outC[0] = bp[0] + famt * dB;
+          outC[1] = bp[1] + famt * dG;
+          outC[2] = bp[2] + famt * dR;
         }
       }
       else {
         // Unsharp-Mask: base = original + amt * detail * halo(detail)
         if (channel == 1) {
           // Luma only
-          double inc = amt * dY * halo(dY);
+          float inc = famt * dY * halo(dY);
           for (int c = 0; c < 3; ++c)
             outC[c] = sp[c] + inc;
         }
         else if (channel == 2) {
           // Chroma only
-          double l = dY;
-          double chroma[3] = { dB - l, dG - l, dR - l };
+          float chroma[3] = { dB - dY, dG - dY, dR - dY };
           for (int c = 0; c < 3; ++c)
-            outC[c] = sp[c] + amt * chroma[c] * halo(chroma[c]);
+            outC[c] = sp[c] + famt * chroma[c] * halo(chroma[c]);
         }
         else {
           // All channels
-          outC[0] = sp[0] + amt * dB * halo(dB);
-          outC[1] = sp[1] + amt * dG * halo(dG);
-          outC[2] = sp[2] + amt * dR * halo(dR);
+          outC[0] = sp[0] + famt * dB * halo(dB);
+          outC[1] = sp[1] + famt * dG * halo(dG);
+          outC[2] = sp[2] + famt * dR * halo(dR);
         }
       }
 
       // Write back clamped
       for (int c = 0; c < 3; ++c) {
-        sp[c] = uchar(std::clamp(outC[c], 0.0, 255.0) + 0.5);
+        sp[c] = uchar(std::clamp(outC[c], 0.0f, 255.0f) + 0.5f);
       }
     }
   }

--- a/tests/Benchmark.cpp
+++ b/tests/Benchmark.cpp
@@ -8,12 +8,20 @@
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
+#include <algorithm>
 #include <chrono>
 #include <cmath>
 #include <functional>
+#include <iomanip>
 #include <iostream>
 #include <string>
+#include <unistd.h>
+#include <utility>
 #include <vector>
+
+extern "C" {
+#include <libavutil/log.h>
+}
 
 #include "BenchmarkOptions.h"
 #include "Clip.h"
@@ -30,12 +38,48 @@
 #include "ReaderBase.h"
 #include "Settings.h"
 #include "Timeline.h"
-#include "effects/Brightness.h"
-#include "effects/ChromaKey.h"
-#include "effects/Crop.h"
-#include "effects/AudioVisualization.h"
-#include "effects/Mask.h"
-#include "effects/Saturation.h"
+// Each effect is guarded so the benchmark compiles against older libopenshot
+// builds that predate a given effect — missing effects are silently skipped.
+#if __has_include("effects/AudioVisualization.h")
+#  include "effects/AudioVisualization.h"
+#  define OPENSHOT_HAS_AUDIOVISUALIZATION
+#endif
+#if __has_include("effects/Brightness.h")
+#  include "effects/Brightness.h"
+#  define OPENSHOT_HAS_BRIGHTNESS
+#endif
+#if __has_include("effects/ChromaKey.h")
+#  include "effects/ChromaKey.h"
+#  define OPENSHOT_HAS_CHROMAKEY
+#endif
+#if __has_include("effects/ColorGrade.h")
+#  include "effects/ColorGrade.h"
+#  define OPENSHOT_HAS_COLORGRADE
+#endif
+#if __has_include("effects/Crop.h")
+#  include "effects/Crop.h"
+#  define OPENSHOT_HAS_CROP
+#endif
+#if __has_include("effects/FilmGrain.h")
+#  include "effects/FilmGrain.h"
+#  define OPENSHOT_HAS_FILMGRAIN
+#endif
+#if __has_include("effects/Glow.h")
+#  include "effects/Glow.h"
+#  define OPENSHOT_HAS_GLOW
+#endif
+#if __has_include("effects/Mask.h")
+#  include "effects/Mask.h"
+#  define OPENSHOT_HAS_MASK
+#endif
+#if __has_include("effects/Saturation.h")
+#  include "effects/Saturation.h"
+#  define OPENSHOT_HAS_SATURATION
+#endif
+#if __has_include("effects/Shadow.h")
+#  include "effects/Shadow.h"
+#  define OPENSHOT_HAS_SHADOW
+#endif
 
 #include <QImage>
 
@@ -43,358 +87,481 @@ using namespace openshot;
 using namespace std;
 
 using Clock = chrono::steady_clock;
-using TrialFunc = function<void()>;
+using TrialResult = pair<int64_t, double>;  // (frames, elapsed_seconds)
+using TrialFunc = function<TrialResult()>;
 using Trial = pair<string, TrialFunc>;
 
-template <typename Func> double time_trial(const string &name, Func func) {
-	auto start = Clock::now();
-	func();
-	auto elapsed =
-			chrono::duration_cast<chrono::milliseconds>(Clock::now() - start).count();
-	cout << name << "," << elapsed << "\n";
-	return static_cast<double>(elapsed);
+// Frame 241 = 10 seconds into a 24 fps source (frames are 1-based: 24*10 + 1).
+// The seek to this frame is included in the timed window — it's real cost OpenShot pays.
+constexpr int64_t START_FRAME = 241;
+constexpr int64_t BENCH_FRAMES = 120;
+
+struct BenchmarkRecord {
+    string name;
+    double fps;
+};
+
+// Each trial is run this many times; the median is reported.
+// The first (cold-cache) run is naturally the low outlier and is discarded by the median,
+// giving stable warm-state numbers without an explicit warmup pass.
+constexpr int TRIAL_RUNS = 3;
+
+static const char* spinner_frames[] = {"⠋","⠙","⠸","⠴","⠦","⠇"};
+static int spinner_index = 0;
+
+static BenchmarkRecord run_trial(const string& name, TrialFunc func) {
+    vector<double> samples;
+    samples.reserve(TRIAL_RUNS);
+    for (int run = 1; run <= TRIAL_RUNS; ++run) {
+        if (isatty(STDOUT_FILENO)) {
+            cout << "\r" << spinner_frames[spinner_index % 6] << " "
+                 << left << setw(44) << (name + "...")
+                 << " [" << run << "/" << TRIAL_RUNS << "]" << flush;
+            spinner_index++;
+        }
+        TrialResult r = func();
+        samples.push_back(r.first / r.second);
+    }
+    sort(samples.begin(), samples.end());
+    return {name, samples[TRIAL_RUNS / 2]};  // median
 }
 
-void read_forward_backward(ReaderBase &reader) {
-	int64_t len = reader.info.video_length;
-	for (int64_t i = 1; i <= len; ++i)
-		reader.GetFrame(i);
-	for (int64_t i = len; i >= 1; --i)
-		reader.GetFrame(i);
+static void print_results(const vector<BenchmarkRecord>& records) {
+    if (records.empty()) return;
+
+    double max_fps = 0.0;
+    size_t max_name = 5;  // at least "Trial"
+    for (const auto& rec : records) {
+        max_fps = std::max(max_fps, rec.fps);
+        max_name = std::max(max_name, rec.name.size());
+    }
+
+    const int bar_width = 24;
+    const double sqrt_max = std::sqrt(max_fps);
+
+    auto make_bar = [&](double fps) {
+        int n = static_cast<int>(std::sqrt(fps) / sqrt_max * bar_width + 0.5);
+        string bar;
+        bar.reserve(static_cast<size_t>(n) * 3);
+        for (int i = 0; i < n; ++i)
+            bar += "\xe2\x96\x88";  // UTF-8 █
+        return bar;
+    };
+
+    cout << "| " << left  << setw(static_cast<int>(max_name)) << "Trial"
+         << " | "  << right << setw(8) << "FPS"
+         << " | Chart |\n";
+    cout << "|:" << string(max_name, '-')
+         << "-|" << string(8, '-') << ":|:"
+         << string(bar_width, '-') << "-|\n";
+    for (const auto& rec : records) {
+        cout << "| " << left  << setw(static_cast<int>(max_name)) << rec.name
+             << " | " << fixed << setprecision(1) << right << setw(8) << rec.fps
+             << " | " << make_bar(rec.fps) << " |\n";
+    }
 }
 
-std::shared_ptr<Frame> make_audio_visualization_frame(int64_t frame_number) {
-	const int width = 1280;
-	const int height = 720;
-	const int sample_rate = 48000;
-	const int samples = 1600;
-	constexpr double pi = 3.14159265358979323846;
-
-	auto frame = std::make_shared<Frame>(frame_number, width, height, "#00000000", samples, 2);
-	auto image = std::make_shared<QImage>(width, height, QImage::Format_RGBA8888_Premultiplied);
-	image->fill(Qt::transparent);
-	frame->AddImage(image);
-	frame->ResizeAudio(2, samples, sample_rate, LAYOUT_STEREO);
-
-	std::vector<float> left(samples);
-	std::vector<float> right(samples);
-	for (int i = 0; i < samples; ++i) {
-		const double t = static_cast<double>(i + frame_number * samples) / sample_rate;
-		left[i] = static_cast<float>((std::sin(2.0 * pi * 110.0 * t) * 0.22) +
-									 (std::sin(2.0 * pi * 440.0 * t) * 0.48) +
-									 (std::sin(2.0 * pi * 1760.0 * t) * 0.18));
-		right[i] = static_cast<float>((std::sin(2.0 * pi * 165.0 * t) * 0.18) +
-									  (std::sin(2.0 * pi * 660.0 * t) * 0.42) +
-									  (std::sin(2.0 * pi * 2640.0 * t) * 0.16));
-	}
-	frame->AddAudio(true, 0, 0, left.data(), samples, 1.0f);
-	frame->AddAudio(true, 1, 0, right.data(), samples, 1.0f);
-	return frame;
+// Time a forward sequential read of BENCH_FRAMES frames starting at START_FRAME.
+// The seek to START_FRAME is included — it reflects real scrubbing cost.
+static TrialResult timed_read(ReaderBase& r) {
+    auto t0 = Clock::now();
+    for (int64_t i = 0; i < BENCH_FRAMES; ++i)
+        r.GetFrame(START_FRAME + i);
+    return {BENCH_FRAMES, chrono::duration<double>(Clock::now() - t0).count()};
 }
 
-void run_audio_visualization_mode(int mode, int64_t frames) {
-	AudioVisualization effect;
-	effect.visualization_type = mode;
-	effect.background = AUDIO_VISUALIZATION_BACKGROUND_TRANSPARENT;
-	effect.detail = Keyframe(0.75);
-	effect.glow = Keyframe(0.25);
-	effect.intensity = Keyframe(1.25);
+#ifdef OPENSHOT_HAS_AUDIOVISUALIZATION
+static std::shared_ptr<Frame> make_audio_visualization_frame(int64_t frame_number) {
+    const int width = 1280;
+    const int height = 720;
+    const int sample_rate = 48000;
+    const int samples = 1600;
+    constexpr double pi = 3.14159265358979323846;
 
-	for (int64_t frame_number = 1; frame_number <= frames; ++frame_number)
-		effect.GetFrame(make_audio_visualization_frame(frame_number), frame_number);
+    auto frame = std::make_shared<Frame>(frame_number, width, height, "#00000000", samples, 2);
+    auto image = std::make_shared<QImage>(width, height, QImage::Format_RGBA8888_Premultiplied);
+    image->fill(Qt::transparent);
+    frame->AddImage(image);
+    frame->ResizeAudio(2, samples, sample_rate, LAYOUT_STEREO);
+
+    std::vector<float> left(samples);
+    std::vector<float> right(samples);
+    for (int i = 0; i < samples; ++i) {
+        const double t = static_cast<double>(i + frame_number * samples) / sample_rate;
+        left[i] = static_cast<float>((std::sin(2.0 * pi * 110.0 * t) * 0.22) +
+                                     (std::sin(2.0 * pi * 440.0 * t) * 0.48) +
+                                     (std::sin(2.0 * pi * 1760.0 * t) * 0.18));
+        right[i] = static_cast<float>((std::sin(2.0 * pi * 165.0 * t) * 0.18) +
+                                      (std::sin(2.0 * pi * 660.0 * t) * 0.42) +
+                                      (std::sin(2.0 * pi * 2640.0 * t) * 0.16));
+    }
+    frame->AddAudio(true, 0, 0, left.data(), samples, 1.0f);
+    frame->AddAudio(true, 1, 0, right.data(), samples, 1.0f);
+    return frame;
 }
+
+static void run_audio_visualization_mode(int mode, int64_t start_frame, int64_t frames) {
+    AudioVisualization effect;
+    effect.visualization_type = mode;
+    effect.background = AUDIO_VISUALIZATION_BACKGROUND_TRANSPARENT;
+    effect.detail = Keyframe(0.75);
+    effect.glow = Keyframe(0.25);
+    effect.intensity = Keyframe(1.25);
+
+    for (int64_t i = 0; i < frames; ++i) {
+        int64_t fn = start_frame + i;
+        effect.GetFrame(make_audio_visualization_frame(fn), fn);
+    }
+}
+
+static TrialResult timed_audio_viz(int mode) {
+    auto t0 = Clock::now();
+    run_audio_visualization_mode(mode, START_FRAME, BENCH_FRAMES);
+    return {BENCH_FRAMES, chrono::duration<double>(Clock::now() - t0).count()};
+}
+#endif // OPENSHOT_HAS_AUDIOVISUALIZATION
 
 int main(int argc, char* argv[]) {
-	const string base = TEST_MEDIA_PATH;
-	const string video = base + "sintel_trailer-720p.mp4";
-	const string mask_img = base + "mask.png";
-	const string overlay = base + "front3.png";
-	benchmark::BenchmarkOptions options;
-	const int64_t chroma_bench_frames = 500;
+    const string base = TEST_MEDIA_PATH;
+    const string video = base + "sintel_trailer-720p.mp4";
+    const string overlay = base + "front3.png";
+    benchmark::BenchmarkOptions options;
 
-	try {
-		vector<string> args;
-		args.reserve(std::max(0, argc - 1));
-		for (int i = 1; i < argc; ++i)
-			args.emplace_back(argv[i]);
-		options = benchmark::ParseBenchmarkOptions(args);
-	} catch (const std::exception& e) {
-		cerr << e.what() << "\n";
-		cerr << benchmark::BenchmarkUsage() << "\n";
-		return 1;
-	}
+    try {
+        vector<string> args;
+        args.reserve(std::max(0, argc - 1));
+        for (int i = 1; i < argc; ++i)
+            args.emplace_back(argv[i]);
+        options = benchmark::ParseBenchmarkOptions(args);
+    } catch (const std::exception& e) {
+        cerr << e.what() << "\n";
+        cerr << benchmark::BenchmarkUsage() << "\n";
+        return 1;
+    }
 
-	if (options.show_help) {
-		cout << benchmark::BenchmarkUsage() << "\n";
-		return 0;
-	}
+    if (options.show_help) {
+        cout << benchmark::BenchmarkUsage() << "\n";
+        return 0;
+    }
 
-	// Route benchmark thread settings through libopenshot's Settings singleton,
-	// matching how an application should configure the library before opening readers.
-	Settings *settings = Settings::Instance();
-	if (options.omp_threads > 0) {
-		settings->OMP_THREADS = options.omp_threads;
-		settings->ApplyOpenMPSettings();
-	}
-	if (options.ff_threads > 0) {
-		settings->FF_THREADS = options.ff_threads;
-	}
+    // Suppress FFmpeg/codec log output so it doesn't interleave with results.
+    av_log_set_level(AV_LOG_QUIET);
 
-	vector<Trial> trials;
-	trials.reserve(10);
+    Settings *settings = Settings::Instance();
+    if (options.omp_threads > 0) {
+        settings->OMP_THREADS = options.omp_threads;
+        settings->ApplyOpenMPSettings();
+    }
+    if (options.ff_threads > 0) {
+        settings->FF_THREADS = options.ff_threads;
+    }
 
-	trials.emplace_back("FFmpegReader", [&]() {
-		FFmpegReader r(video);
-		r.Open();
-		read_forward_backward(r);
-		r.Close();
-	});
+    vector<Trial> trials;
+    trials.reserve(25);
 
-	trials.emplace_back("FFmpegWriter", [&]() {
-		FFmpegReader r(video);
-		r.Open();
-		FFmpegWriter w("benchmark_output.mp4");
-		w.SetAudioOptions("aac", r.info.sample_rate, 192000);
-		w.SetVideoOptions("libx264", r.info.width, r.info.height, r.info.fps,
-											5000000);
-		w.Open();
-		for (int64_t i = 1; i <= r.info.video_length; ++i)
-			w.WriteFrame(r.GetFrame(i));
-		w.Close();
-		r.Close();
-	});
+    trials.emplace_back("FFmpegReader", [&]() -> TrialResult {
+        FFmpegReader r(video);
+        r.Open();
+        TrialResult result = timed_read(r);
+        r.Close();
+        return result;
+    });
 
-	trials.emplace_back("FrameMapper", [&]() {
-		vector<Fraction> rates = {Fraction(24, 1), Fraction(30, 1), Fraction(60, 1),
-															Fraction(30000, 1001), Fraction(60000, 1001)};
-		for (auto &fps : rates) {
-			FFmpegReader r(video);
-			r.Open();
-			FrameMapper map(&r, fps, PULLDOWN_NONE, r.info.sample_rate,
-											r.info.channels, r.info.channel_layout);
-			map.Open();
-			for (int64_t i = 1; i <= map.info.video_length; ++i)
-				map.GetFrame(i);
-			map.Close();
-			r.Close();
-		}
-	});
+    trials.emplace_back("FFmpegWriter", [&]() -> TrialResult {
+        FFmpegReader r(video);
+        r.Open();
+        FFmpegWriter w("benchmark_output.mp4");
+        w.SetAudioOptions("aac", r.info.sample_rate, 192000);
+        w.SetVideoOptions("libx264", r.info.width, r.info.height, r.info.fps, 5000000);
+        w.Open();
+        auto t0 = Clock::now();
+        for (int64_t i = 0; i < BENCH_FRAMES; ++i)
+            w.WriteFrame(r.GetFrame(START_FRAME + i));
+        double elapsed = chrono::duration<double>(Clock::now() - t0).count();
+        w.Close();
+        r.Close();
+        return {BENCH_FRAMES, elapsed};
+    });
 
-	trials.emplace_back("Clip", [&]() {
-		Clip c(video);
-		c.Open();
-		read_forward_backward(c);
-		c.Close();
-	});
+    trials.emplace_back("FrameMapper", [&]() -> TrialResult {
+        FFmpegReader r(video);
+        r.Open();
+        FrameMapper map(&r, Fraction(30000, 1001), PULLDOWN_NONE, r.info.sample_rate,
+                        r.info.channels, r.info.channel_layout);
+        map.Open();
+        TrialResult result = timed_read(map);
+        map.Close();
+        r.Close();
+        return result;
+    });
 
-	trials.emplace_back("Timeline", [&]() {
-		Timeline t(1920, 1080, Fraction(24, 1), 44100, 2, LAYOUT_STEREO);
-		Clip video_clip(video);
-		video_clip.Layer(0);
-		video_clip.Start(0.0);
-		video_clip.End(video_clip.Reader()->info.duration);
-		video_clip.Open();
-		Clip overlay1(overlay);
-		overlay1.Layer(1);
-		overlay1.Start(0.0);
-		overlay1.End(video_clip.Reader()->info.duration);
-		overlay1.Open();
-		Clip overlay2(overlay);
-		overlay2.Layer(2);
-		overlay2.Start(0.0);
-		overlay2.End(video_clip.Reader()->info.duration);
-		overlay2.Open();
-		t.AddClip(&video_clip);
-		t.AddClip(&overlay1);
-		t.AddClip(&overlay2);
-		t.Open();
-		t.info.video_length = t.GetMaxFrame();
-		read_forward_backward(t);
-		t.Close();
-	});
+    trials.emplace_back("Clip", [&]() -> TrialResult {
+        Clip c(video);
+        c.Open();
+        TrialResult result = timed_read(c);
+        c.Close();
+        return result;
+    });
 
-	trials.emplace_back("Timeline (with transforms)", [&]() {
-		Timeline t(1920, 1080, Fraction(24, 1), 44100, 2, LAYOUT_STEREO);
-		Clip video_clip(video);
-		int64_t last = video_clip.Reader()->info.video_length;
-		video_clip.Layer(0);
-		video_clip.Start(0.0);
-		video_clip.End(video_clip.Reader()->info.duration);
-		video_clip.alpha.AddPoint(1, 1.0);
+    trials.emplace_back("Timeline", [&]() -> TrialResult {
+        Timeline t(1280, 720, Fraction(30000, 1001), 44100, 2, LAYOUT_STEREO);
+        Clip video_clip(video);
+        video_clip.Layer(0);
+        video_clip.Start(0.0);
+        video_clip.End(video_clip.Reader()->info.duration);
+        video_clip.Open();
+        Clip overlay1(overlay);
+        overlay1.Layer(1);
+        overlay1.Start(0.0);
+        overlay1.End(video_clip.Reader()->info.duration);
+        overlay1.Open();
+        Clip overlay2(overlay);
+        overlay2.Layer(2);
+        overlay2.Start(0.0);
+        overlay2.End(video_clip.Reader()->info.duration);
+        overlay2.Open();
+        t.AddClip(&video_clip);
+        t.AddClip(&overlay1);
+        t.AddClip(&overlay2);
+        t.Open();
+        t.info.video_length = t.GetMaxFrame();
+        TrialResult result = timed_read(t);
+        t.Close();
+        return result;
+    });
+
+    trials.emplace_back("Timeline (with transforms)", [&]() -> TrialResult {
+        Timeline t(1280, 720, Fraction(30000, 1001), 44100, 2, LAYOUT_STEREO);
+        Clip video_clip(video);
+        int64_t last = video_clip.Reader()->info.video_length;
+        video_clip.Layer(0);
+        video_clip.Start(0.0);
+        video_clip.End(video_clip.Reader()->info.duration);
+        video_clip.alpha.AddPoint(1, 1.0);
         video_clip.alpha.AddPoint(last, 0.0);
-		video_clip.Open();
-		Clip overlay1(overlay);
-		overlay1.Layer(1);
-		overlay1.Start(0.0);
-		overlay1.End(video_clip.Reader()->info.duration);
-		overlay1.Open();
-		overlay1.scale_x.AddPoint(1, 1.0);
-		overlay1.scale_x.AddPoint(last, 0.25);
-		overlay1.scale_y.AddPoint(1, 1.0);
-		overlay1.scale_y.AddPoint(last, 0.25);
-		Clip overlay2(overlay);
-		overlay2.Layer(2);
-		overlay2.Start(0.0);
-		overlay2.End(video_clip.Reader()->info.duration);
-		overlay2.Open();
-		overlay2.rotation.AddPoint(1, 90.0);
-		t.AddClip(&video_clip);
-		t.AddClip(&overlay1);
-		t.AddClip(&overlay2);
-		t.Open();
-		t.info.video_length = t.GetMaxFrame();
-		read_forward_backward(t);
-		t.Close();
-	});
+        video_clip.Open();
+        Clip overlay1(overlay);
+        overlay1.Layer(1);
+        overlay1.Start(0.0);
+        overlay1.End(video_clip.Reader()->info.duration);
+        overlay1.Open();
+        overlay1.scale_x.AddPoint(1, 1.0);
+        overlay1.scale_x.AddPoint(last, 0.25);
+        overlay1.scale_y.AddPoint(1, 1.0);
+        overlay1.scale_y.AddPoint(last, 0.25);
+        Clip overlay2(overlay);
+        overlay2.Layer(2);
+        overlay2.Start(0.0);
+        overlay2.End(video_clip.Reader()->info.duration);
+        overlay2.Open();
+        overlay2.rotation.AddPoint(1, 90.0);
+        t.AddClip(&video_clip);
+        t.AddClip(&overlay1);
+        t.AddClip(&overlay2);
+        t.Open();
+        t.info.video_length = t.GetMaxFrame();
+        TrialResult result = timed_read(t);
+        t.Close();
+        return result;
+    });
 
-	trials.emplace_back("Effect_Mask", [&]() {
-		FFmpegReader r(video);
-		r.Open();
-#ifdef USE_IMAGEMAGICK
-		ImageReader mask_reader(mask_img);
-#else
-		QtImageReader mask_reader(mask_img);
+#ifdef OPENSHOT_HAS_MASK
+    const string mask_img = base + "mask.png";
+    trials.emplace_back("Effect_Mask", [&]() -> TrialResult {
+        FFmpegReader r(video);
+        r.Open();
+#  ifdef USE_IMAGEMAGICK
+        ImageReader mask_reader(mask_img);
+#  else
+        QtImageReader mask_reader(mask_img);
+#  endif
+        mask_reader.Open();
+        Clip clip(&r);
+        clip.Open();
+        Mask m(&mask_reader, Keyframe(0.0), Keyframe(0.5));
+        clip.AddEffect(&m);
+        TrialResult result = timed_read(clip);
+        mask_reader.Close();
+        clip.Close();
+        r.Close();
+        return result;
+    });
 #endif
-		mask_reader.Open();
-		Clip clip(&r);
-		clip.Open();
-		Mask m(&mask_reader, Keyframe(0.0), Keyframe(0.5));
-		clip.AddEffect(&m);
-		read_forward_backward(clip);
-		mask_reader.Close();
-		clip.Close();
-		r.Close();
-	});
 
-	trials.emplace_back("Effect_Brightness", [&]() {
-		FFmpegReader r(video);
-		r.Open();
-		Clip clip(&r);
-		clip.Open();
-		Brightness b(Keyframe(0.5), Keyframe(1.0));
-		clip.AddEffect(&b);
-		read_forward_backward(clip);
-		clip.Close();
-		r.Close();
-	});
+#ifdef OPENSHOT_HAS_BRIGHTNESS
+    trials.emplace_back("Effect_Brightness", [&]() -> TrialResult {
+        FFmpegReader r(video);
+        r.Open();
+        Clip clip(&r);
+        clip.Open();
+        Brightness b(Keyframe(0.5), Keyframe(1.0));
+        clip.AddEffect(&b);
+        TrialResult result = timed_read(clip);
+        clip.Close();
+        r.Close();
+        return result;
+    });
+#endif
 
-	trials.emplace_back("Effect_Crop", [&]() {
-		FFmpegReader r(video);
-		r.Open();
-		Clip clip(&r);
-		clip.Open();
-		Crop c(Keyframe(0.25), Keyframe(0.25), Keyframe(0.25), Keyframe(0.25));
-		clip.AddEffect(&c);
-		read_forward_backward(clip);
-		clip.Close();
-		r.Close();
-	});
+#ifdef OPENSHOT_HAS_CROP
+    trials.emplace_back("Effect_Crop", [&]() -> TrialResult {
+        FFmpegReader r(video);
+        r.Open();
+        Clip clip(&r);
+        clip.Open();
+        Crop c(Keyframe(0.25), Keyframe(0.25), Keyframe(0.25), Keyframe(0.25));
+        clip.AddEffect(&c);
+        TrialResult result = timed_read(clip);
+        clip.Close();
+        r.Close();
+        return result;
+    });
+#endif
 
-	trials.emplace_back("Effect_Saturation", [&]() {
-		FFmpegReader r(video);
-		r.Open();
-		Clip clip(&r);
-		clip.Open();
-		Saturation s(Keyframe(0.25), Keyframe(0.25), Keyframe(0.25),
-								 Keyframe(0.25));
-		clip.AddEffect(&s);
-		read_forward_backward(clip);
-		clip.Close();
-		r.Close();
-	});
+#ifdef OPENSHOT_HAS_SATURATION
+    trials.emplace_back("Effect_Saturation", [&]() -> TrialResult {
+        FFmpegReader r(video);
+        r.Open();
+        Clip clip(&r);
+        clip.Open();
+        Saturation s(Keyframe(0.25), Keyframe(0.25), Keyframe(0.25), Keyframe(0.25));
+        clip.AddEffect(&s);
+        TrialResult result = timed_read(clip);
+        clip.Close();
+        r.Close();
+        return result;
+    });
+#endif
 
-	trials.emplace_back("Effect_ChromaKey_BASIC", [&]() {
-		FFmpegReader r(video);
-		r.Open();
-		Clip clip(&r);
-		clip.Open();
-		// Default/basic chroma key method baseline
-		ChromaKey key(Color(0, 255, 0, 255), Keyframe(80.0), Keyframe(20.0), CHROMAKEY_BASIC);
-		clip.AddEffect(&key);
-		const int64_t bench_frames = std::min<int64_t>(clip.info.video_length, chroma_bench_frames);
-		for (int64_t i = 1; i <= bench_frames; ++i)
-			clip.GetFrame(i);
-		for (int64_t i = bench_frames; i >= 1; --i)
-			clip.GetFrame(i);
-		clip.Close();
-		r.Close();
-	});
+#ifdef OPENSHOT_HAS_CHROMAKEY
+    trials.emplace_back("Effect_ChromaKey_BASIC", [&]() -> TrialResult {
+        FFmpegReader r(video);
+        r.Open();
+        Clip clip(&r);
+        clip.Open();
+        ChromaKey key(Color(0, 255, 0, 255), Keyframe(80.0), Keyframe(20.0), CHROMAKEY_BASIC);
+        clip.AddEffect(&key);
+        TrialResult result = timed_read(clip);
+        clip.Close();
+        r.Close();
+        return result;
+    });
 
-	trials.emplace_back("Effect_ChromaKey_BASIC_SOFT", [&]() {
-		FFmpegReader r(video);
-		r.Open();
-		Clip clip(&r);
-		clip.Open();
-		ChromaKey key(Color(0, 255, 0, 255), Keyframe(80.0), Keyframe(20.0), CHROMAKEY_BASIC_SOFT);
-		clip.AddEffect(&key);
-		const int64_t bench_frames = std::min<int64_t>(clip.info.video_length, chroma_bench_frames);
-		for (int64_t i = 1; i <= bench_frames; ++i)
-			clip.GetFrame(i);
-		for (int64_t i = bench_frames; i >= 1; --i)
-			clip.GetFrame(i);
-		clip.Close();
-		r.Close();
-	});
+    trials.emplace_back("Effect_ChromaKey_BASIC_SOFT", [&]() -> TrialResult {
+        FFmpegReader r(video);
+        r.Open();
+        Clip clip(&r);
+        clip.Open();
+        ChromaKey key(Color(0, 255, 0, 255), Keyframe(80.0), Keyframe(20.0), CHROMAKEY_BASIC_SOFT);
+        clip.AddEffect(&key);
+        TrialResult result = timed_read(clip);
+        clip.Close();
+        r.Close();
+        return result;
+    });
+#endif
 
-	const std::vector<std::pair<std::string, int>> audio_visualization_modes = {
-		{"Effect_AudioVisualization_Waveform", AUDIO_VISUALIZATION_WAVEFORM},
-		{"Effect_AudioVisualization_FilledWaveform", AUDIO_VISUALIZATION_FILLED_WAVEFORM},
-		{"Effect_AudioVisualization_Bars", AUDIO_VISUALIZATION_BARS},
-		{"Effect_AudioVisualization_Radial", AUDIO_VISUALIZATION_RADIAL},
-		{"Effect_AudioVisualization_Spectrum", AUDIO_VISUALIZATION_SPECTRUM},
-		{"Effect_AudioVisualization_PhaseScope", AUDIO_VISUALIZATION_PHASE_SCOPE},
-		{"Effect_AudioVisualization_Particles", AUDIO_VISUALIZATION_PARTICLES},
-		{"Effect_AudioVisualization_VUMeter", AUDIO_VISUALIZATION_VU_METER},
-		{"Effect_AudioVisualization_RadialBars", AUDIO_VISUALIZATION_RADIAL_BARS}
-	};
+#ifdef OPENSHOT_HAS_COLORGRADE
+    trials.emplace_back("Effect_ColorGrade", [&]() -> TrialResult {
+        FFmpegReader r(video);
+        r.Open();
+        Clip clip(&r);
+        clip.Open();
+        ColorGrade cg;
+        clip.AddEffect(&cg);
+        TrialResult result = timed_read(clip);
+        clip.Close();
+        r.Close();
+        return result;
+    });
+#endif
 
-	for (const auto& mode : audio_visualization_modes) {
-		trials.emplace_back(mode.first, [mode]() {
-			run_audio_visualization_mode(mode.second, 240);
-		});
-	}
+#ifdef OPENSHOT_HAS_FILMGRAIN
+    trials.emplace_back("Effect_FilmGrain", [&]() -> TrialResult {
+        FFmpegReader r(video);
+        r.Open();
+        Clip clip(&r);
+        clip.Open();
+        FilmGrain fg;
+        clip.AddEffect(&fg);
+        TrialResult result = timed_read(clip);
+        clip.Close();
+        r.Close();
+        return result;
+    });
+#endif
 
-	trials.emplace_back("Effect_AudioVisualization", [audio_visualization_modes]() {
-		for (const auto& mode : audio_visualization_modes)
-			run_audio_visualization_mode(mode.second, 120);
-	});
+#ifdef OPENSHOT_HAS_SHADOW
+    trials.emplace_back("Effect_Shadow", [&]() -> TrialResult {
+        FFmpegReader r(video);
+        r.Open();
+        Clip clip(&r);
+        clip.Open();
+        Shadow s;
+        clip.AddEffect(&s);
+        TrialResult result = timed_read(clip);
+        clip.Close();
+        r.Close();
+        return result;
+    });
+#endif
 
-	trials.emplace_back("Effect_AudioVisualization_SpectrumModes", [&]() {
-		const std::vector<int> modes = {
-			AUDIO_VISUALIZATION_BARS,
-			AUDIO_VISUALIZATION_RADIAL,
-			AUDIO_VISUALIZATION_SPECTRUM,
-			AUDIO_VISUALIZATION_PARTICLES,
-			AUDIO_VISUALIZATION_RADIAL_BARS
-		};
+#ifdef OPENSHOT_HAS_GLOW
+    trials.emplace_back("Effect_Glow", [&]() -> TrialResult {
+        FFmpegReader r(video);
+        r.Open();
+        Clip clip(&r);
+        clip.Open();
+        Glow g;
+        clip.AddEffect(&g);
+        TrialResult result = timed_read(clip);
+        clip.Close();
+        r.Close();
+        return result;
+    });
+#endif
 
-		for (int mode : modes)
-			run_audio_visualization_mode(mode, 120);
-	});
+#ifdef OPENSHOT_HAS_AUDIOVISUALIZATION
+    const std::vector<std::pair<std::string, int>> audio_visualization_modes = {
+        {"Effect_AudioVisualization_Waveform",       AUDIO_VISUALIZATION_WAVEFORM},
+        {"Effect_AudioVisualization_FilledWaveform", AUDIO_VISUALIZATION_FILLED_WAVEFORM},
+        {"Effect_AudioVisualization_Radial",         AUDIO_VISUALIZATION_RADIAL},
+        {"Effect_AudioVisualization_Spectrum",       AUDIO_VISUALIZATION_SPECTRUM},
+        {"Effect_AudioVisualization_PhaseScope",     AUDIO_VISUALIZATION_PHASE_SCOPE},
+        {"Effect_AudioVisualization_Particles",      AUDIO_VISUALIZATION_PARTICLES},
+        {"Effect_AudioVisualization_RadialBars",     AUDIO_VISUALIZATION_RADIAL_BARS}
+    };
 
-	if (options.list_only) {
-		for (const auto& trial : trials)
-			cout << trial.first << "\n";
-		return 0;
-	}
+    for (const auto& mode : audio_visualization_modes) {
+        trials.emplace_back(mode.first, [mode]() -> TrialResult {
+            return timed_audio_viz(mode.second);
+        });
+    }
+#endif
 
-	cout << "Trial,Milliseconds\n";
-	double total = 0.0;
-	int executed = 0;
-	for (const auto& trial : trials) {
-		if (!options.filter_test.empty() && trial.first != options.filter_test)
-			continue;
-		total += time_trial(trial.first, trial.second);
-		executed++;
-	}
+    if (options.list_only) {
+        for (const auto& trial : trials)
+            cout << trial.first << "\n";
+        return 0;
+    }
 
-	if (!options.filter_test.empty() && executed == 0) {
-		cerr << "Unknown test: " << options.filter_test << "\nAvailable tests:\n";
-		for (const auto& trial : trials)
-			cerr << "  " << trial.first << "\n";
-		return 2;
-	}
+    vector<BenchmarkRecord> records;
+    records.reserve(trials.size());
+    for (const auto& trial : trials) {
+        if (!options.filter_test.empty() && trial.first != options.filter_test)
+            continue;
+        records.push_back(run_trial(trial.first, trial.second));
+    }
 
-	cout << "Overall," << total << "\n";
-	return 0;
+    if (!options.filter_test.empty() && records.empty()) {
+        cerr << "Unknown test: " << options.filter_test << "\nAvailable tests:\n";
+        for (const auto& trial : trials)
+            cerr << "  " << trial.first << "\n";
+        return 2;
+    }
+
+    if (isatty(STDOUT_FILENO))
+        cout << "\r" << string(64, ' ') << "\r" << flush;
+    print_results(records);
+    return 0;
 }

--- a/tests/Benchmark.cpp
+++ b/tests/Benchmark.cpp
@@ -80,7 +80,44 @@ extern "C" {
 #  include "effects/Shadow.h"
 #  define OPENSHOT_HAS_SHADOW
 #endif
+#if __has_include("effects/Blur.h")
+#  include "effects/Blur.h"
+#  define OPENSHOT_HAS_BLUR
+#endif
+#if __has_include("effects/Sharpen.h")
+#  include "effects/Sharpen.h"
+#  define OPENSHOT_HAS_SHARPEN
+#endif
+#if __has_include("effects/Hue.h")
+#  include "effects/Hue.h"
+#  define OPENSHOT_HAS_HUE
+#endif
+#if __has_include("effects/Negate.h")
+#  include "effects/Negate.h"
+#  define OPENSHOT_HAS_NEGATE
+#endif
+#if __has_include("effects/Pixelate.h")
+#  include "effects/Pixelate.h"
+#  define OPENSHOT_HAS_PIXELATE
+#endif
+#if __has_include("effects/Wave.h")
+#  include "effects/Wave.h"
+#  define OPENSHOT_HAS_WAVE
+#endif
+#if __has_include("effects/Caption.h")
+#  include "effects/Caption.h"
+#  define OPENSHOT_HAS_CAPTION
+#endif
+#if __has_include("effects/Displace.h")
+#  include "effects/Displace.h"
+#  define OPENSHOT_HAS_DISPLACE
+#endif
+#if __has_include("FrameScope.h")
+#  include "FrameScope.h"
+#  define OPENSHOT_HAS_FRAMESCOPE
+#endif
 
+#include <QApplication>
 #include <QImage>
 
 using namespace openshot;
@@ -222,6 +259,13 @@ static TrialResult timed_audio_viz(int mode) {
 #endif // OPENSHOT_HAS_AUDIOVISUALIZATION
 
 int main(int argc, char* argv[]) {
+    // QApplication is required by any effect that renders text (e.g. Caption).
+    // It must be alive for the duration of main.
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+    QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+#endif
+    QApplication app(argc, argv);
+
     const string base = TEST_MEDIA_PATH;
     const string video = base + "sintel_trailer-720p.mp4";
     const string overlay = base + "front3.png";
@@ -257,7 +301,7 @@ int main(int argc, char* argv[]) {
     }
 
     vector<Trial> trials;
-    trials.reserve(25);
+    trials.reserve(40);
 
     trials.emplace_back("FFmpegReader", [&]() -> TrialResult {
         FFmpegReader r(video);
@@ -521,6 +565,142 @@ int main(int argc, char* argv[]) {
     });
 #endif
 
+#ifdef OPENSHOT_HAS_BLUR
+    trials.emplace_back("Effect_Blur", [&]() -> TrialResult {
+        FFmpegReader r(video);
+        r.Open();
+        Clip clip(&r);
+        clip.Open();
+        // Gaussian-style: radius=4 px, sigma=3.0, 3 iterations
+        Blur b(Keyframe(4), Keyframe(4), Keyframe(3.0), Keyframe(3));
+        clip.AddEffect(&b);
+        TrialResult result = timed_read(clip);
+        clip.Close();
+        r.Close();
+        return result;
+    });
+#endif
+
+#ifdef OPENSHOT_HAS_SHARPEN
+    trials.emplace_back("Effect_Sharpen", [&]() -> TrialResult {
+        FFmpegReader r(video);
+        r.Open();
+        Clip clip(&r);
+        clip.Open();
+        Sharpen s(Keyframe(1.0), Keyframe(3.0), Keyframe(0.1));
+        clip.AddEffect(&s);
+        TrialResult result = timed_read(clip);
+        clip.Close();
+        r.Close();
+        return result;
+    });
+#endif
+
+#ifdef OPENSHOT_HAS_HUE
+    trials.emplace_back("Effect_Hue", [&]() -> TrialResult {
+        FFmpegReader r(video);
+        r.Open();
+        Clip clip(&r);
+        clip.Open();
+        Hue h(Keyframe(0.25));
+        clip.AddEffect(&h);
+        TrialResult result = timed_read(clip);
+        clip.Close();
+        r.Close();
+        return result;
+    });
+#endif
+
+#ifdef OPENSHOT_HAS_NEGATE
+    trials.emplace_back("Effect_Negate", [&]() -> TrialResult {
+        FFmpegReader r(video);
+        r.Open();
+        Clip clip(&r);
+        clip.Open();
+        Negate n;
+        clip.AddEffect(&n);
+        TrialResult result = timed_read(clip);
+        clip.Close();
+        r.Close();
+        return result;
+    });
+#endif
+
+#ifdef OPENSHOT_HAS_PIXELATE
+    trials.emplace_back("Effect_Pixelate", [&]() -> TrialResult {
+        FFmpegReader r(video);
+        r.Open();
+        Clip clip(&r);
+        clip.Open();
+        // 5 % pixelization across the full frame
+        Pixelate p(Keyframe(0.05), Keyframe(0.0), Keyframe(0.0), Keyframe(0.0), Keyframe(0.0));
+        clip.AddEffect(&p);
+        TrialResult result = timed_read(clip);
+        clip.Close();
+        r.Close();
+        return result;
+    });
+#endif
+
+#ifdef OPENSHOT_HAS_WAVE
+    trials.emplace_back("Effect_Wave", [&]() -> TrialResult {
+        FFmpegReader r(video);
+        r.Open();
+        Clip clip(&r);
+        clip.Open();
+        Wave w(Keyframe(0.5), Keyframe(3.0), Keyframe(0.5), Keyframe(0.0), Keyframe(2.0));
+        clip.AddEffect(&w);
+        TrialResult result = timed_read(clip);
+        clip.Close();
+        r.Close();
+        return result;
+    });
+#endif
+
+#ifdef OPENSHOT_HAS_CAPTION
+    {
+        const char* qt_platform = std::getenv("QT_QPA_PLATFORM");
+        const bool headless = qt_platform && std::string(qt_platform) == "offscreen";
+        if (!headless)
+    trials.emplace_back("Effect_Caption", [&]() -> TrialResult {
+        FFmpegReader r(video);
+        r.Open();
+        Clip clip(&r);
+        clip.Open();
+        Caption c("WEBVTT\n\n"
+                  "00:00:10.000 --> 00:00:15.000\nThis is a test caption.\n\n"
+                  "00:00:15.000 --> 00:00:20.000\nSecond caption line.");
+        clip.AddEffect(&c);
+        TrialResult result = timed_read(clip);
+        clip.Close();
+        r.Close();
+        return result;
+    });
+    }  // headless guard
+#endif
+
+#ifdef OPENSHOT_HAS_DISPLACE
+    trials.emplace_back("Effect_Displace", [&]() -> TrialResult {
+        FFmpegReader r(video);
+        r.Open();
+#  ifdef USE_IMAGEMAGICK
+        ImageReader map_reader(overlay);
+#  else
+        QtImageReader map_reader(overlay);
+#  endif
+        map_reader.Open();
+        Clip clip(&r);
+        clip.Open();
+        Displace d(&map_reader, Keyframe(0.5), Keyframe(0.1), Keyframe(0.1), Keyframe(0.5), Keyframe(1.5));
+        clip.AddEffect(&d);
+        TrialResult result = timed_read(clip);
+        map_reader.Close();
+        clip.Close();
+        r.Close();
+        return result;
+    });
+#endif
+
 #ifdef OPENSHOT_HAS_AUDIOVISUALIZATION
     const std::vector<std::pair<std::string, int>> audio_visualization_modes = {
         {"Effect_AudioVisualization_Waveform",       AUDIO_VISUALIZATION_WAVEFORM},
@@ -539,6 +719,37 @@ int main(int argc, char* argv[]) {
             return timed_audio_viz(mode.second);
         });
     }
+#endif
+
+#ifdef OPENSHOT_HAS_FRAMESCOPE
+    trials.emplace_back("FrameScope", [&]() -> TrialResult {
+        // Mirror the openshot-qt playback path from preview_thread.py:
+        //   FrameScope() → SetWaveformColumns(widget_width) → SetVectorscopeSize(128)
+        //   → SetFrame(frame) → individual typed getters (no JsonValue).
+        // Vectorscope size 128 is the value used during live playback when
+        // both waveform and vectorscope panels are visible.
+        FFmpegReader r(video);
+        r.Open();
+        auto t0 = Clock::now();
+        for (int64_t i = 0; i < BENCH_FRAMES; ++i) {
+            auto frame = r.GetFrame(START_FRAME + i);
+            FrameScope scope;
+            scope.SetWaveformColumns(256);
+            scope.SetVectorscopeSize(128);
+            scope.SetFrame(frame);  // triggers analyze()
+            // Read the same outputs openshot-qt reads
+            scope.GetVideoWaveformLuma();
+            scope.GetVideoHistogramLuma();
+            scope.GetVideoVectorscope();
+            scope.GetVideoAverageLuma();
+            scope.GetVideoClippedShadows();
+            scope.GetVideoClippedHighlights();
+            scope.GetAudioChannels();
+        }
+        double elapsed = chrono::duration<double>(Clock::now() - t0).count();
+        r.Close();
+        return {BENCH_FRAMES, elapsed};
+    });
 #endif
 
     if (options.list_only) {


### PR DESCRIPTION
Changing `openshot-benchmark` tool in a few meaningful ways:
- Outputting **FPS** instead of elapsed time
- Using 120 frames for each test @ 720p/24 FPS source footage
- Each test is run 3 times, median value reported
- Each test now represents a comparable amount of work, and uses FPS metric which is easier to comprehend

<img width="1051" height="642" alt="Screenshot from 2026-05-02 17-17-20" src="https://github.com/user-attachments/assets/ece76ab7-1ac9-4e52-aefb-51a8978e465f" />

```
| Trial                                    |      FPS | Chart | 
|:-----------------------------------------|--------:|:-------------------------|
| FFmpegReader                             |    915.8 | ████████████████ |
| FFmpegWriter                             |    155.6 | ███████ |
| FrameMapper                              |    783.7 | ███████████████ |
| Clip                                     |   1037.1 | █████████████████ |
| Timeline                                 |    264.6 | █████████ |
| Timeline (with transforms)               |    134.6 | ██████ |
| Effect_Mask                              |    348.1 | ██████████ |
| Effect_Brightness                        |    344.4 | ██████████ |
| Effect_Crop                              |    850.0 | ███████████████ |
| Effect_Saturation                        |    278.8 | █████████ |
| Effect_ChromaKey_BASIC                   |    341.5 | ██████████ |
| Effect_ChromaKey_BASIC_SOFT              |    332.0 | ██████████ |
| Effect_ColorGrade                        |    106.6 | █████ |
| Effect_FilmGrain                         |    132.1 | ██████ |
| Effect_Shadow                            |    122.0 | ██████ |
| Effect_Glow                              |    132.7 | ██████ |
| Effect_Blur                              |    170.3 | ███████ |
| Effect_Sharpen                           |    133.4 | ██████ |
| Effect_Hue                               |    254.9 | ████████ |
| Effect_Negate                            |    633.2 | █████████████ |
| Effect_Pixelate                          |    401.8 | ███████████ |
| Effect_Wave                              |    205.8 | ████████ |
| Effect_Caption                           |    245.1 | ████████ |
| Effect_Displace                          |    151.0 | ███████ |
| Effect_AudioVisualization_Waveform       |    166.4 | ███████ |
| Effect_AudioVisualization_FilledWaveform |    345.9 | ██████████ |
| Effect_AudioVisualization_Bars           |   1172.4 | ██████████████████ |
| Effect_AudioVisualization_Radial         |    569.8 | █████████████ |
| Effect_AudioVisualization_Spectrum       |    160.9 | ███████ |
| Effect_AudioVisualization_PhaseScope     |    936.2 | ████████████████ |
| Effect_AudioVisualization_Particles      |    155.3 | ███████ |
| Effect_AudioVisualization_VUMeter        |   2047.2 | ████████████████████████ |
| Effect_AudioVisualization_RadialBars     |    565.4 | █████████████ |
| FrameScope                               |    114.4 | ██████ |
```