### PR TITLE
Fix SVG thumbnail rasterization with max decode size (fix fuzzy thumbnails for small SVG files)

### DIFF
--- a/src/QtImageReader.cpp
+++ b/src/QtImageReader.cpp
@@ -257,7 +257,17 @@ QSize QtImageReader::calculate_max_size() {
     if (HasMaxDecodeSize()) {
         QSize bounded_size(max_width, max_height);
         const QSize max_decode_size(MaxDecodeWidth(), MaxDecodeHeight());
-        if (bounded_size.width() > max_decode_size.width() ||
+        const QString lower_path = path.toLower();
+        const bool is_svg = lower_path.endsWith(".svg") || lower_path.endsWith(".svgz");
+
+        if (is_svg && !parent) {
+            // Vector images have no fixed source pixel limit. With no parent
+            // Timeline/Clip to provide a render size, use MaxDecodeSize as the
+            // rasterization target instead of preserving the tiny document size.
+            bounded_size.scale(max_decode_size, Qt::KeepAspectRatio);
+            max_width = bounded_size.width();
+            max_height = bounded_size.height();
+        } else if (bounded_size.width() > max_decode_size.width() ||
             bounded_size.height() > max_decode_size.height()) {
             bounded_size.scale(max_decode_size, Qt::KeepAspectRatio);
             max_width = bounded_size.width();

--- a/tests/QtImageReader.cpp
+++ b/tests/QtImageReader.cpp
@@ -134,3 +134,25 @@ TEST_CASE( "Max_Decode_Size_QtImageReader", "[libopenshot][qtimagereader]" )
 
 	r.Close();
 }
+
+TEST_CASE( "Max_Decode_Size_SVG_QtImageReader", "[libopenshot][qtimagereader]" )
+{
+	std::stringstream path;
+	path << TEST_MEDIA_PATH << "1F0CF.svg";
+
+	QtImageReader r(path.str());
+	r.Open();
+
+	std::shared_ptr<Frame> original = r.GetFrame(1);
+	REQUIRE(original != nullptr);
+	CHECK(original->GetWidth() == 72);
+	CHECK(original->GetHeight() == 72);
+
+	r.SetMaxDecodeSize(256, 128);
+	std::shared_ptr<Frame> limited = r.GetFrame(2);
+	REQUIRE(limited != nullptr);
+	CHECK(limited->GetWidth() == 128);
+	CHECK(limited->GetHeight() == 128);
+
+	r.Close();
+}


### PR DESCRIPTION
Fix SVG thumbnail rasterization with max decode size (SVG upscaling for tiny sizes)

-Treat SetMaxDecodeSize as the rasterization target for parentless SVG readers, instead of only as a downscale ceiling. This lets thumbnail generation render tiny SVG files at the requested decode size, avoiding blurry thumbnails caused by first rasterizing at the SVG document size. -Raster images and SVGs with a parent clip/timeline keep their existing sizing behavior.