### PR TITLE
Fix non-OpenCV build: guard TrackedObjectBBox usage, move EffectMask test

### DIFF
--- a/src/EffectBase.cpp
+++ b/src/EffectBase.cpp
@@ -548,6 +548,12 @@ std::shared_ptr<QImage> EffectBase::GetMaskImage(std::shared_ptr<QImage> target_
 }
 
 std::shared_ptr<QImage> EffectBase::TrackedObjectMask(std::shared_ptr<QImage> target_image, int64_t frame_number) const {
+#ifndef USE_OPENCV
+	// Tracked-object bounding boxes are only produced by OpenCV-based
+	// trackers; without OpenCV there is nothing to draw a mask for.
+	(void)frame_number;
+	return {};
+#else
 	if (!target_image || target_image->isNull() || trackedObjects.empty())
 		return {};
 
@@ -595,6 +601,7 @@ std::shared_ptr<QImage> EffectBase::TrackedObjectMask(std::shared_ptr<QImage> ta
 	if (!drew_any_box)
 		return {};
 	return mask_image;
+#endif
 }
 
 void EffectBase::BlendWithMask(std::shared_ptr<QImage> original_image, std::shared_ptr<QImage> effected_image,

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -69,7 +69,6 @@ set(OPENSHOT_TESTS
   LensFlare
   AnalogTape
   BenchmarkArgs
-  EffectMask
   Mask
   Pixelate
   Saturation
@@ -96,6 +95,7 @@ if($CACHE{HAVE_OPENCV})
     CVStabilizer
     CVOutline
     ObjectMask
+    EffectMask
     # CVObjectDetection
   )
 endif()


### PR DESCRIPTION
## Summary
Two small fixes so the project builds with `ENABLE_OPENCV=OFF` (currently it fails to link):

**1. `EffectBase::TrackedObjectMask()` linker errors**

The method dereferences `TrackedObjectBBox::Contains()` / `GetBox()` unconditionally, but `TrackedObjectBBox.cpp` is only compiled when OpenCV is enabled (it lives in `OPENSHOT_CV_SOURCES`). Every non-OpenCV build dies with:

```
undefined reference to `openshot::TrackedObjectBBox::Contains(long long) const'
undefined reference to `openshot::TrackedObjectBBox::GetBox(long long)'
```

Guarded the body with `#ifndef USE_OPENCV`, returning an empty mask. This is semantically correct: bounding boxes are only ever produced by the OpenCV-based trackers, so with OpenCV absent there is nothing to draw. Behavior for OpenCV builds is unchanged.

**2. `tests/EffectMask.cpp` unconditionally registered**

The test includes `<opencv2/dnn.hpp>` but was listed in the always-built `OPENSHOT_TESTS` instead of the existing `if($CACHE{HAVE_OPENCV})` block, failing test-suite compilation without OpenCV. Moved it under the guard, losing no coverage (it could never build without OpenCV).

## Testing
- Windows/MSYS2 (MinGW-w64 GCC 16.2.0): full build including unit tests and `openshot-player` example passes with `ENABLE_OPENCV=OFF`
- OpenCV builds take the unchanged code path