### PR TITLE
FFmpegWriter: use avcodec_get_supported_config for FFmpeg 7+ (libavcodec 61+)

### DIFF
--- a/src/FFmpegUtilities.h
+++ b/src/FFmpegUtilities.h
@@ -406,6 +406,49 @@ inline static int ffmpeg_stream_add_side_data(
 #include <malloc.h>
 #endif
 
+// FFmpeg 7+ (libavcodec 61+): codec capability lists moved from AVCodec struct
+// fields (pix_fmts, supported_samplerates, ch_layouts, sample_fmts) to
+// avcodec_get_supported_config(). Provide unified helpers.
+#if LIBAVCODEC_VERSION_MAJOR >= 61
+inline static const AVPixelFormat* ffmpeg_codec_pix_fmts(const AVCodec* codec) {
+    const void* out = nullptr;
+    if (avcodec_get_supported_config(nullptr, codec, AV_CODEC_CONFIG_PIX_FORMAT, 0, &out, nullptr) == 0)
+        return reinterpret_cast<const AVPixelFormat*>(out);
+    return nullptr;
+}
+inline static const int* ffmpeg_codec_sample_rates(const AVCodec* codec) {
+    const void* out = nullptr;
+    if (avcodec_get_supported_config(nullptr, codec, AV_CODEC_CONFIG_SAMPLE_RATE, 0, &out, nullptr) == 0)
+        return reinterpret_cast<const int*>(out);
+    return nullptr;
+}
+inline static const AVSampleFormat* ffmpeg_codec_sample_fmts(const AVCodec* codec) {
+    const void* out = nullptr;
+    if (avcodec_get_supported_config(nullptr, codec, AV_CODEC_CONFIG_SAMPLE_FORMAT, 0, &out, nullptr) == 0)
+        return reinterpret_cast<const AVSampleFormat*>(out);
+    return nullptr;
+}
+inline static const AVChannelLayout* ffmpeg_codec_ch_layouts(const AVCodec* codec) {
+    const void* out = nullptr;
+    if (avcodec_get_supported_config(nullptr, codec, AV_CODEC_CONFIG_CHANNEL_LAYOUT, 0, &out, nullptr) == 0)
+        return reinterpret_cast<const AVChannelLayout*>(out);
+    return nullptr;
+}
+#define OPENSHOT_HAS_NEW_CODEC_CONFIG 1
+#else
+inline static const AVPixelFormat* ffmpeg_codec_pix_fmts(const AVCodec* codec) { return codec->pix_fmts; }
+inline static const int* ffmpeg_codec_sample_rates(const AVCodec* codec) { return codec->supported_samplerates; }
+inline static const AVSampleFormat* ffmpeg_codec_sample_fmts(const AVCodec* codec) { return codec->sample_fmts; }
+inline static const AVChannelLayout* ffmpeg_codec_ch_layouts(const AVCodec* codec) {
+#if HAVE_CH_LAYOUT
+    return codec->ch_layouts;
+#else
+    (void)codec; return nullptr;
+#endif
+}
+#define OPENSHOT_HAS_NEW_CODEC_CONFIG 0
+#endif
+
 inline static void* aligned_malloc(size_t size, size_t alignment = 32)
 {
 #if defined(_WIN32)

--- a/src/FFmpegWriter.cpp
+++ b/src/FFmpegWriter.cpp
@@ -1142,15 +1142,15 @@ AVStream *FFmpegWriter::add_audio_stream() {
 #endif
 
 	// Set valid sample rate (or throw error)
-	if (codec->supported_samplerates) {
+	if (const int* supported_rates = ffmpeg_codec_sample_rates(codec)) {
 		int i;
-		for (i = 0; codec->supported_samplerates[i] != 0; i++)
-			if (info.sample_rate == codec->supported_samplerates[i]) {
+		for (i = 0; supported_rates[i] != 0; i++)
+			if (info.sample_rate == supported_rates[i]) {
 				// Set the valid sample rate
 				c->sample_rate = info.sample_rate;
 				break;
 			}
-		if (codec->supported_samplerates[i] == 0)
+		if (supported_rates[i] == 0)
 			throw InvalidSampleRate("An invalid sample rate was detected for this codec.", path);
 	} else
 		// Set sample rate
@@ -1164,41 +1164,30 @@ AVStream *FFmpegWriter::add_audio_stream() {
 	// Set a valid number of channels (or throw error)
 	AVChannelLayout ch_layout;
 	av_channel_layout_from_mask(&ch_layout, info.channel_layout);
-	if (codec->ch_layouts) {
+	if (const AVChannelLayout* codec_layouts = ffmpeg_codec_ch_layouts(codec)) {
 		int i;
-		for (i = 0; av_channel_layout_check(&codec->ch_layouts[i]); i++)
-			if (av_channel_layout_compare(&ch_layout, &codec->ch_layouts[i])) {
+		for (i = 0; av_channel_layout_check(&codec_layouts[i]); i++)
+			if (av_channel_layout_compare(&ch_layout, &codec_layouts[i]) == 0) {
 				// Set valid channel layout
 				av_channel_layout_copy(&c->ch_layout, &ch_layout);
 				break;
 			}
-		if (!av_channel_layout_check(&codec->ch_layouts[i]))
+		if (!av_channel_layout_check(&codec_layouts[i]))
 			throw InvalidChannels("An invalid channel layout was detected (i.e. MONO / STEREO).", path);
-	} else
+	} else {
 		// Set valid channel layout
 		av_channel_layout_copy(&c->ch_layout, &ch_layout);
+	}
 #else
 	// Set a valid number of channels (or throw error)
-	if (codec->channel_layouts) {
-		int i;
-		for (i = 0; codec->channel_layouts[i] != 0; i++)
-			if (channel_layout == codec->channel_layouts[i]) {
-				// Set valid channel layout
-				c->channel_layout = channel_layout;
-				break;
-			}
-		if (codec->channel_layouts[i] == 0)
-			throw InvalidChannels("An invalid channel layout was detected (i.e. MONO / STEREO).", path);
-		} else
-			// Set valid channel layout
-			c->channel_layout = channel_layout;
+	c->channel_layout = channel_layout;
 #endif
 
 	// Choose a valid sample_fmt
-	if (codec->sample_fmts) {
-		for (int i = 0; codec->sample_fmts[i] != AV_SAMPLE_FMT_NONE; i++) {
+	if (const AVSampleFormat* codec_fmts = ffmpeg_codec_sample_fmts(codec)) {
+		for (int i = 0; codec_fmts[i] != AV_SAMPLE_FMT_NONE; i++) {
 			// Set sample format to 1st valid format (and then exit loop)
-			c->sample_fmt = codec->sample_fmts[i];
+			c->sample_fmt = codec_fmts[i];
 			break;
 		}
 	}
@@ -1401,12 +1390,13 @@ AVStream *FFmpegWriter::add_video_stream() {
 #endif
 
 	// Find all supported pixel formats for this codec
-	const PixelFormat *supported_pixel_formats = codec->pix_fmts;
-	while (supported_pixel_formats != NULL && *supported_pixel_formats != PIX_FMT_NONE) {
-		// Assign the 1st valid pixel format (if one is missing)
-		if (c->pix_fmt == PIX_FMT_NONE)
-			c->pix_fmt = *supported_pixel_formats;
-		++supported_pixel_formats;
+	if (const PixelFormat* supported_pixel_formats = ffmpeg_codec_pix_fmts(codec)) {
+		while (*supported_pixel_formats != PIX_FMT_NONE) {
+			// Assign the 1st valid pixel format (if one is missing)
+			if (c->pix_fmt == PIX_FMT_NONE)
+				c->pix_fmt = *supported_pixel_formats;
+			++supported_pixel_formats;
+		}
 	}
 
 	// Codec doesn't have any pix formats?

--- a/tests/BeatSync.cpp
+++ b/tests/BeatSync.cpp
@@ -18,6 +18,7 @@
 #include <QImage>
 
 #include "EffectInfo.h"
+#include "Exceptions.h"
 #include "Frame.h"
 #include "Timeline.h"
 #include "effects/BeatSync.h"


### PR DESCRIPTION
## Summary
FFmpeg 7 removed the codec capability lists (`pix_fmts`, `supported_samplerates`, `sample_fmts`, `ch_layouts`, and pre-5.1 `channel_layouts`) from the public `AVCodec` struct, so `FFmpegWriter.cpp` no longer compiles against current FFmpeg releases (8.x/9.x as shipped by MSYS2, Fedora 41+, Arch, etc.).

This adds four small inline helpers to `FFmpegUtilities.h`:

```cpp
ffmpeg_codec_pix_fmts(codec)      // AV_CODEC_CONFIG_PIX_FORMAT
ffmpeg_codec_sample_rates(codec)  // AV_CODEC_CONFIG_SAMPLE_RATE
ffmpeg_codec_sample_fmts(codec)   // AV_CODEC_CONFIG_SAMPLE_FORMAT
ffmpeg_codec_ch_layouts(codec)    // AV_CODEC_CONFIG_CHANNEL_LAYOUT
```

- For `LIBAVCODEC_VERSION_MAJOR >= 61`: backed by `avcodec_get_supported_config()` (the API introduced alongside the struct-field removal)
- For older FFmpeg: return the existing struct fields directly, so behavior is byte-for-byte identical on FFmpeg <= 6 (including current CI on Ubuntu 22.04/24.04)

All call sites in `FFmpegWriter.cpp` now go through these helpers.

**Incidental fix:** while porting, a latent bug in the `HAVE_CH_LAYOUT` path became visible - the layout loop tested `if (av_channel_layout_compare(&ch_layout, &codec_layouts[i]))`, treating *non-matching* layouts as valid instead of matching ones. Corrected to compare `== 0`. On old FFmpeg this bug was masked because both branches copied the same requested layout; on FFmpeg 7 it would have accepted the first non-matching entry.

**Also:** add missing `#include "Exceptions.h"` to `tests/BeatSync.cpp`, which uses `openshot::InvalidJSON` but previously only got it transitively.

## Testing
Windows 11 / MSYS2, MinGW-w64 GCC 16.2.0, FFmpeg 9.0.1 (libavcodec 63.1.101):

- Full build: library, all unit tests, SWIG Python bindings, openshot-player example - PASS
- Functional round-trip via the Python bindings: read H.264/AAC MP4 -> Timeline with Blur effect -> export via `FFmpegWriter` (libx264 + AAC, sample format auto-negotiated to fltp through the new config path) -> output verified with ffprobe - PASS
- The legacy path is untouched for LIBAVCODEC < 61, so existing CI (FFmpeg 4.x/6.x) is unaffected