### PR TITLE
Fixing FPS on FFmpegWriter exports

### DIFF
--- a/src/FFmpegWriter.cpp
+++ b/src/FFmpegWriter.cpp
@@ -811,6 +811,9 @@ void FFmpegWriter::flush_encoders() {
 					avcodec_flush_buffers(video_codec_ctx);
 					break;
 				}
+				if (pkt->duration <= 0) {
+					pkt->duration = av_rescale_q(1, av_make_q(info.fps.den, info.fps.num), video_codec_ctx->time_base);
+				}
 				av_packet_rescale_ts(pkt, video_codec_ctx->time_base, video_st->time_base);
 				pkt->stream_index = video_st->index;
 				error_code = av_interleaved_write_frame(oc, pkt);
@@ -833,6 +836,9 @@ void FFmpegWriter::flush_encoders() {
 			}
 
 			// set the timestamp
+			if (pkt->duration <= 0) {
+				pkt->duration = av_rescale_q(1, av_make_q(info.fps.den, info.fps.num), video_codec_ctx->time_base);
+			}
 			av_packet_rescale_ts(pkt, video_codec_ctx->time_base, video_st->time_base);
 			pkt->stream_index = video_st->index;
 
@@ -1274,6 +1280,7 @@ AVStream *FFmpegWriter::add_video_stream() {
 	c->framerate = av_inv_q(c->time_base);
 #endif
 	st->avg_frame_rate = av_inv_q(c->time_base);
+	st->r_frame_rate = av_inv_q(c->time_base);
 	st->time_base.num = info.video_timebase.num;
 	st->time_base.den = info.video_timebase.den;
 
@@ -1556,6 +1563,8 @@ void FFmpegWriter::open_video(AVFormatContext *oc, AVStream *st) {
 	if (avcodec_open2(video_codec_ctx, codec, &opts) < 0)
 		throw InvalidCodec("Could not open video codec", path);
 	AV_COPY_PARAMS_FROM_CONTEXT(st, video_codec_ctx);
+	st->avg_frame_rate = av_make_q(info.fps.num, info.fps.den);
+	st->r_frame_rate = av_make_q(info.fps.num, info.fps.den);
 
 	// Free options
 	av_dict_free(&opts);
@@ -2229,6 +2238,7 @@ bool FFmpegWriter::write_video_packet(std::shared_ptr<Frame> frame, AVFrame *fra
 
 		// Set PTS (in frames and scaled to the codec's timebase)
 		pkt->pts = video_timestamp;
+		pkt->duration = av_rescale_q(1, av_make_q(info.fps.den, info.fps.num), video_codec_ctx->time_base);
 
 		/* write the compressed frame in the media file */
 		int error_code = av_interleaved_write_frame(oc, pkt);
@@ -2335,6 +2345,9 @@ bool FFmpegWriter::write_video_packet(std::shared_ptr<Frame> frame, AVFrame *fra
 		/* if zero size, it means the image was buffered */
 		if (error_code == 0 && got_packet_ptr) {
 			// set the timestamp
+			if (pkt->duration <= 0) {
+				pkt->duration = av_rescale_q(1, av_make_q(info.fps.den, info.fps.num), video_codec_ctx->time_base);
+			}
 			av_packet_rescale_ts(pkt, video_codec_ctx->time_base, video_st->time_base);
 			pkt->stream_index = video_st->index;
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -138,12 +138,21 @@ foreach(tname ${OPENSHOT_TESTS})
     openshot
   )
 
+  set(test_properties
+    LABELS ${tname}
+  )
+  if(tname STREQUAL "Caption")
+    list(APPEND test_properties
+      ENVIRONMENT "QT_QPA_PLATFORM=minimal"
+    )
+  endif()
+
   # Automatically configure CTest targets from Catch2 test cases
   catch_discover_tests(
     openshot-${tname}-test
     TEST_PREFIX ${tname}:
     PROPERTIES
-      LABELS ${tname}
+      ${test_properties}
   )
   list(APPEND CATCH2_TEST_TARGETS openshot-${tname}-test)
   list(APPEND CATCH2_TEST_NAMES ${tname})

--- a/tests/FFmpegWriter.cpp
+++ b/tests/FFmpegWriter.cpp
@@ -18,13 +18,30 @@
 
 #include "FFmpegWriter.h"
 #include "Exceptions.h"
+#include "DummyReader.h"
 #include "FFmpegReader.h"
 #include "Fraction.h"
 #include "Frame.h"
 #include "Timeline.h"
 
+extern "C" {
+	#include <libavformat/avformat.h>
+}
+
 using namespace std;
 using namespace openshot;
+
+namespace {
+AVStream* first_video_stream(AVFormatContext* format_context)
+{
+	for (unsigned int index = 0; index < format_context->nb_streams; ++index) {
+		AVStream* stream = format_context->streams[index];
+		if (stream && stream->codecpar && stream->codecpar->codec_type == AVMEDIA_TYPE_VIDEO)
+			return stream;
+	}
+	return nullptr;
+}
+}
 
 TEST_CASE( "Webm", "[libopenshot][ffmpegwriter]" )
 {
@@ -233,6 +250,34 @@ TEST_CASE( "Gif", "[libopenshot][ffmpegwriter]" )
 
     // Close reader
     r1.Close();
+}
+
+TEST_CASE( "MP4_30fps_duration_exact_with_b_frames", "[libopenshot][ffmpegwriter][fps]" )
+{
+	const std::string out_name = "MP4_30fps_duration_exact_with_b_frames.mp4";
+	DummyReader reader(Fraction(30, 1), 1280, 720, 48000, 2, 1.0f);
+	reader.Open();
+
+	FFmpegWriter writer(out_name);
+	writer.SetVideoOptions(true, "mpeg4", Fraction(30, 1), 1280, 720, Fraction(1, 1), false, false, 15000000);
+	writer.Open();
+	writer.WriteFrame(&reader, 1, 30);
+	writer.Close();
+	reader.Close();
+
+	AVFormatContext* format_context = nullptr;
+	REQUIRE(avformat_open_input(&format_context, out_name.c_str(), nullptr, nullptr) == 0);
+	REQUIRE(avformat_find_stream_info(format_context, nullptr) >= 0);
+	AVStream* stream = first_video_stream(format_context);
+	REQUIRE(stream != nullptr);
+
+	CHECK(stream->r_frame_rate.num == 30);
+	CHECK(stream->r_frame_rate.den == 1);
+	CHECK(stream->avg_frame_rate.num == 30);
+	CHECK(stream->avg_frame_rate.den == 1);
+	CHECK(stream->duration == av_rescale_q(30, av_make_q(1, 30), stream->time_base));
+
+	avformat_close_input(&format_context);
 }
 
 TEST_CASE( "SizeOrdering_x264_CRF", "[libopenshot][ffmpegwriter][filesize]" )


### PR DESCRIPTION
Some exports could report framerates slightly incorrect, for example 30.14 instead of 30 FPS. This was due to an off by one issue on older versions of FFmpeg.