### PR TITLE
Use TrackedObjectMask as "Mask: Source" for any Effect

### DIFF
--- a/src/EffectBase.cpp
+++ b/src/EffectBase.cpp
@@ -20,12 +20,17 @@
 #include "Exceptions.h"
 #include "Clip.h"
 #include "Timeline.h"
+#include "TrackedObjectBBox.h"
 #include "ReaderBase.h"
 #include "ChunkReader.h"
 #include "FFmpegReader.h"
 #include "QtImageReader.h"
 #include "ZmqLogger.h"
 #include <omp.h>
+#include <QBrush>
+#include <QColor>
+#include <QPainter>
+#include <QRectF>
 
 #ifdef USE_IMAGEMAGICK
 	#include "ImageReader.h"
@@ -46,6 +51,7 @@ void EffectBase::InitEffectInfo()
 	parentEffect = NULL;
 	mask_invert = false;
 	mask_reader = NULL;
+	mask_source_id = "";
 	mask_time_mode = MASK_TIME_SOURCE_FPS;
 	mask_loop_mode = MASK_LOOP_PLAY_ONCE;
 
@@ -107,6 +113,7 @@ Json::Value EffectBase::JsonValue() const {
 	root["apply_before_clip"] = info.apply_before_clip;
 	root["order"] = Order();
 	root["mask_invert"] = mask_invert;
+	root["mask_source_id"] = mask_source_id;
 	root["mask_time_mode"] = mask_time_mode;
 	root["mask_loop_mode"] = mask_loop_mode;
 	if (mask_reader)
@@ -184,6 +191,8 @@ void EffectBase::SetJsonValue(const Json::Value root) {
 
 	if (!my_root["mask_invert"].isNull())
 		mask_invert = my_root["mask_invert"].asBool();
+	if (!my_root["mask_source_id"].isNull())
+		MaskSourceId(my_root["mask_source_id"].asString());
 	if (!my_root["mask_time_mode"].isNull()) {
 		const int time_mode = my_root["mask_time_mode"].asInt();
 		mask_time_mode = (time_mode == MASK_TIME_TIMELINE || time_mode == MASK_TIME_SOURCE_FPS)
@@ -269,6 +278,8 @@ Json::Value EffectBase::BasePropertiesJSON(int64_t requested_frame) const {
 			root["mask_reader"] = add_property_json("Mask: Source", 0.0, "reader", mask_reader->Json(), NULL, 0, 1, false, requested_frame);
 		else
 			root["mask_reader"] = add_property_json("Mask: Source", 0.0, "reader", "{}", NULL, 0, 1, false, requested_frame);
+
+		root["mask_source_id"] = add_property_json("Mask: Effect Source", 0.0, "string", mask_source_id, NULL, -1, -1, false, requested_frame);
 	}
 
 	return root;
@@ -320,6 +331,36 @@ void EffectBase::MaskReader(ReaderBase* new_reader) {
 	cached_single_mask_height = 0;
 	if (mask_reader)
 		mask_reader->ParentClip(clip);
+}
+
+void EffectBase::MaskSourceId(const std::string& new_mask_source_id) {
+	mask_source_id = new_mask_source_id;
+	cached_single_mask_image.reset();
+	cached_single_mask_width = 0;
+	cached_single_mask_height = 0;
+}
+
+EffectBase* EffectBase::ResolveMaskSourceEffect() {
+	if (mask_source_id.empty())
+		return NULL;
+
+	Clip* parent_clip = dynamic_cast<Clip*>(clip);
+	if (parent_clip) {
+		EffectBase* source = parent_clip->GetEffect(mask_source_id);
+		if (source && source != this)
+			return source;
+	}
+
+	Timeline* parent_timeline = dynamic_cast<Timeline*>(ParentTimeline());
+	if (parent_timeline) {
+		EffectBase* source = parent_timeline->GetClipEffect(mask_source_id);
+		if (!source)
+			source = parent_timeline->GetEffect(mask_source_id);
+		if (source && source != this)
+			return source;
+	}
+
+	return NULL;
 }
 
 double EffectBase::ResolveMaskHostFps() {
@@ -430,7 +471,22 @@ int64_t EffectBase::MapMaskFrameNumber(int64_t frame_number) {
 }
 
 std::shared_ptr<QImage> EffectBase::GetMaskImage(std::shared_ptr<QImage> target_image, int64_t frame_number) {
-	if (!mask_reader || !target_image || target_image->isNull())
+	if (!target_image || target_image->isNull())
+		return {};
+
+	EffectBase* source_effect = ResolveMaskSourceEffect();
+	if (source_effect) {
+		auto generated_mask = source_effect->TrackedObjectMask(target_image, frame_number);
+		if (generated_mask && !generated_mask->isNull())
+			return generated_mask;
+
+		auto empty_mask = std::make_shared<QImage>(
+			target_image->width(), target_image->height(), QImage::Format_RGBA8888_Premultiplied);
+		empty_mask->fill(QColor(0, 0, 0, 255));
+		return empty_mask;
+	}
+
+	if (!mask_reader)
 		return {};
 
 	std::shared_ptr<QImage> source_mask;
@@ -479,6 +535,55 @@ std::shared_ptr<QImage> EffectBase::GetMaskImage(std::shared_ptr<QImage> target_
 	return scaled_mask;
 }
 
+std::shared_ptr<QImage> EffectBase::TrackedObjectMask(std::shared_ptr<QImage> target_image, int64_t frame_number) const {
+	if (!target_image || target_image->isNull() || trackedObjects.empty())
+		return {};
+
+	auto mask_image = std::make_shared<QImage>(
+		target_image->width(), target_image->height(), QImage::Format_RGBA8888_Premultiplied);
+	mask_image->fill(QColor(0, 0, 0, 255));
+
+	QPainter painter(mask_image.get());
+	painter.setRenderHint(QPainter::Antialiasing, false);
+	painter.setPen(Qt::NoPen);
+	painter.setBrush(QBrush(QColor(255, 255, 255, 255)));
+
+	bool drew_any_box = false;
+	for (auto const& trackedObject : trackedObjects) {
+		auto bbox = std::dynamic_pointer_cast<TrackedObjectBBox>(trackedObject.second);
+		if (!bbox)
+			continue;
+		if (!bbox->Contains(frame_number) || bbox->visible.GetValue(frame_number) != 1)
+			continue;
+
+		BBox box = bbox->GetBox(frame_number);
+		if (box.width <= 0.0f || box.height <= 0.0f || box.cx < 0.0f || box.cy < 0.0f)
+			continue;
+
+		const double x = (box.cx - box.width / 2.0) * target_image->width();
+		const double y = (box.cy - box.height / 2.0) * target_image->height();
+		const double w = box.width * target_image->width();
+		const double h = box.height * target_image->height();
+		QRectF rect(x, y, w, h);
+
+		if (std::abs(box.angle) > 0.0001f) {
+			painter.save();
+			painter.translate(rect.center());
+			painter.rotate(box.angle);
+			painter.drawRect(QRectF(-w / 2.0, -h / 2.0, w, h));
+			painter.restore();
+		} else {
+			painter.drawRect(rect);
+		}
+		drew_any_box = true;
+	}
+
+	painter.end();
+	if (!drew_any_box)
+		return {};
+	return mask_image;
+}
+
 void EffectBase::BlendWithMask(std::shared_ptr<QImage> original_image, std::shared_ptr<QImage> effected_image,
 							   std::shared_ptr<QImage> mask_image) const {
 	if (!original_image || !effected_image || !mask_image)
@@ -513,7 +618,7 @@ void EffectBase::BlendWithMask(std::shared_ptr<QImage> original_image, std::shar
 
 std::shared_ptr<openshot::Frame> EffectBase::ProcessFrame(std::shared_ptr<openshot::Frame> frame, int64_t frame_number) {
 	// Audio-only effects skip common mask handling.
-	if (!info.has_video || !mask_reader)
+	if (!info.has_video || (!mask_reader && mask_source_id.empty()))
 		return GetFrame(frame, frame_number);
 
 	// Effects that already apply masks inside GetFrame() should bypass common blend handling.

--- a/src/EffectBase.h
+++ b/src/EffectBase.h
@@ -58,6 +58,7 @@ namespace openshot
 	private:
 		int order; ///< The order to evaluate this effect. Effects are processed in this order (when more than one overlap).
 		ReaderBase* mask_reader = nullptr; ///< Optional common reader-based mask source.
+		std::string mask_source_id; ///< Optional effect ID that provides a generated mask source.
 		std::shared_ptr<QImage> cached_single_mask_image; ///< Cached scaled mask for still-image mask sources.
 		int cached_single_mask_width = 0; ///< Cached mask width.
 		int cached_single_mask_height = 0; ///< Cached mask height.
@@ -68,6 +69,9 @@ namespace openshot
 		/// Blend original and effected images using mask values.
 		void BlendWithMask(std::shared_ptr<QImage> original_image, std::shared_ptr<QImage> effected_image,
 					   std::shared_ptr<QImage> mask_image) const;
+
+		/// Find the effect named by mask_source_id.
+		EffectBase* ResolveMaskSourceEffect();
 
 	protected:
 		openshot::ClipBase* clip; ///< Pointer to the parent clip instance (if any)
@@ -149,6 +153,9 @@ namespace openshot
 		/// Get the indexes and IDs of all visible objects in the given frame
 		virtual std::string GetVisibleObjects(int64_t frame_number) const {return {}; };
 
+		/// Generate a black/white mask from tracked object data.
+		virtual std::shared_ptr<QImage> TrackedObjectMask(std::shared_ptr<QImage> target_image, int64_t frame_number) const;
+
 		// Get and Set JSON methods
 		virtual std::string Json() const; ///< Generate JSON string of this object
 		virtual void SetJson(const std::string value); ///< Load JSON string into this object
@@ -177,6 +184,10 @@ namespace openshot
 
 		/// Set or replace the common mask reader.
 		void MaskReader(ReaderBase* new_reader);
+
+		/// Get/Set effect ID used as a generated mask source.
+		std::string MaskSourceId() const { return mask_source_id; }
+		void MaskSourceId(const std::string& new_mask_source_id);
 
 		/// Get the order that this effect should be executed.
 		int Order() const { return order; }

--- a/src/effects/Bars.cpp
+++ b/src/effects/Bars.cpp
@@ -167,10 +167,10 @@ std::string Bars::PropertiesJSON(int64_t requested_frame) const {
 	root["color"]["red"] = add_property_json("Red", color.red.GetValue(requested_frame), "float", "", &color.red, 0, 255, false, requested_frame);
 	root["color"]["blue"] = add_property_json("Blue", color.blue.GetValue(requested_frame), "float", "", &color.blue, 0, 255, false, requested_frame);
 	root["color"]["green"] = add_property_json("Green", color.green.GetValue(requested_frame), "float", "", &color.green, 0, 255, false, requested_frame);
-	root["left"] = add_property_json("Left Size", left.GetValue(requested_frame), "float", "", &left, 0.0, 0.5, false, requested_frame);
-	root["top"] = add_property_json("Top Size", top.GetValue(requested_frame), "float", "", &top, 0.0, 0.5, false, requested_frame);
-	root["right"] = add_property_json("Right Size", right.GetValue(requested_frame), "float", "", &right, 0.0, 0.5, false, requested_frame);
-	root["bottom"] = add_property_json("Bottom Size", bottom.GetValue(requested_frame), "float", "", &bottom, 0.0, 0.5, false, requested_frame);
+	root["left"] = add_property_json("Margin: Left", left.GetValue(requested_frame), "float", "", &left, 0.0, 0.5, false, requested_frame);
+	root["top"] = add_property_json("Margin: Top", top.GetValue(requested_frame), "float", "", &top, 0.0, 0.5, false, requested_frame);
+	root["right"] = add_property_json("Margin: Right", right.GetValue(requested_frame), "float", "", &right, 0.0, 0.5, false, requested_frame);
+	root["bottom"] = add_property_json("Margin: Bottom", bottom.GetValue(requested_frame), "float", "", &bottom, 0.0, 0.5, false, requested_frame);
 
 	// Return formatted string
 	return root.toStyledString();

--- a/src/effects/Blur.cpp
+++ b/src/effects/Blur.cpp
@@ -13,10 +13,28 @@
 #include "Blur.h"
 #include "Exceptions.h"
 
+#include <QMargins>
+#include <QPainter>
+#include <QPoint>
+#include <QRect>
+
+#include <algorithm>
+
 using namespace openshot;
+
+namespace {
+double clamp_margin(double value) {
+	if (value < 0.0)
+		return 0.0;
+	if (value > 1.0)
+		return 1.0;
+	return value;
+}
+}
 
 /// Blank constructor, useful when using Json to load the effect properties
 Blur::Blur() : horizontal_radius(6.0), vertical_radius(6.0), sigma(3.0), iterations(3.0),
+	left(0.0), top(0.0), right(0.0), bottom(0.0),
 	mask_mode(BLUR_MASK_POST_BLEND) {
 	// Init effect properties
 	init_effect_details();
@@ -25,7 +43,21 @@ Blur::Blur() : horizontal_radius(6.0), vertical_radius(6.0), sigma(3.0), iterati
 // Default constructor
 Blur::Blur(Keyframe new_horizontal_radius, Keyframe new_vertical_radius, Keyframe new_sigma, Keyframe new_iterations) :
 		horizontal_radius(new_horizontal_radius), vertical_radius(new_vertical_radius),
-		sigma(new_sigma), iterations(new_iterations), mask_mode(BLUR_MASK_POST_BLEND)
+		sigma(new_sigma), iterations(new_iterations),
+		left(0.0), top(0.0), right(0.0), bottom(0.0),
+		mask_mode(BLUR_MASK_POST_BLEND)
+{
+	// Init effect properties
+	init_effect_details();
+}
+
+// Default constructor
+Blur::Blur(Keyframe new_horizontal_radius, Keyframe new_vertical_radius, Keyframe new_sigma, Keyframe new_iterations,
+		   Keyframe new_left, Keyframe new_top, Keyframe new_right, Keyframe new_bottom) :
+		horizontal_radius(new_horizontal_radius), vertical_radius(new_vertical_radius),
+		sigma(new_sigma), iterations(new_iterations),
+		left(new_left), top(new_top), right(new_right), bottom(new_bottom),
+		mask_mode(BLUR_MASK_POST_BLEND)
 {
 	// Init effect properties
 	init_effect_details();
@@ -61,31 +93,59 @@ std::shared_ptr<openshot::Frame> Blur::GetFrame(std::shared_ptr<openshot::Frame>
 
 	int w = frame_image->width();
 	int h = frame_image->height();
+	if (w <= 0 || h <= 0 || iteration_value <= 0)
+		return frame;
+
+	// Define area we're working on in terms of a QRect with QMargins applied.
+	QRect area(QPoint(0, 0), frame_image->size());
+	area = area.marginsRemoved({
+		int(clamp_margin(left.GetValue(frame_number)) * w),
+		int(clamp_margin(top.GetValue(frame_number)) * h),
+		int(clamp_margin(right.GetValue(frame_number)) * w),
+		int(clamp_margin(bottom.GetValue(frame_number)) * h)
+	});
+	area = area.intersected(QRect(QPoint(0, 0), frame_image->size()));
+	if (area.isEmpty())
+		return frame;
 
 	// Grab two copies of the image pixel data
-	QImage image_copy = frame_image->copy();
+	QImage image_copy = frame_image->copy(area);
+	std::shared_ptr<QImage> blur_image = std::make_shared<QImage>(image_copy);
 	std::shared_ptr<QImage> frame_image_2 = std::make_shared<QImage>(image_copy);
+	const int area_w = blur_image->width();
+	const int area_h = blur_image->height();
+	const int horizontal_area_radius = std::min(std::max(0, horizontal_radius_value), std::max(0, area_w - 1));
+	const int vertical_area_radius = std::min(std::max(0, vertical_radius_value), std::max(0, area_h - 1));
+	bool blurred = false;
 
 	// Loop through each iteration
 	for (int iteration = 0; iteration < iteration_value; ++iteration)
 	{
 		// HORIZONTAL BLUR (if any)
-		if (horizontal_radius_value > 0.0) {
+		if (horizontal_area_radius > 0.0) {
 			// Apply horizontal blur to target RGBA channels
-			boxBlurH(frame_image->bits(), frame_image_2->bits(), w, h, horizontal_radius_value);
+			boxBlurH(blur_image->bits(), frame_image_2->bits(), area_w, area_h, horizontal_area_radius);
 
 			// Swap output image back to input
-			frame_image.swap(frame_image_2);
+			blur_image.swap(frame_image_2);
+			blurred = true;
 		}
 
 		// VERTICAL BLUR (if any)
-		if (vertical_radius_value > 0.0) {
+		if (vertical_area_radius > 0.0) {
 			// Apply vertical blur to target RGBA channels
-			boxBlurT(frame_image->bits(), frame_image_2->bits(), w, h, vertical_radius_value);
+			boxBlurT(blur_image->bits(), frame_image_2->bits(), area_w, area_h, vertical_area_radius);
 
 			// Swap output image back to input
-			frame_image.swap(frame_image_2);
+			blur_image.swap(frame_image_2);
+			blurred = true;
 		}
+	}
+
+	if (blurred) {
+		QPainter painter(frame_image.get());
+		painter.drawImage(area, *blur_image);
+		painter.end();
 	}
 
 	// return the modified frame
@@ -249,6 +309,10 @@ Json::Value Blur::JsonValue() const {
 	root["vertical_radius"] = vertical_radius.JsonValue();
 	root["sigma"] = sigma.JsonValue();
 	root["iterations"] = iterations.JsonValue();
+	root["left"] = left.JsonValue();
+	root["top"] = top.JsonValue();
+	root["right"] = right.JsonValue();
+	root["bottom"] = bottom.JsonValue();
 	root["mask_mode"] = mask_mode;
 
 	// return JsonValue
@@ -287,6 +351,14 @@ void Blur::SetJsonValue(const Json::Value root) {
 		sigma.SetJsonValue(root["sigma"]);
 	if (!root["iterations"].isNull())
 		iterations.SetJsonValue(root["iterations"]);
+	if (!root["left"].isNull())
+		left.SetJsonValue(root["left"]);
+	if (!root["top"].isNull())
+		top.SetJsonValue(root["top"]);
+	if (!root["right"].isNull())
+		right.SetJsonValue(root["right"]);
+	if (!root["bottom"].isNull())
+		bottom.SetJsonValue(root["bottom"]);
 	if (!root["mask_mode"].isNull())
 		mask_mode = root["mask_mode"].asInt();
 }
@@ -302,6 +374,10 @@ std::string Blur::PropertiesJSON(int64_t requested_frame) const {
 	root["vertical_radius"] = add_property_json("Vertical Radius", vertical_radius.GetValue(requested_frame), "float", "", &vertical_radius, 0, 100, false, requested_frame);
 	root["sigma"] = add_property_json("Sigma", sigma.GetValue(requested_frame), "float", "", &sigma, 0, 100, false, requested_frame);
 	root["iterations"] = add_property_json("Iterations", iterations.GetValue(requested_frame), "float", "", &iterations, 0, 100, false, requested_frame);
+	root["left"] = add_property_json("Margin: Left", left.GetValue(requested_frame), "float", "", &left, 0.0, 1.0, false, requested_frame);
+	root["top"] = add_property_json("Margin: Top", top.GetValue(requested_frame), "float", "", &top, 0.0, 1.0, false, requested_frame);
+	root["right"] = add_property_json("Margin: Right", right.GetValue(requested_frame), "float", "", &right, 0.0, 1.0, false, requested_frame);
+	root["bottom"] = add_property_json("Margin: Bottom", bottom.GetValue(requested_frame), "float", "", &bottom, 0.0, 1.0, false, requested_frame);
 	root["mask_mode"] = add_property_json("Mask Mode", mask_mode, "int", "", NULL, 0, 1, false, requested_frame);
 	root["mask_mode"]["choices"].append(add_property_choice_json("Limit to Mask", BLUR_MASK_POST_BLEND, mask_mode));
 	root["mask_mode"]["choices"].append(add_property_choice_json("Vary Strength", BLUR_MASK_DRIVE_AMOUNT, mask_mode));

--- a/src/effects/Blur.h
+++ b/src/effects/Blur.h
@@ -57,6 +57,10 @@ namespace openshot
 		Keyframe vertical_radius;	///< Vertical blur radius keyframe. The size of the vertical blur operation in pixels.
 		Keyframe sigma;				///< Sigma keyframe. The amount of spread in the blur operation. Should be larger than radius.
 		Keyframe iterations;		///< Iterations keyframe. The # of blur iterations per pixel. 3 iterations = Gaussian.
+		Keyframe left;			///< Size of left margin
+		Keyframe top;			///< Size of top margin
+		Keyframe right;			///< Size of right margin
+		Keyframe bottom;		///< Size of bottom margin
 		int mask_mode;			///< How to apply common masks to blur (post-blend or drive-amount).
 
 		/// Blank constructor, useful when using Json to load the effect properties
@@ -70,6 +74,19 @@ namespace openshot
 		/// @param new_sigma The curve to adjust the sigma amount (the size of the blur brush (between 0 and 100), float values accepted)
 		/// @param new_iterations The curve to adjust the # of iterations (between 1 and 100)
 		Blur(Keyframe new_horizontal_radius, Keyframe new_vertical_radius, Keyframe new_sigma, Keyframe new_iterations);
+
+		/// Default constructor, which takes blur curves and an affected area.
+		///
+		/// @param new_horizontal_radius The curve to adjust the horizontal blur radius (between 0 and 100, rounded to int)
+		/// @param new_vertical_radius The curve to adjust the vertical blur radius (between 0 and 100, rounded to int)
+		/// @param new_sigma The curve to adjust the sigma amount (the size of the blur brush (between 0 and 100), float values accepted)
+		/// @param new_iterations The curve to adjust the # of iterations (between 1 and 100)
+		/// @param new_left The curve to adjust the left margin size (between 0 and 1)
+		/// @param new_top The curve to adjust the top margin size (between 0 and 1)
+		/// @param new_right The curve to adjust the right margin size (between 0 and 1)
+		/// @param new_bottom The curve to adjust the bottom margin size (between 0 and 1)
+		Blur(Keyframe new_horizontal_radius, Keyframe new_vertical_radius, Keyframe new_sigma, Keyframe new_iterations,
+			 Keyframe new_left, Keyframe new_top, Keyframe new_right, Keyframe new_bottom);
 
 		/// @brief This method is required for all derived classes of ClipBase, and returns a
 		/// new openshot::Frame object. All Clip keyframes and effects are resolved into

--- a/src/effects/Caption.cpp
+++ b/src/effects/Caption.cpp
@@ -27,9 +27,9 @@
 using namespace openshot;
 
 /// Blank constructor, useful when using Json to load the effect properties
-Caption::Caption() : color("#ffffff"), stroke("#a9a9a9"), background("#ff000000"), background_alpha(0.0), left(0.1), top(0.75), right(0.1),
+Caption::Caption() : color("#ffffff"), stroke("#a9a9a9"), background("#ff000000"), background_alpha(0.0), left(0.1), top(0.75), right(0.1), bottom(0.0),
 					 stroke_width(0.5), font_size(30.0), font_alpha(1.0), is_dirty(true), font_name("sans"), font(NULL), metrics(NULL),
-					 fade_in(0.35), fade_out(0.35), background_corner(10.0), background_padding(20.0), line_spacing(1.0)
+					 fade_in(0.0), fade_out(0.0), background_corner(10.0), background_padding(20.0), line_spacing(1.0)
 {
 	// Init effect properties
 	init_effect_details();
@@ -37,9 +37,9 @@ Caption::Caption() : color("#ffffff"), stroke("#a9a9a9"), background("#ff000000"
 
 // Default constructor
 Caption::Caption(std::string captions) :
-		color("#ffffff"), stroke("#a9a9a9"), background("#ff000000"), background_alpha(0.0), left(0.1), top(0.75), right(0.1),
+		color("#ffffff"), stroke("#a9a9a9"), background("#ff000000"), background_alpha(0.0), left(0.1), top(0.75), right(0.1), bottom(0.0),
 		stroke_width(0.5), font_size(30.0), font_alpha(1.0), is_dirty(true), font_name("sans"), font(NULL), metrics(NULL),
-		fade_in(0.35), fade_out(0.35), background_corner(10.0), background_padding(20.0), line_spacing(1.0),
+		fade_in(0.0), fade_out(0.0), background_corner(10.0), background_padding(20.0), line_spacing(1.0),
 		caption_text(captions)
 {
 	// Init effect properties
@@ -162,22 +162,28 @@ std::shared_ptr<openshot::Frame> Caption::GetFrame(std::shared_ptr<openshot::Fra
 	double fade_in_value = fade_in.GetValue(frame_number) * fps.ToDouble();
 	double fade_out_value = fade_out.GetValue(frame_number) * fps.ToDouble();
 	double right_value = right.GetValue(frame_number);
+	double bottom_value = bottom.GetValue(frame_number);
 	double background_corner_value = background_corner.GetValue(frame_number) * timeline_scale_factor;
 	double padding_value = background_padding.GetValue(frame_number) * timeline_scale_factor;
 	double stroke_width_value = stroke_width.GetValue(frame_number) * timeline_scale_factor;
 	double line_spacing_value = line_spacing.GetValue(frame_number);
 	double metrics_line_spacing = metrics.lineSpacing();
 
-	// Calculate caption area (based on left, top, and right margin)
+	// Calculate caption area (based on left, top, right, and bottom margin)
 	double left_margin_x = frame_image->width() * left_value;
-	double starting_y = (frame_image->height() * top_value) + metrics_line_spacing;
+	double top_margin_y = frame_image->height() * top_value;
+	double starting_y = top_margin_y + metrics_line_spacing;
 	double current_y = starting_y;
 	double bottom_y = starting_y;
 	double top_y = starting_y;
 	double max_text_width = 0.0;
 	double right_margin_x = frame_image->width() - (frame_image->width() * right_value);
 	double caption_area_width = right_margin_x - left_margin_x;
-	QRectF caption_area = QRectF(left_margin_x, starting_y, caption_area_width, frame_image->height());
+	double bottom_margin_y = frame_image->height() - (frame_image->height() * bottom_value);
+	double caption_area_height = std::max(bottom_margin_y - starting_y, 0.0);
+	QRectF caption_area = QRectF(left_margin_x, starting_y, caption_area_width, caption_area_height);
+	QRectF caption_clip_area = QRectF(left_margin_x, top_margin_y, caption_area_width,
+									  std::max(bottom_margin_y - top_margin_y, 0.0));
 
 	// Keep track of all required text paths
 	std::vector<QPainterPath> text_paths;
@@ -220,8 +226,12 @@ std::shared_ptr<openshot::Frame> Caption::GetFrame(std::shared_ptr<openshot::Fra
 				!line.isEmpty() && frame_number >= start_frame && frame_number <= end_frame && line.length() > 1) {
 
 				// Calculate fade in/out ranges
-				fade_in_percentage = ((float) frame_number - (float) start_frame) / fade_in_value;
-				fade_out_percentage = 1.0 - (((float) frame_number - ((float) end_frame - fade_out_value)) / fade_out_value);
+				fade_in_percentage = fade_in_value > 0.0
+					? ((float) frame_number - (float) start_frame) / fade_in_value
+					: 1.0;
+				fade_out_percentage = fade_out_value > 0.0
+					? 1.0 - (((float) frame_number - ((float) end_frame - fade_out_value)) / fade_out_value)
+					: -1.0;
 
 				// Loop through words, and find word-wrap boundaries
 				QStringList words = line.split(" ");
@@ -317,6 +327,8 @@ std::shared_ptr<openshot::Frame> Caption::GetFrame(std::shared_ptr<openshot::Fra
 	background_brush.setStyle(Qt::SolidPattern);
 	painter.setBrush(background_brush);
 	painter.setPen(Qt::NoPen);
+	painter.save();
+	painter.setClipRect(caption_clip_area);
 	painter.drawRoundedRect(caption_area_with_padding, background_corner_value, background_corner_value);
 
 	// Set fill-color of text
@@ -360,6 +372,7 @@ std::shared_ptr<openshot::Frame> Caption::GetFrame(std::shared_ptr<openshot::Fra
 		painter.setBrush(font_brush);
 		painter.drawPath(path);
 	}
+	painter.restore();
 
 	// End painter
 	painter.end();
@@ -396,6 +409,7 @@ Json::Value Caption::JsonValue() const {
 	root["left"] = left.JsonValue();
 	root["top"] = top.JsonValue();
 	root["right"] = right.JsonValue();
+	root["bottom"] = bottom.JsonValue();
 	root["caption_text"] = caption_text;
 	root["caption_font"] = font_name;
 
@@ -457,6 +471,8 @@ void Caption::SetJsonValue(const Json::Value root) {
 		top.SetJsonValue(root["top"]);
 	if (!root["right"].isNull())
 		right.SetJsonValue(root["right"]);
+	if (!root["bottom"].isNull())
+		bottom.SetJsonValue(root["bottom"]);
 	if (!root["caption_text"].isNull())
 		caption_text = root["caption_text"].asString();
 	if (!root["caption_font"].isNull())
@@ -497,6 +513,7 @@ std::string Caption::PropertiesJSON(int64_t requested_frame) const {
 	root["left"] = add_property_json("Margin: Left", left.GetValue(requested_frame), "float", "", &left, 0.0, 0.5, false, requested_frame);
 	root["top"] = add_property_json("Margin: Top", top.GetValue(requested_frame), "float", "", &top, 0.0, 1.0, false, requested_frame);
 	root["right"] = add_property_json("Margin: Right", right.GetValue(requested_frame), "float", "", &right, 0.0, 0.5, false, requested_frame);
+	root["bottom"] = add_property_json("Margin: Bottom", bottom.GetValue(requested_frame), "float", "", &bottom, 0.0, 1.0, false, requested_frame);
 	root["caption_text"] = add_property_json("Captions", 0.0, "caption", caption_text, NULL, -1, -1, false, requested_frame);
 	root["caption_font"] = add_property_json("Font", 0.0, "font", font_name, NULL, -1, -1, false, requested_frame);
 

--- a/src/effects/Caption.cpp
+++ b/src/effects/Caption.cpp
@@ -494,9 +494,9 @@ std::string Caption::PropertiesJSON(int64_t requested_frame) const {
 	root["fade_in"] = add_property_json("Fade In (Seconds)", fade_in.GetValue(requested_frame), "float", "", &fade_in, 0.0, 3.0, false, requested_frame);
 	root["fade_out"] = add_property_json("Fade Out (Seconds)", fade_out.GetValue(requested_frame), "float", "", &fade_out, 0.0, 3.0, false, requested_frame);
 	root["line_spacing"] = add_property_json("Line Spacing", line_spacing.GetValue(requested_frame), "float", "", &line_spacing, 0.0, 5.0, false, requested_frame);
-	root["left"] = add_property_json("Left Size", left.GetValue(requested_frame), "float", "", &left, 0.0, 0.5, false, requested_frame);
-	root["top"] = add_property_json("Top Size", top.GetValue(requested_frame), "float", "", &top, 0.0, 1.0, false, requested_frame);
-	root["right"] = add_property_json("Right Size", right.GetValue(requested_frame), "float", "", &right, 0.0, 0.5, false, requested_frame);
+	root["left"] = add_property_json("Margin: Left", left.GetValue(requested_frame), "float", "", &left, 0.0, 0.5, false, requested_frame);
+	root["top"] = add_property_json("Margin: Top", top.GetValue(requested_frame), "float", "", &top, 0.0, 1.0, false, requested_frame);
+	root["right"] = add_property_json("Margin: Right", right.GetValue(requested_frame), "float", "", &right, 0.0, 0.5, false, requested_frame);
 	root["caption_text"] = add_property_json("Captions", 0.0, "caption", caption_text, NULL, -1, -1, false, requested_frame);
 	root["caption_font"] = add_property_json("Font", 0.0, "font", font_name, NULL, -1, -1, false, requested_frame);
 

--- a/src/effects/Caption.h
+++ b/src/effects/Caption.h
@@ -65,6 +65,7 @@ public:
 	Keyframe left;		 ///< Size of left bar
 	Keyframe top;		 ///< Size of top bar
 	Keyframe right;		 ///< Size of right bar
+	Keyframe bottom;	 ///< Size of bottom bar
 	Keyframe fade_in;		 ///< Fade in per caption (# of seconds)
 	Keyframe fade_out;		 ///< Fade in per caption (# of seconds)
 	std::string font_name;	///< Font string

--- a/src/effects/Crop.cpp
+++ b/src/effects/Crop.cpp
@@ -187,10 +187,10 @@ std::string Crop::PropertiesJSON(int64_t requested_frame) const {
 	Json::Value root = BasePropertiesJSON(requested_frame);
 
 	// Keyframes
-	root["left"] = add_property_json("Left Size", left.GetValue(requested_frame), "float", "", &left, 0.0, 1.0, false, requested_frame);
-	root["top"] = add_property_json("Top Size", top.GetValue(requested_frame), "float", "", &top, 0.0, 1.0, false, requested_frame);
-	root["right"] = add_property_json("Right Size", right.GetValue(requested_frame), "float", "", &right, 0.0, 1.0, false, requested_frame);
-	root["bottom"] = add_property_json("Bottom Size", bottom.GetValue(requested_frame), "float", "", &bottom, 0.0, 1.0, false, requested_frame);
+	root["left"] = add_property_json("Margin: Left", left.GetValue(requested_frame), "float", "", &left, 0.0, 1.0, false, requested_frame);
+	root["top"] = add_property_json("Margin: Top", top.GetValue(requested_frame), "float", "", &top, 0.0, 1.0, false, requested_frame);
+	root["right"] = add_property_json("Margin: Right", right.GetValue(requested_frame), "float", "", &right, 0.0, 1.0, false, requested_frame);
+	root["bottom"] = add_property_json("Margin: Bottom", bottom.GetValue(requested_frame), "float", "", &bottom, 0.0, 1.0, false, requested_frame);
 	root["x"] = add_property_json("X Offset", x.GetValue(requested_frame), "float", "", &x, -1.0, 1.0, false, requested_frame);
 	root["y"] = add_property_json("Y Offset", y.GetValue(requested_frame), "float", "", &y, -1.0, 1.0, false, requested_frame);
 

--- a/src/effects/ObjectDetection.cpp
+++ b/src/effects/ObjectDetection.cpp
@@ -23,6 +23,8 @@
 
 #include <QImage>
 #include <QPainter>
+#include <QBrush>
+#include <QColor>
 #include <QRectF>
 #include <QString>
 #include <QStringList>
@@ -305,6 +307,68 @@ std::string ObjectDetection::GetVisibleObjects(int64_t frame_number) const{
 	}
 
 	return root.toStyledString();
+}
+
+std::shared_ptr<QImage> ObjectDetection::TrackedObjectMask(std::shared_ptr<QImage> target_image, int64_t frame_number) const {
+	if (!target_image || target_image->isNull())
+		return {};
+
+	auto detections_it = detectionsData.find(frame_number);
+	if (detections_it == detectionsData.end())
+		return {};
+
+	auto mask_image = std::make_shared<QImage>(
+		target_image->width(), target_image->height(), QImage::Format_RGBA8888_Premultiplied);
+	mask_image->fill(QColor(0, 0, 0, 255));
+
+	QPainter painter(mask_image.get());
+	painter.setRenderHint(QPainter::Antialiasing, false);
+	painter.setPen(Qt::NoPen);
+	painter.setBrush(QBrush(QColor(255, 255, 255, 255)));
+
+	bool drew_any_box = false;
+	const DetectionData& detections = detections_it->second;
+	for (int i = 0; i < detections.boxes.size(); i++) {
+		if (detections.confidences.at(i) < confidence_threshold)
+			continue;
+
+		const int class_id = detections.classIds.at(i);
+		if (class_id < 0 || class_id >= classNames.size())
+			continue;
+
+		const std::string class_name = classNames[class_id];
+		if (!display_classes.empty() &&
+			std::find(display_classes.begin(), display_classes.end(), class_name) == display_classes.end()) {
+			continue;
+		}
+
+		int object_id = detections.objectIds.at(i);
+		auto tracked_object_it = trackedObjects.find(object_id);
+		if (tracked_object_it == trackedObjects.end() || !tracked_object_it->second)
+			continue;
+
+		auto tracked_object = std::static_pointer_cast<TrackedObjectBBox>(tracked_object_it->second);
+		if (!tracked_object->ExactlyContains(frame_number) ||
+			tracked_object->visible.GetValue(frame_number) != 1) {
+			continue;
+		}
+
+		BBox box = tracked_object->GetBox(frame_number);
+		if (box.width <= 0.0f || box.height <= 0.0f || box.cx < 0.0f || box.cy < 0.0f)
+			continue;
+
+		const double x = (box.cx - box.width / 2.0) * target_image->width();
+		const double y = (box.cy - box.height / 2.0) * target_image->height();
+		const double w = box.width * target_image->width();
+		const double h = box.height * target_image->height();
+		painter.drawRect(QRectF(x, y, w, h));
+		drew_any_box = true;
+	}
+
+	painter.end();
+	if (!drew_any_box)
+		return {};
+	return mask_image;
 }
 
 // Generate JSON string of this object

--- a/src/effects/ObjectDetection.h
+++ b/src/effects/ObjectDetection.h
@@ -104,6 +104,9 @@ namespace openshot
         /// Get the indexes and IDs of all visible objects in the given frame
         std::string GetVisibleObjects(int64_t frame_number) const override;
 
+        /// Generate a black/white mask from visible detected bounding boxes.
+        std::shared_ptr<QImage> TrackedObjectMask(std::shared_ptr<QImage> target_image, int64_t frame_number) const override;
+
         // Get and Set JSON methods
         std::string Json() const override; ///< Generate JSON string of this object
         void SetJson(const std::string value) override; ///< Load JSON string into this object

--- a/src/effects/Pixelate.cpp
+++ b/src/effects/Pixelate.cpp
@@ -198,10 +198,10 @@ std::string Pixelate::PropertiesJSON(int64_t requested_frame) const {
 
 	// Keyframes
 	root["pixelization"] = add_property_json("Pixelization", pixelization.GetValue(requested_frame), "float", "", &pixelization, 0.0, 0.9999, false, requested_frame);
-	root["left"] = add_property_json("Left Margin", left.GetValue(requested_frame), "float", "", &left, 0.0, 1.0, false, requested_frame);
-	root["top"] = add_property_json("Top Margin", top.GetValue(requested_frame), "float", "", &top, 0.0, 1.0, false, requested_frame);
-	root["right"] = add_property_json("Right Margin", right.GetValue(requested_frame), "float", "", &right, 0.0, 1.0, false, requested_frame);
-	root["bottom"] = add_property_json("Bottom Margin", bottom.GetValue(requested_frame), "float", "", &bottom, 0.0, 1.0, false, requested_frame);
+	root["left"] = add_property_json("Margin: Left", left.GetValue(requested_frame), "float", "", &left, 0.0, 1.0, false, requested_frame);
+	root["top"] = add_property_json("Margin: Top", top.GetValue(requested_frame), "float", "", &top, 0.0, 1.0, false, requested_frame);
+	root["right"] = add_property_json("Margin: Right", right.GetValue(requested_frame), "float", "", &right, 0.0, 1.0, false, requested_frame);
+	root["bottom"] = add_property_json("Margin: Bottom", bottom.GetValue(requested_frame), "float", "", &bottom, 0.0, 1.0, false, requested_frame);
 	root["mask_mode"] = add_property_json("Mask Mode", mask_mode, "int", "", NULL, 0, 1, false, requested_frame);
 	root["mask_mode"]["choices"].append(add_property_choice_json("Limit to Mask", PIXELATE_MASK_LIMIT_TO_AREA, mask_mode));
 	root["mask_mode"]["choices"].append(add_property_choice_json("Vary Strength", PIXELATE_MASK_VARY_STRENGTH, mask_mode));

--- a/tests/Blur.cpp
+++ b/tests/Blur.cpp
@@ -1,0 +1,60 @@
+/**
+ * @file
+ * @brief Unit tests for Blur effect
+ *
+ * @ref License
+ */
+
+// Copyright (c) 2008-2026 OpenShot Studios, LLC
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "openshot_catch.h"
+
+#include "Frame.h"
+#include "effects/Blur.h"
+
+#include <QColor>
+
+using namespace openshot;
+
+TEST_CASE("Blur margins limit affected area", "[effect][blur]") {
+	auto frame = std::make_shared<Frame>(1, 8, 1, "#000000");
+	auto image = frame->GetImage();
+
+	for (int x = 0; x < image->width(); ++x)
+		image->setPixelColor(x, 0, (x % 2 == 0) ? QColor(255, 255, 255, 255) : QColor(0, 0, 0, 255));
+
+	Blur effect(Keyframe(1.0), Keyframe(0.0), Keyframe(3.0), Keyframe(1.0),
+				Keyframe(0.5), Keyframe(0.0), Keyframe(0.0), Keyframe(0.0));
+	auto out = effect.GetFrame(frame, 1);
+	auto out_image = out->GetImage();
+
+	CHECK(out_image->pixelColor(0, 0) == QColor(255, 255, 255, 255));
+	CHECK(out_image->pixelColor(1, 0) == QColor(0, 0, 0, 255));
+	CHECK(out_image->pixelColor(2, 0) == QColor(255, 255, 255, 255));
+	CHECK(out_image->pixelColor(3, 0) == QColor(0, 0, 0, 255));
+
+	CHECK(out_image->pixelColor(4, 0).red() < 255);
+	CHECK(out_image->pixelColor(4, 0).red() > 0);
+	CHECK(out_image->pixelColor(5, 0).red() > 0);
+}
+
+TEST_CASE("Blur margin properties serialize", "[effect][blur][json]") {
+	Blur effect(Keyframe(6.0), Keyframe(6.0), Keyframe(3.0), Keyframe(3.0),
+				Keyframe(0.1), Keyframe(0.2), Keyframe(0.3), Keyframe(0.4));
+
+	Json::Value json = effect.JsonValue();
+	REQUIRE(json["left"].isObject());
+	REQUIRE(json["top"].isObject());
+	REQUIRE(json["right"].isObject());
+	REQUIRE(json["bottom"].isObject());
+
+	Blur copy;
+	copy.SetJsonValue(json);
+
+	CHECK(copy.left.GetValue(1) == Approx(0.1));
+	CHECK(copy.top.GetValue(1) == Approx(0.2));
+	CHECK(copy.right.GetValue(1) == Approx(0.3));
+	CHECK(copy.bottom.GetValue(1) == Approx(0.4));
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -54,6 +54,7 @@ set(OPENSHOT_TESTS
   # Effects
   AudioVisualization
   BeatSync
+  Blur
   ColorGrade
   ColorMap
   ChromaKey

--- a/tests/Caption.cpp
+++ b/tests/Caption.cpp
@@ -82,16 +82,30 @@ TEST_CASE("caption effect", "[libopenshot][caption]") {
         CHECK(c1.left.GetValue(1) == Approx(0.10f).margin(0.00001));
         CHECK(c1.right.GetValue(1) == Approx(0.10f).margin(0.00001));
         CHECK(c1.top.GetValue(1) == Approx(0.75).margin(0.00001));
+        CHECK(c1.bottom.GetValue(1) == Approx(0.0).margin(0.00001));
         CHECK(c1.stroke_width.GetValue(1) == Approx(0.5f).margin(0.00001));
         CHECK(c1.font_size.GetValue(1) == Approx(30.0f).margin(0.00001));
         CHECK(c1.font_alpha.GetValue(1) == Approx(1.0f).margin(0.00001));
         CHECK(c1.font_name == "sans");
-        CHECK(c1.fade_in.GetValue(1) == Approx(0.35f).margin(0.00001));
-        CHECK(c1.fade_out.GetValue(1) == Approx(0.35f).margin(0.00001));
+        CHECK(c1.fade_in.GetValue(1) == Approx(0.0f).margin(0.00001));
+        CHECK(c1.fade_out.GetValue(1) == Approx(0.0f).margin(0.00001));
         CHECK(c1.background_corner.GetValue(1) == Approx(10.0f).margin(0.00001));
         CHECK(c1.background_padding.GetValue(1) == Approx(20.0f).margin(0.00001));
         CHECK(c1.line_spacing.GetValue(1) == Approx(1.0f).margin(0.00001));
         CHECK(c1.CaptionText() == "00:00:00:000 --> 00:10:00:000\nEdit this caption with our caption editor");
+
+        Json::Value caption_json = c1.JsonValue();
+        REQUIRE(caption_json["bottom"].isObject());
+        caption_json["bottom"] = openshot::Keyframe(0.25).JsonValue();
+        openshot::Caption c2;
+        c2.SetJsonValue(caption_json);
+        CHECK(c2.bottom.GetValue(1) == Approx(0.25).margin(0.00001));
+
+        Json::Value properties = openshot::stringToJson(c1.PropertiesJSON(1));
+        CHECK(properties["top"]["name"].asString() == "Margin: Top");
+        CHECK(properties["left"]["name"].asString() == "Margin: Left");
+        CHECK(properties["bottom"]["name"].asString() == "Margin: Bottom");
+        CHECK(properties["right"]["name"].asString() == "Margin: Right");
 
         // Load clip with video
         std::stringstream path;

--- a/tests/EffectMask.cpp
+++ b/tests/EffectMask.cpp
@@ -27,6 +27,7 @@
 #include "effects/Pixelate.h"
 #include "effects/Saturation.h"
 #include "effects/Sharpen.h"
+#include "effects/Tracker.h"
 #include "QtImageReader.h"
 #include "openshot_catch.h"
 
@@ -153,17 +154,70 @@ TEST_CASE("EffectBase mask fields serialize and deserialize", "[effect][mask][js
 
 	Brightness effect(Keyframe(0.0), Keyframe(0.0));
 	effect.mask_invert = true;
+	effect.MaskSourceId("tracker-effect-id");
 	effect.MaskReader(new QtImageReader(mask_path));
 
 	const Json::Value json = effect.JsonValue();
 	CHECK(json["mask_invert"].asBool());
+	CHECK(json["mask_source_id"].asString() == "tracker-effect-id");
 	REQUIRE(json["mask_reader"].isObject());
 	CHECK(json["mask_reader"]["type"].asString() == "QtImageReader");
 
 	Brightness copy(Keyframe(0.0), Keyframe(0.0));
 	copy.SetJsonValue(json);
 	CHECK(copy.mask_invert);
+	CHECK(copy.MaskSourceId() == "tracker-effect-id");
 	CHECK(copy.MaskReader() != nullptr);
+}
+
+TEST_CASE("EffectBase can use tracker effect bbox as generated mask source", "[effect][mask][tracker]") {
+	Clip parent_clip;
+	Tracker tracker;
+	tracker.Id("tracker-source");
+	tracker.trackedData->SetBaseFPS(Fraction(30, 1));
+	tracker.trackedData->AddBox(1, 0.25f, 0.5f, 0.5f, 1.0f, 0.0f);
+	tracker.trackedData->draw_box = Keyframe(0.0);
+
+	Brightness brightness(Keyframe(0.8), Keyframe(0.0));
+	brightness.MaskSourceId("tracker-source");
+
+	parent_clip.AddEffect(&tracker);
+	parent_clip.AddEffect(&brightness);
+
+	auto frame = std::make_shared<Frame>(1, 4, 1, "#000000");
+	frame->GetImage()->fill(QColor(80, 80, 80, 255));
+
+	auto out = brightness.ProcessFrame(frame, 1);
+	auto out_image = out->GetImage();
+
+	CHECK(out_image->pixelColor(0, 0).red() > 80);
+	CHECK(out_image->pixelColor(1, 0).red() > 80);
+	CHECK(out_image->pixelColor(2, 0).red() == 80);
+	CHECK(out_image->pixelColor(3, 0).red() == 80);
+}
+
+TEST_CASE("EffectBase tracker mask source with no visible bbox preserves original frame", "[effect][mask][tracker]") {
+	Clip parent_clip;
+	Tracker tracker;
+	tracker.Id("tracker-source");
+	tracker.trackedData->SetBaseFPS(Fraction(30, 1));
+	tracker.trackedData->AddBox(1, 0.25f, 0.5f, 0.5f, 1.0f, 0.0f);
+	tracker.trackedData->visible = Keyframe(0.0);
+
+	Brightness brightness(Keyframe(0.8), Keyframe(0.0));
+	brightness.MaskSourceId("tracker-source");
+
+	parent_clip.AddEffect(&tracker);
+	parent_clip.AddEffect(&brightness);
+
+	auto frame = std::make_shared<Frame>(1, 4, 1, "#000000");
+	frame->GetImage()->fill(QColor(80, 80, 80, 255));
+
+	auto out = brightness.ProcessFrame(frame, 1);
+	auto out_image = out->GetImage();
+
+	for (int x = 0; x < 4; ++x)
+		CHECK(out_image->pixelColor(x, 0).red() == 80);
 }
 
 TEST_CASE("Blur mask mode drive amount differs from post blend", "[effect][mask][blur]") {


### PR DESCRIPTION
Adding the ability to use TrackedObjectMask as "Mask: Source" for any effect (i.e. blur/pixilate only the tracked area)

- Add tracked effect IDs as mask sources
- Generate bbox masks from Tracker/Object Detection
- Preserve original frame when no bbox is visible
- Add focused mask-source tests