### PR TITLE
Sentry fixes related to 4.0.0 release (libopenshot)

### DIFF
--- a/src/AudioRecorder.cpp
+++ b/src/AudioRecorder.cpp
@@ -210,6 +210,9 @@ void AudioRecorder::Open()
 	}
 
 	if (!settings.device_type.empty()) {
+		// Device types are created lazily. Selecting a type before the scan is
+		// a no-op, which can send a DirectSound input name to WASAPI on Windows.
+		device_manager.getAvailableDeviceTypes();
 		device_manager.setCurrentAudioDeviceType(settings.device_type, true);
 	}
 

--- a/src/FFmpegReader.cpp
+++ b/src/FFmpegReader.cpp
@@ -760,23 +760,10 @@ void FFmpegReader::Close() {
 		// Keep track of most recent packet
 		AVPacket *recent_packet = packet;
 
-		// Drain any packets from the decoder
+		// Discard pending decoder output on close. Draining would allocate and
+		// cache frames that are immediately discarded, and can throw before
+		// resources are released (especially when closing under memory pressure).
 		packet = NULL;
-		int attempts = 0;
-		int max_attempts = 128;
-		while (packet_status.packets_decoded() < packet_status.packets_read() && attempts < max_attempts) {
-			ZmqLogger::Instance()->AppendDebugMethod("FFmpegReader::Close (Drain decoder loop)",
-													 "packets_read", packet_status.packets_read(),
-													 "packets_decoded", packet_status.packets_decoded(),
-													 "attempts", attempts);
-			if (packet_status.video_decoded < packet_status.video_read) {
-				ProcessVideoPacket(info.video_length);
-			}
-			if (packet_status.audio_decoded < packet_status.audio_read) {
-				ProcessAudioPacket(info.video_length);
-			}
-			attempts++;
-		}
 
 		// Remove packet
 		if (recent_packet) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -151,6 +151,13 @@ foreach(tname ${OPENSHOT_TESTS})
   set(test_properties
     LABELS ${tname}
   )
+  if(tname STREQUAL "FFmpegReader")
+    # Catch2 v2 has no native SKIP assertion. Report unavailable VAAPI
+    # prerequisites as skipped in CTest rather than as a passing decode test.
+    list(APPEND test_properties
+      SKIP_REGULAR_EXPRESSION "Skipping VAAPI test:"
+    )
+  endif()
   if(tname STREQUAL "Caption" OR tname STREQUAL "Timer")
     list(APPEND test_properties
       ENVIRONMENT "QT_QPA_PLATFORM=minimal"

--- a/tests/FFmpegReader.cpp
+++ b/tests/FFmpegReader.cpp
@@ -34,6 +34,26 @@ using namespace openshot;
 
 namespace {
 
+#if defined(__linux__) && USE_HW_ACCEL
+bool VaapiDeviceAvailableForTest()
+{
+	// These tests select HW_DE_DEVICE_SET=0. A render node can exist on an
+	// NVIDIA machine (or be inaccessible) without providing a usable VAAPI
+	// device. Probe with the same FFmpeg library and adapter as the reader.
+	AVBufferRef* device = nullptr;
+	const int result = av_hwdevice_ctx_create(
+		&device, AV_HWDEVICE_TYPE_VAAPI, "/dev/dri/renderD128", nullptr, 0);
+	av_buffer_unref(&device);
+	if (result < 0) {
+		char error[AV_ERROR_MAX_STRING_SIZE] = {};
+		av_strerror(result, error, sizeof(error));
+		WARN("Skipping VAAPI test: cannot initialize /dev/dri/renderD128: " << error);
+		return false;
+	}
+	return true;
+}
+#endif
+
 double SampleAverageLuma(const std::shared_ptr<Frame>& frame, int sample_grid = 4) {
 	const int width = frame->GetWidth();
 	const int height = frame->GetHeight();
@@ -667,19 +687,14 @@ TEST_CASE( "HardwareDecodeSuccessful_IsFalse_WhenHardwareDecodeIsDisabled", "[li
 TEST_CASE( "VAAPI_H264_420_Reports_HardwareDecodeSuccess", "[libopenshot][ffmpegreader][hardware]" )
 {
 #if !defined(__linux__) || !USE_HW_ACCEL
-	WARN("Skipping hardware decode success test: requires Linux build with hardware decode support");
+	WARN("Skipping VAAPI test: requires Linux build with hardware decode support");
 	return;
 #else
 	if (std::system("ffmpeg -hide_banner -version >/dev/null 2>&1") != 0) {
-		WARN("Skipping hardware decode success test: ffmpeg executable not available");
+		WARN("Skipping VAAPI test: ffmpeg executable not available");
 		return;
 	}
-	if (std::system("ffmpeg -hide_banner -hwaccels 2>/dev/null | grep -q '\\<vaapi\\>'") != 0) {
-		WARN("Skipping hardware decode success test: ffmpeg does not report VAAPI support");
-		return;
-	}
-	if (std::system("sh -c 'test -e /dev/dri/renderD128 -o -e /dev/dri/renderD129 -o -e /dev/dri/renderD130' >/dev/null 2>&1") != 0) {
-		WARN("Skipping hardware decode success test: no render node available under /dev/dri");
+	if (!VaapiDeviceAvailableForTest()) {
 		return;
 	}
 
@@ -718,19 +733,14 @@ TEST_CASE( "VAAPI_H264_420_Reports_HardwareDecodeSuccess", "[libopenshot][ffmpeg
 TEST_CASE( "VAAPI_H264_422_Does_Not_Return_Black_Frames", "[libopenshot][ffmpegreader][hardware]" )
 {
 #if !defined(__linux__) || !USE_HW_ACCEL
-	WARN("Skipping VAAPI regression test: requires Linux build with hardware decode support");
+	WARN("Skipping VAAPI test: requires Linux build with hardware decode support");
 	return;
 #else
 	if (std::system("ffmpeg -hide_banner -version >/dev/null 2>&1") != 0) {
-		WARN("Skipping VAAPI regression test: ffmpeg executable not available");
+		WARN("Skipping VAAPI test: ffmpeg executable not available");
 		return;
 	}
-	if (std::system("ffmpeg -hide_banner -hwaccels 2>/dev/null | grep -q '\\<vaapi\\>'") != 0) {
-		WARN("Skipping VAAPI regression test: ffmpeg does not report VAAPI support");
-		return;
-	}
-	if (std::system("sh -c 'test -e /dev/dri/renderD128 -o -e /dev/dri/renderD129 -o -e /dev/dri/renderD130' >/dev/null 2>&1") != 0) {
-		WARN("Skipping VAAPI regression test: no render node available under /dev/dri");
+	if (!VaapiDeviceAvailableForTest()) {
 		return;
 	}
 

--- a/tests/FFmpegReader.cpp
+++ b/tests/FFmpegReader.cpp
@@ -433,6 +433,24 @@ TEST_CASE( "GIF_TimeBase", "[libopenshot][ffmpegreader]" )
         r.Close();
 }
 
+TEST_CASE("Close discards buffered decoder output", "[libopenshot][ffmpegreader]")
+{
+	FFmpegReader reader(std::string(TEST_MEDIA_PATH) + "sintel_trailer-720p.mp4");
+	reader.Open();
+	reader.GetFrame(1);
+	const auto decoded = reader.packet_status.packets_decoded();
+	REQUIRE(reader.packet_status.packets_read() > decoded);
+	CHECK_NOTHROW(reader.Close());
+	CHECK(reader.packet_status.packets_decoded() == decoded);
+	CHECK(reader.pFormatCtx == nullptr);
+	CHECK(reader.pCodecCtx == nullptr);
+	CHECK(reader.aCodecCtx == nullptr);
+	CHECK_NOTHROW(reader.Close());
+	reader.Open();
+	CHECK(reader.GetFrame(1)->number == 1);
+	reader.Close();
+}
+
 TEST_CASE( "Multiple_Open_and_Close", "[libopenshot][ffmpegreader]" )
 {
 	// Create a reader


### PR DESCRIPTION
Misc fixes for Sentry

  - Initialize audio backends before selecting recording devices.
  - Discard buffered frames during FFmpeg reader shutdown.
  - Skip VAAPI tests only when hardware initialization is unavailable.
