### PR TITLE
Fix use-after-free when deleting timeline-owned clips

### DIFF
--- a/src/Timeline.cpp
+++ b/src/Timeline.cpp
@@ -1566,12 +1566,12 @@ void Timeline::apply_json_to_clips(Json::Value change) {
 
 		// Remove existing clip
 		if (existing_clip) {
-			// Remove clip from timeline
-			RemoveClip(existing_clip);
-
 			// Calculate start and end frames that this impacts, and remove those frames from the cache
 			int64_t old_starting_frame = (existing_clip->Position() * info.fps.ToDouble()) + 1;
 			int64_t old_ending_frame = ((existing_clip->Position() + existing_clip->Duration()) * info.fps.ToDouble()) + 1;
+
+			// RemoveClip deletes clips owned by the timeline. Read their bounds first.
+			RemoveClip(existing_clip);
 			final_cache->Remove(old_starting_frame - 8, old_ending_frame + 8);
 		}
 

--- a/tests/Timeline.cpp
+++ b/tests/Timeline.cpp
@@ -37,6 +37,41 @@
 
 using namespace openshot;
 
+TEST_CASE("Deleting a JSON-owned clip invalidates its former range", "[libopenshot][timeline][sentry-delete]")
+{
+	Timeline timeline(2, 2, Fraction(30, 1), 44100, 2, LAYOUT_STEREO);
+	DummyReader reader;
+	Clip source(&reader);
+	source.Id("owned");
+	source.Position(1.0);
+	source.End(1.0);
+	Json::Value changes(Json::arrayValue);
+	Json::Value change;
+	change["type"] = "insert";
+	change["key"].append("clips");
+	change["value"] = source.JsonValue();
+	changes.append(change);
+	timeline.ApplyJsonDiff(changes.toStyledString());
+	REQUIRE(timeline.GetClip("owned") != nullptr);
+
+	for (int number : {5, 45, 90})
+		timeline.GetCache()->Add(std::make_shared<Frame>(number, 2, 2, "black"));
+	REQUIRE(timeline.GetCache()->Contains(45));
+
+	changes[0]["type"] = "delete";
+	Json::Value id;
+	id["id"] = "owned";
+	changes[0]["key"].append(id);
+	changes[0]["value"] = Json::nullValue;
+	timeline.ApplyJsonDiff(changes.toStyledString());
+	CHECK(timeline.GetClip("owned") == nullptr);
+	CHECK_FALSE(timeline.GetCache()->Contains(45));
+	CHECK(timeline.GetCache()->Contains(5));
+	CHECK(timeline.GetCache()->Contains(90));
+	// Duplicate delayed deletes are harmless.
+	CHECK_NOTHROW(timeline.ApplyJsonDiff(changes.toStyledString()));
+}
+
 static uint64_t image_fingerprint(const std::shared_ptr<QImage>& image) {
 	const uint64_t kFnvOffset = 1469598103934665603ULL;
 	const uint64_t kFnvPrime = 1099511628211ULL;


### PR DESCRIPTION
Deleting a timeline-owned clip frees it immediately. The JSON deletion handler then read its position and duration to invalidate cached frames, accessing freed memory.

Read the clip bounds before removal and retain the existing cache invalidation behavior.

This fixes a confirmed deletion crash path associated with OPENSHOT-BV93. Other stacks in that Sentry issue group remain outside this fix.