### PR TITLE
Cap Mask contrast factor at maximum contrast

### DIFF
--- a/src/effects/Mask.cpp
+++ b/src/effects/Mask.cpp
@@ -75,7 +75,7 @@ std::shared_ptr<openshot::Frame> Mask::GetFrame(std::shared_ptr<openshot::Frame>
 	double brightness_value = brightness.GetValue(frame_number);
 
 	int brightness_adj = static_cast<int>(255 * brightness_value);
-	float contrast_factor = 20.0f / std::max(0.00001f, 20.0f - static_cast<float>(contrast_value));
+	float contrast_factor = 20.0f / std::max(0.5f, 20.0f - static_cast<float>(contrast_value));
 	const bool output_mask = replace_image;
 	const auto clamp_u8 = [](int value) -> unsigned char {
 		if (value < 0) return 0;

--- a/tests/Mask.cpp
+++ b/tests/Mask.cpp
@@ -103,6 +103,26 @@ TEST_CASE("Mask replace_image emits grayscale values", "[effect][mask_effect][re
 	CHECK(px1.alpha() == px1.red());
 }
 
+TEST_CASE("Mask maximum contrast keeps a narrow transition band", "[effect][mask_effect][contrast]") {
+	auto frame = std::make_shared<Frame>(1, 3, 1, "#000000");
+	auto image = frame->GetImage();
+	image->setPixelColor(0, 0, QColor(255, 0, 0, 255));
+	image->setPixelColor(1, 0, QColor(255, 0, 0, 255));
+	image->setPixelColor(2, 0, QColor(255, 0, 0, 255));
+
+	const std::string mask_path = create_mask_png({128, 129, 134});
+	Mask mask;
+	mask.Reader(new QtImageReader(mask_path));
+	mask.brightness = Keyframe(0.0);
+	mask.contrast = Keyframe(20.0);
+
+	auto out = mask.GetFrame(frame, 1);
+
+	CHECK(out->GetImage()->pixelColor(0, 0).alpha() == 127);
+	CHECK(out->GetImage()->pixelColor(1, 0).alpha() == 87);
+	CHECK(out->GetImage()->pixelColor(2, 0).alpha() == 0);
+}
+
 TEST_CASE("Mask accepts legacy reader json field", "[effect][mask_effect][json]") {
 	const std::string mask_path = create_mask_png({128});
 	QtImageReader reader(mask_path);


### PR DESCRIPTION
-Raise the Mask contrast denominator floor from 0.00001 to 0.5, capping the contrast factor at 40. This prevents contrast values near 20 from turning the 8-bit gray lookup into a one-value step function, where tiny mask image differences can create hard transparent edge artifacts during gradient wipes. -Add a regression test covering the maximum contrast transition band.