### PR TITLE
AudioLocation.h: add missing <cstdint> include

### DIFF
--- a/src/AudioLocation.h
+++ b/src/AudioLocation.h
@@ -13,6 +13,7 @@
 #ifndef OPENSHOT_AUDIOLOCATION_H
 #define OPENSHOT_AUDIOLOCATION_H
 
+#include <cstdint>
 
 namespace openshot
 {


### PR DESCRIPTION
## Summary
One-line fix: add `#include <cstdint>` to `src/AudioLocation.h`.

The struct uses `int64_t` but relied on it arriving via transitive includes. GCC 16 no longer provides `int64_t` transitively, so the struct definition fails to parse:

```
H:/libopenshot/src/AudioLocation.h:26:17: error: 'int64_t' does not name a type
   26 |                 int64_t frame;
      |                 ^~~~~~~
```

which cascades into misleading `struct openshot::AudioLocation has no member named frame` errors at every use site in `Clip.cpp`.

Making the header self-contained fixes the build with no behavior change.

## Testing
- Full build passes on Windows/MSYS2 (MinGW-w64 GCC 16.2.0)
- Header-only change; no effect on FFmpeg/OpenCV code paths or older compilers