### PR TITLE
Fixing GetMaxFrame() to fix tiny float overshoot

### DIFF
--- a/src/Timeline.cpp
+++ b/src/Timeline.cpp
@@ -479,8 +479,13 @@ double Timeline::GetMaxTime() {
 int64_t Timeline::GetMaxFrame() {
 	const double fps = info.fps.ToDouble();
 	const double t = GetMaxTime();
-	// Inclusive start, exclusive end -> ceil at the end boundary
-	return static_cast<int64_t>(std::ceil(t * fps));
+	const double frames = t * fps;
+	constexpr double frame_boundary_epsilon = 1e-4;
+
+	// End is exclusive; ignore tiny float overshoots at frame boundaries.
+	if (frames > 0.0 && frames < frame_boundary_epsilon)
+		return 1;
+	return static_cast<int64_t>(std::ceil(frames - frame_boundary_epsilon));
 }
 
 // Compute the first frame# based on the first clip position

--- a/tests/Timeline.cpp
+++ b/tests/Timeline.cpp
@@ -1835,3 +1835,24 @@ TEST_CASE("GetFrame past-end requests are not cached", "[libopenshot][timeline][
 	CHECK(second->number == end + 120);
 	CHECK(t.GetCache()->Count() == count_before);
 }
+
+TEST_CASE("GetMaxFrame ignores tiny float overshoot at clip end", "[libopenshot][timeline][frames]") {
+	TimelineSolidColorReader reader(
+		64, 64,
+		30, 1,
+		600,
+		QColor(10, 20, 30, 255));
+	Clip clip(&reader);
+	clip.Layer(1);
+	clip.Position(0.0);
+	clip.End(16.83333396911621f);
+
+	Timeline t(640, 480, Fraction(30, 1), 44100, 2, LAYOUT_STEREO);
+	t.AddClip(&clip);
+
+	// This value reproduces an exported project where 505 frames at 30 FPS
+	// reloaded from JSON as a tiny float overshoot beyond the frame boundary.
+	REQUIRE(t.GetMaxTime() * t.info.fps.ToDouble() > 505.0);
+	REQUIRE(t.GetMaxTime() * t.info.fps.ToDouble() < 505.0001);
+	CHECK(t.GetMaxFrame() == 505);
+}


### PR DESCRIPTION
Fixing GetMaxFrame() to fix tiny float overshoot, causing occasional black frames at the end of an export.  For example, it might have concluded that we had 505.00001 frames, and this would then be converted later to 506 with ceil().