### PR TITLE
Clean-up and modernization of our cmake build system

### DIFF
--- a/bindings/java/CMakeLists.txt
+++ b/bindings/java/CMakeLists.txt
@@ -12,12 +12,12 @@
 find_package(SWIG 4.0 REQUIRED)
 include(${SWIG_USE_FILE})
 
-### Enable some legacy SWIG behaviors in newer CMake versions
+### Use modern SWIG target behavior when available
 if (POLICY CMP0078)
-    cmake_policy(SET CMP0078 OLD)
+    cmake_policy(SET CMP0078 NEW)
 endif()
 if (POLICY CMP0086)
-    cmake_policy(SET CMP0086 OLD)
+    cmake_policy(SET CMP0086 NEW)
 endif()
 
 find_package(Java REQUIRED)
@@ -25,8 +25,6 @@ include(UseJava)
 
 find_package(JNI REQUIRED)
 include_directories(${JNI_INCLUDE_DIRS})
-message(STATUS "JNI_INCLUDE_DIRS=${JNI_INCLUDE_DIRS}")
-message(STATUS "JNI_LIBRARIES=${JNI_LIBRARIES}")
 
 ### Enable C++ in SWIG
 set_property(SOURCE openshot.i PROPERTY CPLUSPLUS ON)
@@ -34,7 +32,7 @@ set_property(SOURCE openshot.i PROPERTY SWIG_MODULE_NAME openshot)
 
 ### Set the swig package name for the JAR
 set_source_files_properties(openshot.i PROPERTIES
-        SWIG_FLAGS "-package;org.openshot"
+        SWIG_FLAGS "-package;org.openshot;-w503,516,813,822"
 )
 
 ### Suppress a ton of warnings in the generated SWIG C++ code
@@ -51,7 +49,6 @@ elseif(CMAKE_VERSION VERSION_GREATER 3.12)
     set(_inc $<TARGET_PROPERTY:openshot,INCLUDE_DIRECTORIES>)
 endif()
 if (DEFINED _inc)
-    message(STATUS "Include directories: ${_inc}")
     set_property(SOURCE openshot.i PROPERTY INCLUDE_DIRECTORIES ${_inc})
 endif()
 
@@ -61,10 +58,12 @@ if (CMAKE_VERSION VERSION_GREATER 3.20)
 endif()
 
 ### Add the SWIG interface file (which defines all the SWIG methods)
-if (CMAKE_VERSION VERSION_LESS 3.8.0)
-    swig_add_module(openshot-java java openshot.i)
+swig_add_library(openshot-java LANGUAGE java SOURCES openshot.i)
+
+if (POLICY CMP0078)
+    set(_openshot_java_target openshot-java)
 else()
-    swig_add_library(openshot-java LANGUAGE java SOURCES openshot.i)
+    set(_openshot_java_target ${SWIG_MODULE_openshot-java_REAL_NAME})
 endif()
 
 ### Set the prefix for the library to 'lib'
@@ -72,10 +71,9 @@ endif()
 
 ### Compile the generated wrapper file
 get_property(_java_files TARGET openshot-java PROPERTY SWIG_SUPPORT_FILES)
-message("_java_files: ${_java_files}")
 
 ### Link the new Java wrapper library with libopenshot
-target_link_libraries(${SWIG_MODULE_openshot-java_REAL_NAME} PUBLIC
+target_link_libraries(${_openshot_java_target} PUBLIC
         ${JNI_LIBRARIES} openshot)
 
 ### Create a custom target for the JAR file
@@ -83,7 +81,7 @@ add_custom_command(
         OUTPUT ${CMAKE_BINARY_DIR}/bindings/java/openshotJNI.jar
         COMMAND ${Java_JAVAC_EXECUTABLE} -d ${CMAKE_BINARY_DIR}/bindings/java ${CMAKE_BINARY_DIR}/bindings/java/*.java
         COMMAND ${Java_JAR_EXECUTABLE} -cf ${CMAKE_BINARY_DIR}/bindings/java/openshotJNI.jar -C ${CMAKE_BINARY_DIR}/bindings/java .
-        DEPENDS openshot-java
+        DEPENDS ${_openshot_java_target}
         WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bindings/java
         COMMENT "Creating openshotJNI.jar"
 )

--- a/bindings/java/openshot.i
+++ b/bindings/java/openshot.i
@@ -14,6 +14,12 @@
 /* Suppress warnings about ignored operator= */
 %warnfilter(362);
 
+/* JUCE thread internals are implementation details, not binding API */
+%ignore juce::Thread;
+namespace juce {
+    class Thread {};
+}
+
 /* Don't generate multiple wrappers for functions with default args */
 %feature("compactdefaultargs", "1");
 

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -12,16 +12,29 @@
 find_package(SWIG 3.0 REQUIRED)
 include(${SWIG_USE_FILE})
 
-### Enable some legacy SWIG behaviors, in newer CMAKEs
+### Use modern SWIG target behavior when available
 if (POLICY CMP0078)
-  cmake_policy(SET CMP0078 OLD)
+  cmake_policy(SET CMP0078 NEW)
 endif()
 if (POLICY CMP0086)
-  cmake_policy(SET CMP0086 OLD)
+  cmake_policy(SET CMP0086 NEW)
 endif()
 
-find_package(PythonInterp 3)
-find_package(PythonLibs 3)
+if (CMAKE_VERSION VERSION_LESS 3.12)
+  find_package(PythonInterp 3)
+  find_package(PythonLibs 3)
+else()
+  find_package(Python3 3 COMPONENTS Interpreter Development)
+  if (Python3_FOUND)
+    set(PYTHON_EXECUTABLE "${Python3_EXECUTABLE}")
+    set(PYTHON_INCLUDE_PATH "${Python3_INCLUDE_DIRS}")
+    set(PYTHON_LIBRARIES "${Python3_LIBRARIES}")
+    set(PYTHON_VERSION_MAJOR "${Python3_VERSION_MAJOR}")
+    set(PYTHON_VERSION_MINOR "${Python3_VERSION_MINOR}")
+    set(PYTHONINTERP_FOUND TRUE)
+    set(PYTHONLIBS_FOUND TRUE)
+  endif()
+endif()
 
 if (NOT PYTHONLIBS_FOUND OR NOT PYTHONINTERP_FOUND)
   return()
@@ -85,18 +98,20 @@ if (CMAKE_VERSION VERSION_GREATER 3.20)
 endif()
 
 ### Add the SWIG interface file (which defines all the SWIG methods)
-if (CMAKE_VERSION VERSION_LESS 3.8.0)
-  swig_add_module(pyopenshot python openshot.i)
+swig_add_library(pyopenshot LANGUAGE python SOURCES openshot.i)
+
+if (POLICY CMP0078)
+  set(_pyopenshot_target pyopenshot)
 else()
-  swig_add_library(pyopenshot LANGUAGE python SOURCES openshot.i)
+  set(_pyopenshot_target ${SWIG_MODULE_pyopenshot_REAL_NAME})
 endif()
 
 ### Set output name of target
-set_target_properties(${SWIG_MODULE_pyopenshot_REAL_NAME} PROPERTIES
+set_target_properties(${_pyopenshot_target} PROPERTIES
   PREFIX "_" OUTPUT_NAME "openshot")
 
 ### Link the new python wrapper library with libopenshot
-target_link_libraries(${SWIG_MODULE_pyopenshot_REAL_NAME} PUBLIC
+target_link_libraries(${_pyopenshot_target} PUBLIC
   ${PYTHON_LIBRARIES} openshot)
 
 ######### INSTALL PATH ########
@@ -128,7 +143,7 @@ message(STATUS "PYTHON_MODULE_PATH: ${CMAKE_INSTALL_PREFIX}/${PYTHON_MODULE_PATH
 
 ############### INSTALL HEADERS & LIBRARY ################
 ### Install Python bindings
-install(TARGETS ${SWIG_MODULE_pyopenshot_REAL_NAME}
+install(TARGETS ${_pyopenshot_target}
   DESTINATION ${PYTHON_MODULE_PATH} )
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/openshot.py
   DESTINATION ${PYTHON_MODULE_PATH} )

--- a/bindings/python/openshot.i
+++ b/bindings/python/openshot.i
@@ -14,6 +14,12 @@
 /* Suppress warnings about ignored operator= */
 %warnfilter(362);
 
+/* JUCE thread internals are implementation details, not binding API */
+%ignore juce::Thread;
+namespace juce {
+    class Thread {};
+}
+
 /* Don't generate multiple wrappers for functions with default args */
 %feature("compactdefaultargs", "1");
 
@@ -248,7 +254,7 @@ static int openshot_swig_is_qwidget(PyObject *obj) {
     $1 = reinterpret_cast<QWidget*>(ptr);
 }
 
-%typemap(typecheck) QWidget * {
+%typemap(typecheck, precedence=SWIG_TYPECHECK_POINTER) QWidget * {
     $1 = openshot_swig_is_qwidget($input);
 }
 

--- a/bindings/ruby/CMakeLists.txt
+++ b/bindings/ruby/CMakeLists.txt
@@ -12,12 +12,12 @@
 find_package(SWIG 3.0 REQUIRED)
 include(${SWIG_USE_FILE})
 
-### Enable some legacy SWIG behaviors, in newer CMAKEs
+### Use modern SWIG target behavior when available
 if (POLICY CMP0078)
-	cmake_policy(SET CMP0078 OLD)
+	cmake_policy(SET CMP0078 NEW)
 endif()
 if (POLICY CMP0086)
-	cmake_policy(SET CMP0086 OLD)
+	cmake_policy(SET CMP0086 NEW)
 endif()
 
 find_package(Ruby)
@@ -102,10 +102,12 @@ if (CMAKE_VERSION VERSION_GREATER 3.20)
 endif()
 
 ### Add the SWIG interface file (which defines all the SWIG methods)
-if (CMAKE_VERSION VERSION_LESS 3.8.0)
-	swig_add_module(rbopenshot ruby openshot.i)
+swig_add_library(rbopenshot LANGUAGE ruby SOURCES openshot.i)
+
+if (POLICY CMP0078)
+  set(_rbopenshot_target rbopenshot)
 else()
-	swig_add_library(rbopenshot LANGUAGE ruby SOURCES openshot.i)
+  set(_rbopenshot_target ${SWIG_MODULE_rbopenshot_REAL_NAME})
 endif()
 
 ### Set name of target (with no prefix, since Ruby does not like that)
@@ -113,11 +115,11 @@ endif()
 #      e.g. rbopenshot.so, but its initializer method will be named
 #      'Init_openshot()' (via the module name set in the SWIG .i file).
 #      Which leads to Ruby barfing when it attempts to load the module.
-set_target_properties(${SWIG_MODULE_rbopenshot_REAL_NAME} PROPERTIES
+set_target_properties(${_rbopenshot_target} PROPERTIES
   PREFIX "" OUTPUT_NAME "openshot")
 
 ### Link the new Ruby wrapper library with libopenshot
-target_link_libraries(${SWIG_MODULE_rbopenshot_REAL_NAME} PUBLIC
+target_link_libraries(${_rbopenshot_target} PUBLIC
     ${RUBY_LIBRARY} openshot)
 
 ######### INSTALL PATH ########
@@ -147,5 +149,5 @@ message(STATUS "RUBY_MODULE_PATH: ${CMAKE_INSTALL_PREFIX}/${RUBY_MODULE_PATH}")
 
 ############### INSTALL HEADERS & LIBRARY ################
 # Install Ruby bindings
-install(TARGETS ${SWIG_MODULE_rbopenshot_REAL_NAME}
+install(TARGETS ${_rbopenshot_target}
   DESTINATION ${RUBY_MODULE_PATH} )

--- a/bindings/ruby/openshot.i
+++ b/bindings/ruby/openshot.i
@@ -14,6 +14,21 @@
 /* Suppress warnings about ignored operator= */
 %warnfilter(362);
 
+/* JUCE thread internals are implementation details, not binding API */
+%ignore juce::Thread;
+namespace juce {
+    class Thread {};
+}
+
+/* Ruby bindings intentionally expose the primary OpenShot base class only */
+%warnfilter(802) openshot::Clip;
+%warnfilter(802) openshot::Timeline;
+
+/* Ruby bindings do not expose Profile comparison operators */
+%warnfilter(503) operator<;
+%warnfilter(503) operator>;
+%warnfilter(503) operator==;
+
 /* Don't generate multiple wrappers for functions with default args */
 %feature("compactdefaultargs", "1");
 

--- a/cmake/Modules/Findbabl.cmake
+++ b/cmake/Modules/Findbabl.cmake
@@ -20,7 +20,7 @@ function(_babl_GET_VERSION _header)
 endfunction()
 
 find_package(PkgConfig)
-pkg_check_modules(PC_BABL babl)
+pkg_check_modules(PC_BABL QUIET babl)
 
 set(babl_VERSION ${PC_BABL_VERSION})
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -393,7 +393,7 @@ mark_as_advanced(QT_VERSION_STR)
 # Find FFmpeg libraries (used for video encoding / decoding)
 find_package(FFmpeg REQUIRED
   COMPONENTS avcodec avformat avutil swscale
-  OPTIONAL_COMPONENTS swresample avresample
+  OPTIONAL_COMPONENTS swresample
 )
 
 set(all_comps avcodec avformat avutil swscale)
@@ -404,6 +404,7 @@ if(TARGET FFmpeg::swresample)
   set(resample_lib swresample)
   set(USE_SW TRUE)
 else()
+  find_package(FFmpeg REQUIRED COMPONENTS avresample)
   set(resample_lib avresample)
   set(USE_SW FALSE)
 endif()


### PR DESCRIPTION
- Modernized SWIG policy handling for Python, Ruby, and Java without raising the project-wide CMake policy version.
- Switched Python discovery to Python3 on CMake 3.12+, with legacy PythonInterp/PythonLibs fallback for older CMake.
- Removed dead pre-CMake-3.8 SWIG branches.
- Quieted optional babl pkg-config probing.
- Changed FFmpeg probing so avresample is only checked if swresample is unavailable.
- Cleaned Java binding debug configure messages.
- Addressed the SWIG build warnings:
  - Added SWIG-only juce::Thread declaration for Python/Ruby/Java.
  - Added Python QWidget typecheck precedence.
  - Filtered known Ruby binding limitations for multiple inheritance and unexposed Profile operators.
  - Suppressed Java-only SWIG categories for unsupported operators/proxy limitations via Java SWIG flags.